### PR TITLE
feat: integrated code review with flip animation

### DIFF
--- a/src/main/diff-parser.test.ts
+++ b/src/main/diff-parser.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect } from 'vitest'
+import { parseDiff, synthesizeUntrackedFile } from './diff-parser'
+
+describe('parseDiff', () => {
+  it('returns empty array for empty input', () => {
+    expect(parseDiff('')).toEqual([])
+    expect(parseDiff('   ')).toEqual([])
+    expect(parseDiff('\n\n')).toEqual([])
+  })
+
+  it('parses single file with additions only', () => {
+    const diff = [
+      'diff --git a/newfile.ts b/newfile.ts',
+      'new file mode 100644',
+      'index 0000000..abc1234',
+      '--- /dev/null',
+      '+++ b/newfile.ts',
+      '@@ -0,0 +1,3 @@',
+      '+line one',
+      '+line two',
+      '+line three',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+    expect(result[0].path).toBe('newfile.ts')
+    expect(result[0].status).toBe('added')
+    expect(result[0].hunks).toHaveLength(1)
+
+    const lines = result[0].hunks[0].lines
+    expect(lines).toHaveLength(3)
+    expect(lines.every((l) => l.lineType === 'addition')).toBe(true)
+    expect(lines[0]).toEqual({
+      content: 'line one',
+      lineType: 'addition',
+      oldLineNo: null,
+      newLineNo: 1,
+    })
+    expect(lines[1]).toEqual({
+      content: 'line two',
+      lineType: 'addition',
+      oldLineNo: null,
+      newLineNo: 2,
+    })
+    expect(lines[2]).toEqual({
+      content: 'line three',
+      lineType: 'addition',
+      oldLineNo: null,
+      newLineNo: 3,
+    })
+  })
+
+  it('parses single file with deletions only', () => {
+    const diff = [
+      'diff --git a/removed.ts b/removed.ts',
+      'deleted file mode 100644',
+      'index abc1234..0000000',
+      '--- a/removed.ts',
+      '+++ /dev/null',
+      '@@ -1,3 +0,0 @@',
+      '-line one',
+      '-line two',
+      '-line three',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+    expect(result[0].path).toBe('removed.ts')
+    expect(result[0].status).toBe('deleted')
+    expect(result[0].hunks).toHaveLength(1)
+
+    const lines = result[0].hunks[0].lines
+    expect(lines).toHaveLength(3)
+    expect(lines.every((l) => l.lineType === 'deletion')).toBe(true)
+    expect(lines[0]).toEqual({
+      content: 'line one',
+      lineType: 'deletion',
+      oldLineNo: 1,
+      newLineNo: null,
+    })
+    expect(lines[2]).toEqual({
+      content: 'line three',
+      lineType: 'deletion',
+      oldLineNo: 3,
+      newLineNo: null,
+    })
+  })
+
+  it('parses mixed additions, deletions, and context lines', () => {
+    const diff = [
+      'diff --git a/src/foo.ts b/src/foo.ts',
+      'index abc1234..def5678 100644',
+      '--- a/src/foo.ts',
+      '+++ b/src/foo.ts',
+      '@@ -1,4 +1,4 @@',
+      ' line one',
+      '-line two',
+      '+line two modified',
+      ' line three',
+      ' line four',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+    expect(result[0].status).toBe('modified')
+
+    const lines = result[0].hunks[0].lines
+    expect(lines).toHaveLength(5)
+    expect(lines[0]).toEqual({
+      content: 'line one',
+      lineType: 'context',
+      oldLineNo: 1,
+      newLineNo: 1,
+    })
+    expect(lines[1]).toEqual({
+      content: 'line two',
+      lineType: 'deletion',
+      oldLineNo: 2,
+      newLineNo: null,
+    })
+    expect(lines[2]).toEqual({
+      content: 'line two modified',
+      lineType: 'addition',
+      oldLineNo: null,
+      newLineNo: 2,
+    })
+    expect(lines[3]).toEqual({
+      content: 'line three',
+      lineType: 'context',
+      oldLineNo: 3,
+      newLineNo: 3,
+    })
+    expect(lines[4]).toEqual({
+      content: 'line four',
+      lineType: 'context',
+      oldLineNo: 4,
+      newLineNo: 4,
+    })
+  })
+
+  it('parses multiple files in one diff', () => {
+    const diff = [
+      'diff --git a/file-a.ts b/file-a.ts',
+      'index aaa1111..bbb2222 100644',
+      '--- a/file-a.ts',
+      '+++ b/file-a.ts',
+      '@@ -1,2 +1,2 @@',
+      '-old a',
+      '+new a',
+      ' unchanged a',
+      'diff --git a/file-b.ts b/file-b.ts',
+      'index ccc3333..ddd4444 100644',
+      '--- a/file-b.ts',
+      '+++ b/file-b.ts',
+      '@@ -1,2 +1,3 @@',
+      ' keep',
+      '+added line',
+      ' end',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(2)
+    expect(result[0].path).toBe('file-a.ts')
+    expect(result[0].hunks[0].lines).toHaveLength(3)
+    expect(result[1].path).toBe('file-b.ts')
+    expect(result[1].hunks[0].lines).toHaveLength(3)
+  })
+
+  it('parses multiple hunks in one file', () => {
+    const diff = [
+      'diff --git a/multi.ts b/multi.ts',
+      'index 111..222 100644',
+      '--- a/multi.ts',
+      '+++ b/multi.ts',
+      '@@ -1,3 +1,3 @@',
+      ' first',
+      '-old second',
+      '+new second',
+      ' third',
+      '@@ -10,3 +10,4 @@',
+      ' tenth',
+      ' eleventh',
+      '+inserted',
+      ' twelfth',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+    expect(result[0].hunks).toHaveLength(2)
+
+    const h1 = result[0].hunks[0]
+    expect(h1.oldStart).toBe(1)
+    expect(h1.newStart).toBe(1)
+    expect(h1.lines).toHaveLength(4)
+
+    const h2 = result[0].hunks[1]
+    expect(h2.oldStart).toBe(10)
+    expect(h2.newStart).toBe(10)
+    expect(h2.lines).toHaveLength(4)
+    expect(h2.lines[2]).toEqual({
+      content: 'inserted',
+      lineType: 'addition',
+      oldLineNo: null,
+      newLineNo: 12,
+    })
+  })
+
+  it('parses file renames', () => {
+    const diff = [
+      'diff --git a/old-name.ts b/new-name.ts',
+      'similarity index 95%',
+      'rename from old-name.ts',
+      'rename to new-name.ts',
+      'index aaa..bbb 100644',
+      '--- a/old-name.ts',
+      '+++ b/new-name.ts',
+      '@@ -1,3 +1,3 @@',
+      ' line one',
+      '-line two',
+      '+line two changed',
+      ' line three',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+    expect(result[0].path).toBe('new-name.ts')
+    expect(result[0].oldPath).toBe('old-name.ts')
+    expect(result[0].status).toBe('renamed')
+  })
+
+  it('parses new file mode', () => {
+    const diff = [
+      'diff --git a/brand-new.ts b/brand-new.ts',
+      'new file mode 100644',
+      'index 0000000..abc1234',
+      '--- /dev/null',
+      '+++ b/brand-new.ts',
+      '@@ -0,0 +1,2 @@',
+      '+hello',
+      '+world',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+    expect(result[0].status).toBe('added')
+    expect(result[0].oldPath).toBeNull()
+  })
+
+  it('parses deleted file mode', () => {
+    const diff = [
+      'diff --git a/gone.ts b/gone.ts',
+      'deleted file mode 100644',
+      'index abc1234..0000000',
+      '--- a/gone.ts',
+      '+++ /dev/null',
+      '@@ -1,2 +0,0 @@',
+      '-goodbye',
+      '-world',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+    expect(result[0].status).toBe('deleted')
+    expect(result[0].hunks[0].lines).toHaveLength(2)
+    expect(result[0].hunks[0].lines[0].lineType).toBe('deletion')
+  })
+
+  it('skips no-newline-at-EOF marker', () => {
+    const diff = [
+      'diff --git a/noeol.ts b/noeol.ts',
+      'index aaa..bbb 100644',
+      '--- a/noeol.ts',
+      '+++ b/noeol.ts',
+      '@@ -1,2 +1,2 @@',
+      ' keep',
+      '-no eol old',
+      '\\ No newline at end of file',
+      '+no eol new',
+      '\\ No newline at end of file',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+
+    const lines = result[0].hunks[0].lines
+    expect(lines).toHaveLength(3)
+    expect(lines.every((l) => l.content !== '\\ No newline at end of file')).toBe(true)
+    expect(lines.every((l) => !l.content.includes('No newline'))).toBe(true)
+  })
+
+  it('handles binary file diff with no hunks', () => {
+    const diff = [
+      'diff --git a/image.png b/image.png',
+      'index abc1234..def5678 100644',
+      'Binary files a/image.png and b/image.png differ',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+    expect(result[0].path).toBe('image.png')
+    expect(result[0].status).toBe('modified')
+    expect(result[0].hunks).toHaveLength(0)
+  })
+
+  it('parses hunk headers without counts (implicit count of 1)', () => {
+    const diff = [
+      'diff --git a/single.ts b/single.ts',
+      'index aaa..bbb 100644',
+      '--- a/single.ts',
+      '+++ b/single.ts',
+      '@@ -1 +1 @@',
+      '-old line',
+      '+new line',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result).toHaveLength(1)
+
+    const hunk = result[0].hunks[0]
+    expect(hunk.oldStart).toBe(1)
+    expect(hunk.oldCount).toBe(1)
+    expect(hunk.newStart).toBe(1)
+    expect(hunk.newCount).toBe(1)
+    expect(hunk.header).toBe('@@ -1 +1 @@')
+  })
+
+  it('parses hunk headers with explicit counts', () => {
+    const diff = [
+      'diff --git a/counts.ts b/counts.ts',
+      'index aaa..bbb 100644',
+      '--- a/counts.ts',
+      '+++ b/counts.ts',
+      '@@ -5,7 +5,9 @@',
+      ' context',
+      '-removed',
+      '+added one',
+      '+added two',
+      ' more context',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    const hunk = result[0].hunks[0]
+    expect(hunk.oldStart).toBe(5)
+    expect(hunk.oldCount).toBe(7)
+    expect(hunk.newStart).toBe(5)
+    expect(hunk.newCount).toBe(9)
+    expect(hunk.header).toBe('@@ -5,7 +5,9 @@')
+  })
+
+  it('preserves hunk header context text after @@', () => {
+    const diff = [
+      'diff --git a/ctx.ts b/ctx.ts',
+      'index aaa..bbb 100644',
+      '--- a/ctx.ts',
+      '+++ b/ctx.ts',
+      '@@ -10,3 +10,3 @@ function foo() {',
+      ' inside',
+      '-old',
+      '+new',
+      ' end',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result[0].hunks[0].header).toBe('@@ -10,3 +10,3 @@')
+  })
+
+  it('sets oldPath to null for non-renamed files', () => {
+    const diff = [
+      'diff --git a/same.ts b/same.ts',
+      'index aaa..bbb 100644',
+      '--- a/same.ts',
+      '+++ b/same.ts',
+      '@@ -1,1 +1,1 @@',
+      '-old',
+      '+new',
+    ].join('\n')
+
+    const result = parseDiff(diff)
+    expect(result[0].oldPath).toBeNull()
+    expect(result[0].status).toBe('modified')
+  })
+})
+
+describe('synthesizeUntrackedFile', () => {
+  it('creates correct DiffFile with all addition lines', () => {
+    const result = synthesizeUntrackedFile('src/new.ts', 'alpha\nbeta\ngamma\n')
+
+    expect(result.path).toBe('src/new.ts')
+    expect(result.oldPath).toBeNull()
+    expect(result.status).toBe('added')
+    expect(result.hunks).toHaveLength(1)
+
+    const hunk = result.hunks[0]
+    expect(hunk.oldStart).toBe(0)
+    expect(hunk.oldCount).toBe(0)
+    expect(hunk.newStart).toBe(1)
+    expect(hunk.newCount).toBe(3)
+    expect(hunk.header).toBe('@@ -0,0 +1,3 @@')
+
+    expect(hunk.lines).toHaveLength(3)
+    expect(hunk.lines[0]).toEqual({
+      content: 'alpha',
+      lineType: 'addition',
+      oldLineNo: null,
+      newLineNo: 1,
+    })
+    expect(hunk.lines[1]).toEqual({
+      content: 'beta',
+      lineType: 'addition',
+      oldLineNo: null,
+      newLineNo: 2,
+    })
+    expect(hunk.lines[2]).toEqual({
+      content: 'gamma',
+      lineType: 'addition',
+      oldLineNo: null,
+      newLineNo: 3,
+    })
+  })
+
+  it('handles content without trailing newline', () => {
+    const result = synthesizeUntrackedFile('notrail.ts', 'one\ntwo')
+
+    expect(result.hunks[0].lines).toHaveLength(2)
+    expect(result.hunks[0].newCount).toBe(2)
+  })
+
+  it('handles single-line content', () => {
+    const result = synthesizeUntrackedFile('single.ts', 'only line\n')
+
+    expect(result.hunks[0].lines).toHaveLength(1)
+    expect(result.hunks[0].lines[0].content).toBe('only line')
+    expect(result.hunks[0].header).toBe('@@ -0,0 +1,1 @@')
+  })
+
+  it('handles empty content', () => {
+    const result = synthesizeUntrackedFile('empty.ts', '')
+
+    expect(result.hunks[0].lines).toHaveLength(0)
+    expect(result.hunks[0].newCount).toBe(0)
+  })
+})

--- a/src/main/diff-parser.ts
+++ b/src/main/diff-parser.ts
@@ -1,0 +1,158 @@
+import type { DiffFile, DiffHunk, DiffLine, FileStatus, LineType } from '../shared/types'
+
+const DIFF_HEADER = /^diff --git a\/(.*) b\/(.*)$/
+const RENAME_FROM = /^rename from (.*)$/
+const RENAME_TO = /^rename to (.*)$/
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/
+
+function parseFileStatus(lines: string[], oldPath: string, newPath: string): FileStatus {
+  for (const line of lines) {
+    if (line.startsWith('new file mode')) return 'added'
+    if (line.startsWith('deleted file mode')) return 'deleted'
+    if (line.startsWith('rename from') || line.startsWith('similarity index')) return 'renamed'
+  }
+  if (oldPath !== newPath) return 'renamed'
+  return 'modified'
+}
+
+export function parseDiff(raw: string): DiffFile[] {
+  if (!raw.trim()) return []
+
+  const lines = raw.split('\n')
+  const files: DiffFile[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    const headerMatch = lines[i].match(DIFF_HEADER)
+    if (!headerMatch) {
+      i++
+      continue
+    }
+
+    let oldPath = headerMatch[1]
+    let newPath = headerMatch[2]
+    i++
+
+    // Collect metadata lines until the first hunk or next diff header
+    const metaLines: string[] = []
+    while (i < lines.length && !lines[i].startsWith('@@') && !lines[i].match(DIFF_HEADER)) {
+      metaLines.push(lines[i])
+
+      const renameFrom = lines[i].match(RENAME_FROM)
+      if (renameFrom) oldPath = renameFrom[1]
+      const renameTo = lines[i].match(RENAME_TO)
+      if (renameTo) newPath = renameTo[1]
+
+      i++
+    }
+
+    const status = parseFileStatus(metaLines, oldPath, newPath)
+    const hunks: DiffHunk[] = []
+
+    while (i < lines.length && !lines[i].match(DIFF_HEADER)) {
+      const hunkMatch = lines[i].match(HUNK_HEADER)
+      if (!hunkMatch) {
+        i++
+        continue
+      }
+
+      const oldStart = parseInt(hunkMatch[1], 10)
+      const oldCount = hunkMatch[2] !== undefined ? parseInt(hunkMatch[2], 10) : 1
+      const newStart = parseInt(hunkMatch[3], 10)
+      const newCount = hunkMatch[4] !== undefined ? parseInt(hunkMatch[4], 10) : 1
+      const header = lines[i].match(/^(@@ .* @@)/)![1]
+      i++
+
+      const hunkLines: DiffLine[] = []
+      let oldLine = oldStart
+      let newLine = newStart
+
+      while (i < lines.length && !lines[i].match(DIFF_HEADER) && !lines[i].match(HUNK_HEADER)) {
+        const line = lines[i]
+
+        if (line === '\\ No newline at end of file') {
+          i++
+          continue
+        }
+
+        if (line.startsWith('+')) {
+          hunkLines.push({
+            content: line.slice(1),
+            lineType: 'addition' as LineType,
+            oldLineNo: null,
+            newLineNo: newLine++,
+          })
+        } else if (line.startsWith('-')) {
+          hunkLines.push({
+            content: line.slice(1),
+            lineType: 'deletion' as LineType,
+            oldLineNo: oldLine++,
+            newLineNo: null,
+          })
+        } else if (line.startsWith(' ')) {
+          hunkLines.push({
+            content: line.slice(1),
+            lineType: 'context' as LineType,
+            oldLineNo: oldLine++,
+            newLineNo: newLine++,
+          })
+        } else if (line === '') {
+          // Could be end of diff or an empty context line — peek ahead
+          if (i + 1 >= lines.length || lines[i + 1].match(DIFF_HEADER)) break
+          hunkLines.push({
+            content: '',
+            lineType: 'context' as LineType,
+            oldLineNo: oldLine++,
+            newLineNo: newLine++,
+          })
+        } else {
+          break
+        }
+
+        i++
+      }
+
+      hunks.push({ header, oldStart, oldCount, newStart, newCount, lines: hunkLines })
+    }
+
+    files.push({
+      path: newPath,
+      oldPath: status === 'renamed' ? oldPath : null,
+      hunks,
+      status,
+    })
+  }
+
+  return files
+}
+
+export function synthesizeUntrackedFile(filePath: string, content: string): DiffFile {
+  const fileLines = content.split('\n')
+  // Remove trailing empty element from split if content ends with newline
+  if (fileLines.length > 0 && fileLines[fileLines.length - 1] === '') {
+    fileLines.pop()
+  }
+
+  const lines: DiffLine[] = fileLines.map((line, idx) => ({
+    content: line,
+    lineType: 'addition' as LineType,
+    oldLineNo: null,
+    newLineNo: idx + 1,
+  }))
+
+  const hunk: DiffHunk = {
+    header: `@@ -0,0 +1,${lines.length} @@`,
+    oldStart: 0,
+    oldCount: 0,
+    newStart: 1,
+    newCount: lines.length,
+    lines,
+  }
+
+  return {
+    path: filePath,
+    oldPath: null,
+    hunks: [hunk],
+    status: 'added',
+  }
+}

--- a/src/main/diff-parser.ts
+++ b/src/main/diff-parser.ts
@@ -60,7 +60,7 @@ export function parseDiff(raw: string): DiffFile[] {
       const oldCount = hunkMatch[2] !== undefined ? parseInt(hunkMatch[2], 10) : 1
       const newStart = parseInt(hunkMatch[3], 10)
       const newCount = hunkMatch[4] !== undefined ? parseInt(hunkMatch[4], 10) : 1
-      const header = lines[i].match(/^(@@ .* @@)/)![1]
+      const header = lines[i].substring(0, lines[i].indexOf(' @@', 2) + 3)
       i++
 
       const hunkLines: DiffLine[] = []

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -220,9 +220,16 @@ app.whenReady().then(async () => {
 
       let diffArgs: string[]
       switch (mode) {
-        case 'uncommitted':
-          diffArgs = ['diff', 'HEAD']
+        case 'uncommitted': {
+          // Check if HEAD exists — new repos with no commits have no HEAD
+          try {
+            await execAsync('git', ['rev-parse', 'HEAD'], { cwd })
+            diffArgs = ['diff', 'HEAD']
+          } catch {
+            diffArgs = ['diff', '--cached']
+          }
           break
+        }
         case 'unpushed':
           diffArgs = ['diff', '@{upstream}']
           break
@@ -240,9 +247,14 @@ app.whenReady().then(async () => {
           ['ls-files', '--others', '--exclude-standard'],
           { cwd }
         )
+        const { stat } = await import('fs/promises')
         const untrackedPaths = untrackedRaw.split('\n').filter(Boolean)
+        const MAX_FILE_SIZE = 1_000_000 // 1MB
         for (const filePath of untrackedPaths) {
-          const content = await readFile(join(cwd, filePath), 'utf-8').catch(() => '')
+          const fullPath = join(cwd, filePath)
+          const fileStat = await stat(fullPath).catch(() => null)
+          if (!fileStat || fileStat.size > MAX_FILE_SIZE) continue
+          const content = await readFile(fullPath, 'utf-8').catch(() => '')
           files.push(synthesizeUntrackedFile(filePath, content))
         }
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,6 +21,7 @@ import {
   initSessionManager,
   createSession,
   createPrSession,
+  getSession,
   getSessions,
   restoreSessions,
   killSession,
@@ -29,6 +30,8 @@ import {
   removeSession,
   relocateProject,
 } from './session-manager'
+import { parseDiff, synthesizeUntrackedFile } from './diff-parser'
+import type { DiffMode } from '../shared/types'
 
 // Use native Wayland rendering when available (avoids Xwayland scaling artifacts)
 app.commandLine.appendSwitch('ozone-platform-hint', 'auto')
@@ -202,6 +205,81 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('pty:scrollback', (_event, sessionId: string) => {
     return getScrollback(sessionId)
+  })
+
+  ipcMain.handle(
+    'review:get-diff',
+    async (_event, sessionId: string, mode: DiffMode, baseBranch?: string) => {
+      const session = getSession(sessionId)
+      if (!session) throw new Error(`Session not found: ${sessionId}`)
+      const cwd = session.worktreePath || session.projectPath
+      const { execFile: execFileCb } = await import('child_process')
+      const { promisify: pfy } = await import('util')
+      const { readFile } = await import('fs/promises')
+      const execAsync = pfy(execFileCb)
+
+      let diffArgs: string[]
+      switch (mode) {
+        case 'uncommitted':
+          diffArgs = ['diff', 'HEAD']
+          break
+        case 'unpushed':
+          diffArgs = ['diff', '@{upstream}']
+          break
+        case 'branch':
+          diffArgs = ['diff', `${baseBranch ?? 'main'}...`]
+          break
+      }
+
+      const { stdout: rawDiff } = await execAsync('git', diffArgs, { cwd, maxBuffer: 10_000_000 })
+      const files = parseDiff(rawDiff)
+
+      if (mode === 'uncommitted') {
+        const { stdout: untrackedRaw } = await execAsync(
+          'git',
+          ['ls-files', '--others', '--exclude-standard'],
+          { cwd }
+        )
+        const untrackedPaths = untrackedRaw.split('\n').filter(Boolean)
+        for (const filePath of untrackedPaths) {
+          const content = await readFile(join(cwd, filePath), 'utf-8').catch(() => '')
+          files.push(synthesizeUntrackedFile(filePath, content))
+        }
+      }
+
+      return files
+    }
+  )
+
+  ipcMain.handle('review:list-branches', async (_event, sessionId: string) => {
+    const session = getSession(sessionId)
+    if (!session) throw new Error(`Session not found: ${sessionId}`)
+    const cwd = session.worktreePath || session.projectPath
+    const { execFile: execFileCb } = await import('child_process')
+    const { promisify: pfy } = await import('util')
+    const execAsync = pfy(execFileCb)
+    const { stdout } = await execAsync('git', ['branch', '-a', '--format=%(refname:short)'], {
+      cwd,
+    })
+    return stdout.split('\n').filter(Boolean)
+  })
+
+  ipcMain.handle('review:get-default-branch', async (_event, sessionId: string) => {
+    const session = getSession(sessionId)
+    if (!session) throw new Error(`Session not found: ${sessionId}`)
+    const cwd = session.worktreePath || session.projectPath
+    const { execFile: execFileCb } = await import('child_process')
+    const { promisify: pfy } = await import('util')
+    const execAsync = pfy(execFileCb)
+    try {
+      const { stdout } = await execAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+        cwd,
+      })
+      const ref = stdout.trim()
+      return ref.replace('refs/remotes/origin/', '')
+    } catch {
+      return 'main'
+    }
   })
 
   ipcMain.handle('config:get-canvas', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -226,7 +226,13 @@ app.whenReady().then(async () => {
             await execAsync('git', ['rev-parse', 'HEAD'], { cwd })
             diffArgs = ['diff', 'HEAD']
           } catch {
-            diffArgs = ['diff', '--cached']
+            // No HEAD: diff staged+unstaged against the empty tree
+            const { stdout: emptyTree } = await execAsync(
+              'git',
+              ['hash-object', '-t', 'tree', '/dev/null'],
+              { cwd }
+            )
+            diffArgs = ['diff', emptyTree.trim()]
           }
           break
         }

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -328,6 +328,10 @@ export async function createPrSession(
   return session
 }
 
+export function getSession(id: string): Session | undefined {
+  return sessions.get(id)?.session
+}
+
 export function getSessions(): Session[] {
   return Array.from(sessions.values()).map((e) => e.session)
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -69,4 +69,9 @@ contextBridge.exposeInMainWorld('api', {
     return () => ipcRenderer.removeListener('pty:data', handler)
   },
   openSwimLanes: (sessionIds: string[]) => ipcRenderer.invoke('swim-lanes:open', sessionIds),
+  getReviewDiff: (sessionId: string, mode: string, baseBranch?: string) =>
+    ipcRenderer.invoke('review:get-diff', sessionId, mode, baseBranch),
+  getReviewBranches: (sessionId: string) => ipcRenderer.invoke('review:list-branches', sessionId),
+  getReviewDefaultBranch: (sessionId: string) =>
+    ipcRenderer.invoke('review:get-default-branch', sessionId),
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -45,7 +45,7 @@ export default function App() {
       if (e.ctrlKey && e.key === 'n') {
         e.preventDefault()
         setShowCreateDialog(true)
-      } else if (e.ctrlKey && e.key === 'r') {
+      } else if (e.ctrlKey && e.shiftKey && e.key === 'R') {
         e.preventDefault()
         scanProjects()
       } else if (e.key === 'Escape') {
@@ -119,7 +119,7 @@ export default function App() {
             <button
               className="refresh-btn"
               onClick={scanProjects}
-              title="Refresh projects (Ctrl+R)"
+              title="Refresh projects (Ctrl+Shift+R)"
             >
               ⟳
             </button>

--- a/src/renderer/SwimLanesApp.tsx
+++ b/src/renderer/SwimLanesApp.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import type { Session } from '../shared/types'
 import BroadcastBar from './components/BroadcastBar'
 import LaneHeader from './components/LaneHeader'
 import Terminal from './components/Terminal'
+import ReviewOverlay from './components/ReviewOverlay'
 
 function parseSessionIds(): string[] {
   const params = new URLSearchParams(window.location.search)
@@ -13,6 +14,8 @@ function parseSessionIds(): string[] {
 export default function SwimLanesApp() {
   const [sessionIds] = useState(parseSessionIds)
   const [sessions, setSessions] = useState<Session[]>([])
+  const [focusedLane, setFocusedLane] = useState<string | null>(null)
+  const [reviewOpenLanes, setReviewOpenLanes] = useState<Set<string>>(new Set())
 
   useEffect(() => {
     window.api.getSessions().then((all) => {
@@ -26,6 +29,38 @@ export default function SwimLanesApp() {
     return unsub
   }, [sessionIds])
 
+  const toggleReview = useCallback((laneId: string) => {
+    setReviewOpenLanes((prev) => {
+      const next = new Set(prev)
+      if (next.has(laneId)) {
+        next.delete(laneId)
+        setTimeout(() => {
+          const term = document.querySelector<HTMLElement>(
+            `[data-lane-id="${laneId}"] .xterm-helper-textarea`
+          )
+          term?.focus()
+        }, 420)
+      } else {
+        next.add(laneId)
+      }
+      return next
+    })
+  }, [])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === 'r') {
+        e.preventDefault()
+        e.stopPropagation()
+        if (focusedLane) {
+          toggleReview(focusedLane)
+        }
+      }
+    }
+    document.addEventListener('keydown', handler, true)
+    return () => document.removeEventListener('keydown', handler, true)
+  }, [focusedLane, toggleReview])
+
   const handleRevive = async (id: string) => {
     await window.api.reviveSession(id)
   }
@@ -37,10 +72,11 @@ export default function SwimLanesApp() {
         {sessionIds.map((id) => {
           const session = sessions.find((s) => s.id === id)
           const isDead = session?.status === 'dead' || session?.status === 'error'
+          const isReviewOpen = reviewOpenLanes.has(id)
 
           return (
-            <div key={id} className="lane">
-              <LaneHeader session={session} />
+            <div key={id} className="lane" data-lane-id={id} onClick={() => setFocusedLane(id)}>
+              <LaneHeader session={session} focused={focusedLane === id} />
               <div className="lane-terminal">
                 {isDead ? (
                   <div className="dead-session-overlay">
@@ -54,7 +90,18 @@ export default function SwimLanesApp() {
                     </div>
                   </div>
                 ) : (
-                  <Terminal sessionId={id} />
+                  <div className="flip-container">
+                    <div className={`flip-inner${isReviewOpen ? ' flipped' : ''}`}>
+                      <div className="flip-front">
+                        <Terminal sessionId={id} />
+                      </div>
+                      <div className="flip-back">
+                        {isReviewOpen && (
+                          <ReviewOverlay sessionId={id} onClose={() => toggleReview(id)} />
+                        )}
+                      </div>
+                    </div>
+                  </div>
                 )}
               </div>
             </div>

--- a/src/renderer/components/DetailPane.tsx
+++ b/src/renderer/components/DetailPane.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import Terminal from './Terminal'
+import ReviewOverlay from './ReviewOverlay'
 import { useSessionsStore } from '../stores/sessions'
 
 interface Props {
@@ -12,19 +13,57 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
   const session = useSessionsStore((s) => s.sessions.find((s) => s.id === sessionId))
   const isDead = session?.status === 'dead'
   const [reviving, setReviving] = useState(false)
+  const [reviewOpen, setReviewOpen] = useState(false)
+
+  const closeReview = useCallback(() => {
+    setReviewOpen(false)
+    // Return focus to the terminal after the flip animation
+    setTimeout(() => {
+      const term = document.querySelector<HTMLElement>(
+        '.detail-pane-terminal .xterm-helper-textarea'
+      )
+      term?.focus()
+    }, 420)
+  }, [])
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement
-      const isTerminalFocused = target.closest('.terminal-container')
-      if (e.key === 'Escape' && !isTerminalFocused) {
+      if (e.ctrlKey && e.key === 'r') {
+        e.preventDefault()
         e.stopPropagation()
-        onClose()
+        setReviewOpen((prev) => {
+          if (prev) {
+            // Flipping back — refocus terminal after animation
+            setTimeout(() => {
+              const term = document.querySelector<HTMLElement>(
+                '.detail-pane-terminal .xterm-helper-textarea'
+              )
+              term?.focus()
+            }, 420)
+          }
+          return !prev
+        })
+        return
+      }
+
+      if (e.key === 'Escape') {
+        if (reviewOpen) {
+          e.preventDefault()
+          e.stopPropagation()
+          closeReview()
+          return
+        }
+        const target = e.target as HTMLElement
+        const isTerminalFocused = target.closest('.terminal-container')
+        if (!isTerminalFocused) {
+          e.stopPropagation()
+          onClose()
+        }
       }
     }
     document.addEventListener('keydown', handler, true)
     return () => document.removeEventListener('keydown', handler, true)
-  }, [onClose])
+  }, [onClose, reviewOpen, closeReview])
 
   const handleRevive = async () => {
     setReviving(true)
@@ -64,7 +103,16 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
             </div>
           </div>
         ) : (
-          <Terminal sessionId={sessionId} />
+          <div className="flip-container">
+            <div className={`flip-inner${reviewOpen ? ' flipped' : ''}`}>
+              <div className="flip-front">
+                <Terminal sessionId={sessionId} />
+              </div>
+              <div className="flip-back">
+                {reviewOpen && <ReviewOverlay sessionId={sessionId} onClose={closeReview} />}
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/src/renderer/components/LaneHeader.tsx
+++ b/src/renderer/components/LaneHeader.tsx
@@ -3,9 +3,10 @@ import { STATUS_CONFIG } from '../utils/status-config'
 
 interface Props {
   session?: Session
+  focused?: boolean
 }
 
-export default function LaneHeader({ session }: Props) {
+export default function LaneHeader({ session, focused }: Props) {
   if (!session) {
     return (
       <div className="lane-header">
@@ -17,7 +18,7 @@ export default function LaneHeader({ session }: Props) {
   const { className: statusClass } = STATUS_CONFIG[session.status]
 
   return (
-    <div className="lane-header">
+    <div className={`lane-header${focused ? ' lane-header--focused' : ''}`}>
       <span className={`status-dot ${statusClass}`} />
       <span className="lane-header-name">
         {session.projectName}/{session.worktreeName}

--- a/src/renderer/components/ReviewOverlay.tsx
+++ b/src/renderer/components/ReviewOverlay.tsx
@@ -40,6 +40,7 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
   const [branches, setBranches] = useState<string[]>([])
   const [selectedBranch, setSelectedBranch] = useState('main')
   const [pendingModeSwitch, setPendingModeSwitch] = useState<DiffMode | null>(null)
+  const [pendingBranch, setPendingBranch] = useState<string | null>(null)
 
   useEffect(() => {
     containerRef.current?.focus()
@@ -91,10 +92,11 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
 
   const handleBranchChange = useCallback(
     (branch: string) => {
-      setSelectedBranch(branch)
       if (hasAnnotations) {
+        setPendingBranch(branch)
         setPendingModeSwitch('branch')
       } else {
+        setSelectedBranch(branch)
         switchMode('branch', branch)
       }
     },
@@ -349,15 +351,20 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
                 <div className="rv-confirm-actions">
                   <button
                     className="rv-feedback-btn rv-feedback-btn--cancel"
-                    onClick={() => setPendingModeSwitch(null)}
+                    onClick={() => {
+                      setPendingModeSwitch(null)
+                      setPendingBranch(null)
+                    }}
                   >
                     Cancel
                   </button>
                   <button
                     className="rv-feedback-btn rv-feedback-btn--submit"
                     onClick={() => {
-                      switchMode(pendingModeSwitch)
+                      if (pendingBranch) setSelectedBranch(pendingBranch)
+                      switchMode(pendingModeSwitch, pendingBranch ?? undefined)
                       setPendingModeSwitch(null)
+                      setPendingBranch(null)
                     }}
                   >
                     Continue

--- a/src/renderer/components/ReviewOverlay.tsx
+++ b/src/renderer/components/ReviewOverlay.tsx
@@ -1,0 +1,373 @@
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
+import { useReviewStore, getReviewProgress } from '../stores/review'
+import { useSessionsStore } from '../stores/sessions'
+import type { DiffMode, RejectMode } from '../../shared/types'
+import { generatePrompt } from '../utils/prompt-generator'
+import DiffViewer, { getHunkKey } from './review/DiffViewer'
+import FileTree from './review/FileTree'
+import ReviewTopBar from './review/ReviewTopBar'
+import ReviewBottomBar from './review/ReviewBottomBar'
+import FeedbackInput from './review/FeedbackInput'
+
+interface Props {
+  sessionId: string
+  onClose: () => void
+}
+
+let annotationIdCounter = 0
+function nextAnnotationId(): string {
+  return `ann-${++annotationIdCounter}-${Date.now()}`
+}
+
+export default function ReviewOverlay({ sessionId, onClose }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const reviewState = useReviewStore((s) => s.sessions[sessionId])
+  const fetchDiff = useReviewStore((s) => s.fetchDiff)
+  const addAnnotation = useReviewStore((s) => s.addAnnotation)
+  const removeAnnotation = useReviewStore((s) => s.removeAnnotation)
+  const clearAnnotations = useReviewStore((s) => s.clearAnnotations)
+  const session = useSessionsStore((s) => s.sessions.find((s) => s.id === sessionId))
+
+  const [focusedHunkKey, setFocusedHunkKey] = useState<string | null>(null)
+  const [scrollToFile, setScrollToFile] = useState<string | undefined>(undefined)
+  const [feedbackState, setFeedbackState] = useState<{
+    hunkKey: string
+    mode: 'comment' | 'reject'
+  } | null>(null)
+  const [confirmAction, setConfirmAction] = useState<'send' | 'copy' | null>(null)
+
+  const [diffMode, setDiffMode] = useState<DiffMode>('uncommitted')
+  const [branches, setBranches] = useState<string[]>([])
+  const [selectedBranch, setSelectedBranch] = useState('main')
+  const [pendingModeSwitch, setPendingModeSwitch] = useState<DiffMode | null>(null)
+
+  useEffect(() => {
+    containerRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    fetchDiff(sessionId, 'uncommitted')
+    window.api
+      .getReviewBranches(sessionId)
+      .then(setBranches)
+      .catch(() => {})
+    window.api
+      .getReviewDefaultBranch(sessionId)
+      .then(setSelectedBranch)
+      .catch(() => {})
+  }, [sessionId, fetchDiff])
+
+  const files = useMemo(() => reviewState?.files ?? [], [reviewState?.files])
+  const annotations = useMemo(() => reviewState?.annotations ?? {}, [reviewState?.annotations])
+
+  const allHunkKeys = files.flatMap((file) => file.hunks.map((_, i) => getHunkKey(file.path, i)))
+  const progress = reviewState
+    ? getReviewProgress(reviewState)
+    : { total: 0, reviewed: 0, approved: 0, commented: 0, rejected: 0 }
+  const unreviewedCount = progress.total - progress.reviewed
+  const hasAnnotations = progress.reviewed > 0
+
+  const switchMode = useCallback(
+    (newMode: DiffMode, branch?: string) => {
+      setDiffMode(newMode)
+      setFocusedHunkKey(null)
+      clearAnnotations(sessionId)
+      fetchDiff(sessionId, newMode, newMode === 'branch' ? (branch ?? selectedBranch) : undefined)
+    },
+    [sessionId, selectedBranch, fetchDiff, clearAnnotations]
+  )
+
+  const handleModeChange = useCallback(
+    (newMode: DiffMode) => {
+      if (newMode === diffMode) return
+      if (hasAnnotations) {
+        setPendingModeSwitch(newMode)
+      } else {
+        switchMode(newMode)
+      }
+    },
+    [diffMode, hasAnnotations, switchMode]
+  )
+
+  const handleBranchChange = useCallback(
+    (branch: string) => {
+      setSelectedBranch(branch)
+      if (hasAnnotations) {
+        setPendingModeSwitch('branch')
+      } else {
+        switchMode('branch', branch)
+      }
+    },
+    [hasAnnotations, switchMode]
+  )
+
+  const navigateHunk = useCallback(
+    (direction: 1 | -1) => {
+      if (allHunkKeys.length === 0) return
+      if (!focusedHunkKey) {
+        setFocusedHunkKey(direction === 1 ? allHunkKeys[0] : allHunkKeys[allHunkKeys.length - 1])
+        return
+      }
+      const idx = allHunkKeys.indexOf(focusedHunkKey)
+      const next = (idx + direction + allHunkKeys.length) % allHunkKeys.length
+      setFocusedHunkKey(allHunkKeys[next])
+    },
+    [allHunkKeys, focusedHunkKey]
+  )
+
+  const handleHunkAction = useCallback(
+    (filePath: string, hunkIndex: number, action: 'approve' | 'comment' | 'reject') => {
+      const key = getHunkKey(filePath, hunkIndex)
+      setFocusedHunkKey(key)
+      if (action === 'approve') {
+        addAnnotation(sessionId, key, {
+          id: nextAnnotationId(),
+          decision: 'approved',
+        })
+      } else {
+        setFeedbackState({ hunkKey: key, mode: action })
+      }
+    },
+    [sessionId, addAnnotation]
+  )
+
+  const handleFeedbackSubmit = useCallback(
+    (comment: string, rejectMode?: RejectMode) => {
+      if (!feedbackState) return
+      addAnnotation(sessionId, feedbackState.hunkKey, {
+        id: nextAnnotationId(),
+        decision: feedbackState.mode === 'comment' ? 'commented' : 'rejected',
+        comment: comment || undefined,
+        rejectMode,
+      })
+      setFeedbackState(null)
+      containerRef.current?.focus()
+    },
+    [sessionId, feedbackState, addAnnotation]
+  )
+
+  const handleRemoveAnnotation = useCallback(
+    (hunkKey: string, annotationId: string) => {
+      removeAnnotation(sessionId, hunkKey, annotationId)
+    },
+    [sessionId, removeAnnotation]
+  )
+
+  const executeAction = useCallback(
+    (action: 'send' | 'copy') => {
+      const prompt = generatePrompt(files, annotations)
+      if (!prompt) return
+
+      if (action === 'send') {
+        window.api.ptyWrite(sessionId, prompt)
+        setTimeout(() => onClose(), 500)
+      } else {
+        navigator.clipboard.writeText(prompt)
+      }
+    },
+    [files, annotations, sessionId, onClose]
+  )
+
+  const handleSendOrCopy = useCallback(
+    (action: 'send' | 'copy') => {
+      if (unreviewedCount > 0) {
+        setConfirmAction(action)
+      } else {
+        executeAction(action)
+      }
+    },
+    [unreviewedCount, executeAction]
+  )
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (feedbackState) return
+      if (confirmAction) return
+      if (pendingModeSwitch) return
+
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        onClose()
+        return
+      }
+
+      const noMod = !e.ctrlKey && !e.altKey && !e.metaKey
+      if (e.key === 'j' && noMod) {
+        e.preventDefault()
+        navigateHunk(1)
+        return
+      }
+      if (e.key === 'k' && noMod) {
+        e.preventDefault()
+        navigateHunk(-1)
+        return
+      }
+
+      if (focusedHunkKey && noMod) {
+        if (e.key === 'a') {
+          e.preventDefault()
+          addAnnotation(sessionId, focusedHunkKey, {
+            id: nextAnnotationId(),
+            decision: 'approved',
+          })
+          return
+        }
+        if (e.key === 'c') {
+          e.preventDefault()
+          setFeedbackState({ hunkKey: focusedHunkKey, mode: 'comment' })
+          return
+        }
+        if (e.key === 'r') {
+          e.preventDefault()
+          setFeedbackState({ hunkKey: focusedHunkKey, mode: 'reject' })
+          return
+        }
+      }
+    }
+    document.addEventListener('keydown', handler, true)
+    return () => document.removeEventListener('keydown', handler, true)
+  }, [
+    onClose,
+    navigateHunk,
+    focusedHunkKey,
+    feedbackState,
+    confirmAction,
+    pendingModeSwitch,
+    sessionId,
+    addAnnotation,
+  ])
+
+  const handleFileClick = useCallback((filePath: string) => {
+    setScrollToFile(filePath)
+    setTimeout(() => setScrollToFile(undefined), 100)
+  }, [])
+
+  const loading = !reviewState || reviewState.loading
+  const error = reviewState?.error
+  const focusedFile = focusedHunkKey ? focusedHunkKey.split('::')[0] : undefined
+
+  return (
+    <div ref={containerRef} className="review-overlay" tabIndex={-1}>
+      {loading ? (
+        <div className="review-loading">
+          <div className="review-loading-bar" />
+          <div className="review-loading-bar" />
+          <div className="review-loading-bar" />
+        </div>
+      ) : error ? (
+        <div className="review-error-container">
+          <div className="review-error-icon">!</div>
+          <div className="review-error">{error}</div>
+          <button
+            className="rv-feedback-btn rv-feedback-btn--submit"
+            onClick={() =>
+              fetchDiff(sessionId, diffMode, diffMode === 'branch' ? selectedBranch : undefined)
+            }
+          >
+            Retry
+          </button>
+        </div>
+      ) : files.length === 0 ? (
+        <div className="review-placeholder">No changes</div>
+      ) : (
+        <div className="review-layout">
+          <ReviewTopBar
+            repoName={session?.projectName ?? ''}
+            branch={session?.worktreeName ?? ''}
+            fileCount={files.length}
+            mode={diffMode}
+            onModeChange={handleModeChange}
+            branches={branches}
+            selectedBranch={selectedBranch}
+            onBranchChange={handleBranchChange}
+          />
+          <div className="review-body">
+            <div className="review-sidebar">
+              <FileTree files={files} focusedFile={focusedFile} onFileClick={handleFileClick} />
+            </div>
+            <div className="review-main">
+              <DiffViewer
+                files={files}
+                annotations={annotations}
+                focusedHunkKey={focusedHunkKey}
+                scrollToFile={scrollToFile}
+                onHunkAction={handleHunkAction}
+                onRemoveAnnotation={handleRemoveAnnotation}
+              />
+              {feedbackState && (
+                <FeedbackInput
+                  mode={feedbackState.mode}
+                  onSubmit={handleFeedbackSubmit}
+                  onCancel={() => {
+                    setFeedbackState(null)
+                    containerRef.current?.focus()
+                  }}
+                />
+              )}
+            </div>
+          </div>
+          <ReviewBottomBar
+            approved={progress.approved}
+            commented={progress.commented}
+            rejected={progress.rejected}
+            total={progress.total}
+            onSendToSession={() => handleSendOrCopy('send')}
+            onCopyToClipboard={() => handleSendOrCopy('copy')}
+          />
+          {confirmAction && (
+            <div className="rv-confirm-overlay">
+              <div className="rv-confirm-dialog">
+                <p>
+                  {unreviewedCount} hunk{unreviewedCount !== 1 ? 's' : ''} unreviewed. They will be
+                  omitted from the prompt.
+                </p>
+                <div className="rv-confirm-actions">
+                  <button
+                    className="rv-feedback-btn rv-feedback-btn--cancel"
+                    onClick={() => setConfirmAction(null)}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="rv-feedback-btn rv-feedback-btn--submit"
+                    onClick={() => {
+                      executeAction(confirmAction)
+                      setConfirmAction(null)
+                    }}
+                  >
+                    Continue
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+          {pendingModeSwitch && (
+            <div className="rv-confirm-overlay">
+              <div className="rv-confirm-dialog">
+                <p>Switching mode will clear all annotations. Continue?</p>
+                <div className="rv-confirm-actions">
+                  <button
+                    className="rv-feedback-btn rv-feedback-btn--cancel"
+                    onClick={() => setPendingModeSwitch(null)}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="rv-feedback-btn rv-feedback-btn--submit"
+                    onClick={() => {
+                      switchMode(pendingModeSwitch)
+                      setPendingModeSwitch(null)
+                    }}
+                  >
+                    Continue
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/ReviewOverlay.tsx
+++ b/src/renderer/components/ReviewOverlay.tsx
@@ -183,6 +183,9 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      // Scope shortcuts to this overlay instance (prevents cross-lane actions in swim lanes)
+      if (!containerRef.current?.contains(e.target as Node)) return
+
       if (feedbackState) return
       if (confirmAction) return
       if (pendingModeSwitch) return

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -55,6 +55,9 @@ export default function Terminal({ sessionId }: Props) {
           return false
         }
       }
+      if (e.ctrlKey && !e.shiftKey && e.key === 'r') {
+        return false
+      }
       if (e.shiftKey && !e.ctrlKey && !e.altKey && e.key === 'Enter') {
         if (e.type === 'keydown') {
           window.api.ptyWrite(sessionId, '\x1b[13;2u')

--- a/src/renderer/components/review/DiffViewer.tsx
+++ b/src/renderer/components/review/DiffViewer.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useState } from 'react'
+import type {
+  DiffFile,
+  DiffHunk,
+  DiffLine,
+  FileStatus,
+  HunkAnnotation,
+} from '../../../shared/types'
+import HunkToolbar from './HunkToolbar'
+
+export function getHunkKey(filePath: string, hunkIndex: number): string {
+  return `${filePath}::${hunkIndex}`
+}
+
+function DiffLineRow({ line }: { line: DiffLine }) {
+  const modifier =
+    line.lineType === 'addition'
+      ? ' rv-diff-line--addition'
+      : line.lineType === 'deletion'
+        ? ' rv-diff-line--deletion'
+        : ''
+
+  const prefix = line.lineType === 'addition' ? '+' : line.lineType === 'deletion' ? '-' : ' '
+
+  return (
+    <div className={`rv-diff-line${modifier}`}>
+      <div className="rv-line-gutter">{line.oldLineNo ?? ''}</div>
+      <div className="rv-line-gutter">{line.newLineNo ?? ''}</div>
+      <div className="rv-line-content">
+        {prefix}
+        {line.content}
+      </div>
+    </div>
+  )
+}
+
+function AnnotationBadge({
+  annotation,
+  onRemove,
+}: {
+  annotation: HunkAnnotation
+  onRemove: () => void
+}) {
+  const label =
+    annotation.decision === 'approved'
+      ? 'Approved'
+      : annotation.decision === 'commented'
+        ? (annotation.comment ?? 'Comment')
+        : (annotation.comment ?? 'Rejected')
+
+  const displayLabel = label.length > 60 ? label.slice(0, 60) + '...' : label
+
+  return (
+    <div
+      className={`rv-annotation-badge rv-annotation-badge--${annotation.decision}`}
+      title={label}
+    >
+      <span className="rv-annotation-text">{displayLabel}</span>
+      <button
+        className="rv-annotation-remove"
+        onClick={(e) => {
+          e.stopPropagation()
+          onRemove()
+        }}
+        title="Remove"
+      >
+        &times;
+      </button>
+    </div>
+  )
+}
+
+function DiffHunkView({
+  hunk,
+  hunkIndex,
+  filePath,
+  annotations,
+  isFocused,
+  onHunkAction,
+  onRemoveAnnotation,
+}: {
+  hunk: DiffHunk
+  hunkIndex: number
+  filePath: string
+  annotations: HunkAnnotation[]
+  isFocused: boolean
+  onHunkAction: (action: 'approve' | 'comment' | 'reject') => void
+  onRemoveAnnotation: (annotationId: string) => void
+}) {
+  const [headerHovered, setHeaderHovered] = useState(false)
+
+  const classes = ['rv-diff-hunk']
+  if (annotations.length > 0) {
+    const hasRejected = annotations.some((a) => a.decision === 'rejected')
+    const hasCommented = annotations.some((a) => a.decision === 'commented')
+    if (hasRejected) classes.push('rv-diff-hunk--rejected')
+    else if (hasCommented) classes.push('rv-diff-hunk--commented')
+    else classes.push('rv-diff-hunk--approved')
+  }
+  if (isFocused) classes.push('rv-diff-hunk--focused')
+
+  return (
+    <div className={classes.join(' ')} data-hunk-key={getHunkKey(filePath, hunkIndex)}>
+      <div
+        className="rv-hunk-header"
+        onMouseEnter={() => setHeaderHovered(true)}
+        onMouseLeave={() => setHeaderHovered(false)}
+      >
+        <span>{hunk.header}</span>
+        {headerHovered && (
+          <HunkToolbar
+            onApprove={() => onHunkAction('approve')}
+            onComment={() => onHunkAction('comment')}
+            onReject={() => onHunkAction('reject')}
+          />
+        )}
+      </div>
+      {hunk.lines.map((line, i) => (
+        <DiffLineRow key={i} line={line} />
+      ))}
+      {annotations.map((ann) => (
+        <AnnotationBadge
+          key={ann.id}
+          annotation={ann}
+          onRemove={() => onRemoveAnnotation(ann.id)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function statusBadgeClass(status: FileStatus): string {
+  return `rv-file-status rv-file-status--${status}`
+}
+
+interface DiffViewerProps {
+  files: DiffFile[]
+  annotations: Record<string, HunkAnnotation[]>
+  focusedHunkKey: string | null
+  scrollToFile?: string
+  onHunkAction: (
+    filePath: string,
+    hunkIndex: number,
+    action: 'approve' | 'comment' | 'reject'
+  ) => void
+  onRemoveAnnotation: (hunkKey: string, annotationId: string) => void
+}
+
+function DiffViewer({
+  files,
+  annotations,
+  focusedHunkKey,
+  scrollToFile,
+  onHunkAction,
+  onRemoveAnnotation,
+}: DiffViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (scrollToFile && containerRef.current) {
+      const el = containerRef.current.querySelector(`#file-${CSS.escape(scrollToFile)}`)
+      el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }, [scrollToFile])
+
+  useEffect(() => {
+    if (focusedHunkKey && containerRef.current) {
+      const el = containerRef.current.querySelector(
+        `[data-hunk-key="${CSS.escape(focusedHunkKey)}"]`
+      )
+      el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [focusedHunkKey])
+
+  return (
+    <div className="rv-diff-viewer" ref={containerRef}>
+      {files.map((file) => (
+        <div key={file.path} className="rv-file-section" id={`file-${file.path}`}>
+          <div className="rv-file-header">
+            <span className={statusBadgeClass(file.status)}>{file.status}</span>
+            <span>{file.path}</span>
+          </div>
+          {file.hunks.map((hunk, hunkIndex) => {
+            const key = getHunkKey(file.path, hunkIndex)
+            return (
+              <DiffHunkView
+                key={key}
+                hunk={hunk}
+                hunkIndex={hunkIndex}
+                filePath={file.path}
+                annotations={annotations[key] ?? []}
+                isFocused={focusedHunkKey === key}
+                onHunkAction={(action) => onHunkAction(file.path, hunkIndex, action)}
+                onRemoveAnnotation={(annId) => onRemoveAnnotation(key, annId)}
+              />
+            )
+          })}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default DiffViewer

--- a/src/renderer/components/review/FeedbackInput.tsx
+++ b/src/renderer/components/review/FeedbackInput.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useRef, useEffect } from 'react'
+import type { RejectMode } from '../../../shared/types'
+
+interface FeedbackInputProps {
+  mode: 'comment' | 'reject'
+  onSubmit: (comment: string, rejectMode?: RejectMode) => void
+  onCancel: () => void
+}
+
+const FeedbackInput: React.FC<FeedbackInputProps> = ({ mode, onSubmit, onCancel }) => {
+  const [comment, setComment] = useState('')
+  const [rejectMode, setRejectMode] = useState<RejectMode>('propose_alternative')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation()
+      onCancel()
+    } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.stopPropagation()
+      onSubmit(comment, mode === 'reject' ? rejectMode : undefined)
+    }
+  }
+
+  return (
+    <div className="rv-feedback-input" onKeyDown={handleKeyDown}>
+      {mode === 'reject' && (
+        <div className="rv-feedback-radio-group">
+          <label>
+            <input
+              type="radio"
+              name="reject-mode"
+              value="propose_alternative"
+              checked={rejectMode === 'propose_alternative'}
+              onChange={() => setRejectMode('propose_alternative')}
+            />
+            Propose alternative
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="reject-mode"
+              value="request_possibilities"
+              checked={rejectMode === 'request_possibilities'}
+              onChange={() => setRejectMode('request_possibilities')}
+            />
+            Request other possibilities
+          </label>
+        </div>
+      )}
+      <textarea
+        ref={textareaRef}
+        className="rv-feedback-textarea"
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        placeholder={mode === 'reject' ? 'Describe your feedback...' : 'Add a comment...'}
+      />
+      <div className="rv-feedback-actions">
+        <button className="rv-feedback-btn rv-feedback-btn--cancel" onClick={onCancel}>
+          Cancel
+        </button>
+        <button
+          className="rv-feedback-btn rv-feedback-btn--submit"
+          onClick={() => onSubmit(comment, mode === 'reject' ? rejectMode : undefined)}
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default FeedbackInput

--- a/src/renderer/components/review/FileTree.tsx
+++ b/src/renderer/components/review/FileTree.tsx
@@ -1,0 +1,178 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { DiffFile } from '../../../shared/types'
+
+interface FileTreeProps {
+  files: DiffFile[]
+  focusedFile?: string
+  onFileClick: (filePath: string) => void
+}
+
+interface TreeNode {
+  name: string
+  fullPath: string
+  children: Map<string, TreeNode>
+  file?: DiffFile
+}
+
+function buildTree(files: DiffFile[]): TreeNode {
+  const root: TreeNode = { name: '', fullPath: '', children: new Map() }
+  for (const file of files) {
+    const parts = file.path.split('/')
+    let current = root
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]
+      if (!current.children.has(part)) {
+        current.children.set(part, {
+          name: part,
+          fullPath: parts.slice(0, i + 1).join('/'),
+          children: new Map(),
+        })
+      }
+      current = current.children.get(part)!
+    }
+    current.file = file
+  }
+  return root
+}
+
+function DirectoryNode({
+  node,
+  focusedFile,
+  onFileClick,
+  depth,
+}: {
+  node: TreeNode
+  focusedFile?: string
+  onFileClick: (filePath: string) => void
+  depth: number
+}) {
+  const [expanded, setExpanded] = useState(true)
+  const entries = Array.from(node.children.values())
+  const dirs = entries.filter((n) => !n.file)
+  const files = entries.filter((n) => n.file)
+
+  return (
+    <div className="rv-file-tree-dir">
+      <div
+        className="rv-file-tree-dir-label"
+        style={{ paddingLeft: depth * 16 + 8 }}
+        onClick={() => setExpanded(!expanded)}
+      >
+        <span className="rv-file-tree-arrow">{expanded ? '\u25BC' : '\u25B6'}</span>
+        <span className="rv-file-tree-dir-name">{node.name}/</span>
+      </div>
+      {expanded && (
+        <div>
+          {dirs.map((dir) => (
+            <DirectoryNode
+              key={dir.fullPath}
+              node={dir}
+              focusedFile={focusedFile}
+              onFileClick={onFileClick}
+              depth={depth + 1}
+            />
+          ))}
+          {files.map((fileNode) => (
+            <FileNode
+              key={fileNode.fullPath}
+              node={fileNode}
+              focusedFile={focusedFile}
+              onFileClick={onFileClick}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function FileNode({
+  node,
+  focusedFile,
+  onFileClick,
+  depth,
+}: {
+  node: TreeNode
+  focusedFile?: string
+  onFileClick: (filePath: string) => void
+  depth: number
+}) {
+  const file = node.file!
+  const isFocused = focusedFile === file.path
+
+  return (
+    <div
+      className={`rv-file-tree-file${isFocused ? ' rv-file-tree-file--focused' : ''}`}
+      style={{ paddingLeft: depth * 16 + 26 }}
+      onClick={() => onFileClick(file.path)}
+    >
+      <span className="rv-file-tree-file-name">{node.name}</span>
+    </div>
+  )
+}
+
+export default function FileTree({ files, focusedFile, onFileClick }: FileTreeProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [narrow, setNarrow] = useState(false)
+
+  const handleResize = useCallback((entries: ResizeObserverEntry[]) => {
+    for (const entry of entries) {
+      setNarrow(entry.contentRect.width < 700)
+    }
+  }, [])
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const observer = new ResizeObserver(handleResize)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [handleResize])
+
+  const tree = buildTree(files)
+  const entries = Array.from(tree.children.values())
+  const dirs = entries.filter((n) => !n.file)
+  const topFiles = entries.filter((n) => n.file)
+
+  if (narrow) {
+    return (
+      <div ref={containerRef} className="rv-file-tree">
+        <select
+          className="rv-file-tree-dropdown"
+          value={focusedFile ?? ''}
+          onChange={(e) => onFileClick(e.target.value)}
+        >
+          {files.map((f) => (
+            <option key={f.path} value={f.path}>
+              {f.path}
+            </option>
+          ))}
+        </select>
+      </div>
+    )
+  }
+
+  return (
+    <div ref={containerRef} className="rv-file-tree">
+      {dirs.map((dir) => (
+        <DirectoryNode
+          key={dir.fullPath}
+          node={dir}
+          focusedFile={focusedFile}
+          onFileClick={onFileClick}
+          depth={0}
+        />
+      ))}
+      {topFiles.map((fileNode) => (
+        <FileNode
+          key={fileNode.fullPath}
+          node={fileNode}
+          focusedFile={focusedFile}
+          onFileClick={onFileClick}
+          depth={0}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/components/review/HunkToolbar.tsx
+++ b/src/renderer/components/review/HunkToolbar.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+interface HunkToolbarProps {
+  onApprove: () => void
+  onComment: () => void
+  onReject: () => void
+}
+
+const HunkToolbar: React.FC<HunkToolbarProps> = ({ onApprove, onComment, onReject }) => {
+  return (
+    <div className="rv-hunk-toolbar">
+      <button
+        className="rv-toolbar-btn rv-toolbar-btn--approve"
+        title="Approve"
+        onMouseDown={(e) => {
+          e.preventDefault()
+          onApprove()
+        }}
+      >
+        ✓
+      </button>
+      <button
+        className="rv-toolbar-btn rv-toolbar-btn--comment"
+        title="Comment"
+        onMouseDown={(e) => {
+          e.preventDefault()
+          onComment()
+        }}
+      >
+        💬
+      </button>
+      <button
+        className="rv-toolbar-btn rv-toolbar-btn--reject"
+        title="Reject"
+        onMouseDown={(e) => {
+          e.preventDefault()
+          onReject()
+        }}
+      >
+        ✗
+      </button>
+    </div>
+  )
+}
+
+export default HunkToolbar

--- a/src/renderer/components/review/ReviewBottomBar.tsx
+++ b/src/renderer/components/review/ReviewBottomBar.tsx
@@ -1,0 +1,72 @@
+interface ReviewBottomBarProps {
+  approved: number
+  commented: number
+  rejected: number
+  total: number
+  onSendToSession: () => void
+  onCopyToClipboard: () => void
+}
+
+export default function ReviewBottomBar({
+  approved,
+  commented,
+  rejected,
+  total,
+  onSendToSession,
+  onCopyToClipboard,
+}: ReviewBottomBarProps) {
+  const parts: JSX.Element[] = []
+
+  if (approved > 0) {
+    parts.push(
+      <span key="approved" className="rv-bottom-bar-count--approved">
+        {approved} approved
+      </span>
+    )
+  }
+  if (commented > 0) {
+    parts.push(
+      <span key="commented" className="rv-bottom-bar-count--commented">
+        {commented} commented
+      </span>
+    )
+  }
+  if (rejected > 0) {
+    parts.push(
+      <span key="rejected" className="rv-bottom-bar-count--rejected">
+        {rejected} rejected
+      </span>
+    )
+  }
+
+  return (
+    <div className="rv-bottom-bar">
+      <div className="rv-bottom-bar-stats">
+        {parts.length > 0 ? (
+          <>
+            {parts.reduce<JSX.Element[]>((acc, el, i) => {
+              if (i > 0) acc.push(<span key={`sep-${i}`}> &middot; </span>)
+              acc.push(el)
+              return acc
+            }, [])}
+            {' / '}
+            {total} total
+          </>
+        ) : (
+          <>{total} total</>
+        )}
+      </div>
+      <div className="rv-bottom-bar-actions">
+        <button
+          className="rv-bottom-bar-btn rv-bottom-bar-btn--secondary"
+          onClick={onCopyToClipboard}
+        >
+          Copy
+        </button>
+        <button className="rv-bottom-bar-btn rv-bottom-bar-btn--primary" onClick={onSendToSession}>
+          Send to session
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/review/ReviewTopBar.tsx
+++ b/src/renderer/components/review/ReviewTopBar.tsx
@@ -1,0 +1,65 @@
+import type { DiffMode } from '../../../shared/types'
+
+interface Props {
+  repoName: string
+  branch: string
+  fileCount: number
+  mode: DiffMode
+  onModeChange: (mode: DiffMode) => void
+  branches: string[]
+  selectedBranch: string
+  onBranchChange: (branch: string) => void
+}
+
+const MODES: { value: DiffMode; label: string }[] = [
+  { value: 'uncommitted', label: 'Uncommitted' },
+  { value: 'unpushed', label: 'Unpushed' },
+  { value: 'branch', label: 'Branch' },
+]
+
+export default function ReviewTopBar({
+  repoName,
+  branch,
+  fileCount,
+  mode,
+  onModeChange,
+  branches,
+  selectedBranch,
+  onBranchChange,
+}: Props) {
+  return (
+    <div className="rv-top-bar">
+      <span className="rv-top-bar-label">Review</span>
+      <span className="rv-top-bar-sep">&mdash;</span>
+      <span className="rv-top-bar-repo">{repoName}</span>
+      <span className="rv-top-bar-branch">{branch}</span>
+      <div className="rv-mode-control">
+        {MODES.map((m) => (
+          <button
+            key={m.value}
+            className={`rv-mode-btn${mode === m.value ? ' rv-mode-btn--active' : ''}`}
+            onClick={() => onModeChange(m.value)}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+      {mode === 'branch' && branches.length > 0 && (
+        <select
+          className="rv-branch-dropdown"
+          value={selectedBranch}
+          onChange={(e) => onBranchChange(e.target.value)}
+        >
+          {branches.map((b) => (
+            <option key={b} value={b}>
+              {b}
+            </option>
+          ))}
+        </select>
+      )}
+      <span className="rv-top-bar-files">
+        {fileCount} file{fileCount !== 1 ? 's' : ''}
+      </span>
+    </div>
+  )
+}

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import type { Project, Session } from '../shared/types'
+import type { DiffFile, DiffMode, Project, Session } from '../shared/types'
 
 declare global {
   interface Window {
@@ -40,6 +40,9 @@ declare global {
       ptyGetScrollback: (sessionId: string) => Promise<string>
       onPtyData: (callback: (data: { sessionId: string; data: string }) => void) => () => void
       openSwimLanes: (sessionIds: string[]) => Promise<void>
+      getReviewDiff: (sessionId: string, mode: DiffMode, baseBranch?: string) => Promise<DiffFile[]>
+      getReviewBranches: (sessionId: string) => Promise<string[]>
+      getReviewDefaultBranch: (sessionId: string) => Promise<string>
     }
   }
 }

--- a/src/renderer/stores/review.test.ts
+++ b/src/renderer/stores/review.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useReviewStore, getReviewProgress } from './review'
+import type { HunkAnnotation, DiffFile } from '../../shared/types'
+
+const store = useReviewStore
+
+function makeAnnotation(
+  id: string,
+  decision: HunkAnnotation['decision'],
+  comment?: string
+): HunkAnnotation {
+  return { id, decision, comment }
+}
+
+function makeFile(path: string, hunkCount: number): DiffFile {
+  return {
+    path,
+    oldPath: null,
+    hunks: Array.from({ length: hunkCount }, (_, i) => ({
+      header: `@@ -${i},1 +${i},1 @@`,
+      oldStart: i,
+      oldCount: 1,
+      newStart: i,
+      newCount: 1,
+      lines: [],
+    })),
+    status: 'modified',
+  }
+}
+
+beforeEach(() => {
+  store.setState({ sessions: {} })
+})
+
+describe('addAnnotation', () => {
+  it('adds annotation to empty session, creates session state', () => {
+    const ann = makeAnnotation('a1', 'approved')
+    store.getState().addAnnotation('s1', 'file.ts::0', ann)
+
+    const session = store.getState().sessions['s1']
+    expect(session).toBeDefined()
+    expect(session.annotations['file.ts::0']).toEqual([ann])
+  })
+
+  it('adds multiple annotations to same hunk', () => {
+    const ann1 = makeAnnotation('a1', 'approved')
+    const ann2 = makeAnnotation('a2', 'commented', 'needs work')
+    store.getState().addAnnotation('s1', 'file.ts::0', ann1)
+    store.getState().addAnnotation('s1', 'file.ts::0', ann2)
+
+    const anns = store.getState().sessions['s1'].annotations['file.ts::0']
+    expect(anns).toHaveLength(2)
+    expect(anns).toEqual([ann1, ann2])
+  })
+
+  it('adds annotations to different hunks', () => {
+    const ann1 = makeAnnotation('a1', 'approved')
+    const ann2 = makeAnnotation('a2', 'rejected')
+    store.getState().addAnnotation('s1', 'file.ts::0', ann1)
+    store.getState().addAnnotation('s1', 'file.ts::1', ann2)
+
+    const { annotations } = store.getState().sessions['s1']
+    expect(annotations['file.ts::0']).toEqual([ann1])
+    expect(annotations['file.ts::1']).toEqual([ann2])
+  })
+})
+
+describe('removeAnnotation', () => {
+  it('removes specific annotation by ID', () => {
+    const ann1 = makeAnnotation('a1', 'approved')
+    const ann2 = makeAnnotation('a2', 'commented')
+    store.getState().addAnnotation('s1', 'f::0', ann1)
+    store.getState().addAnnotation('s1', 'f::0', ann2)
+
+    store.getState().removeAnnotation('s1', 'f::0', 'a1')
+
+    expect(store.getState().sessions['s1'].annotations['f::0']).toEqual([ann2])
+  })
+
+  it('removes hunk key when last annotation removed', () => {
+    const ann = makeAnnotation('a1', 'approved')
+    store.getState().addAnnotation('s1', 'f::0', ann)
+
+    store.getState().removeAnnotation('s1', 'f::0', 'a1')
+
+    expect(store.getState().sessions['s1'].annotations['f::0']).toBeUndefined()
+  })
+})
+
+describe('clearAnnotations', () => {
+  it('clears all annotations for a session', () => {
+    store.getState().addAnnotation('s1', 'f::0', makeAnnotation('a1', 'approved'))
+    store.getState().addAnnotation('s1', 'f::1', makeAnnotation('a2', 'rejected'))
+
+    store.getState().clearAnnotations('s1')
+
+    expect(store.getState().sessions['s1'].annotations).toEqual({})
+  })
+})
+
+describe('setFocusedHunk', () => {
+  it('sets and clears focused hunk key', () => {
+    store.getState().setFocusedHunk('s1', 'file.ts::2')
+    expect(store.getState().sessions['s1'].focusedHunkKey).toBe('file.ts::2')
+
+    store.getState().setFocusedHunk('s1', null)
+    expect(store.getState().sessions['s1'].focusedHunkKey).toBeNull()
+  })
+})
+
+describe('getReviewProgress', () => {
+  it('returns correct counts for mixed decisions', () => {
+    store.setState({
+      sessions: {
+        s1: {
+          files: [makeFile('a.ts', 3)],
+          loading: false,
+          error: null,
+          annotations: {
+            'a.ts::0': [makeAnnotation('a1', 'approved')],
+            'a.ts::1': [makeAnnotation('a2', 'commented')],
+            'a.ts::2': [makeAnnotation('a3', 'rejected')],
+          },
+          focusedHunkKey: null,
+          cachedMode: null,
+          diffUpdated: false,
+        },
+      },
+    })
+
+    const progress = getReviewProgress(store.getState().sessions['s1'])
+    expect(progress).toEqual({ total: 3, reviewed: 3, approved: 1, commented: 1, rejected: 1 })
+  })
+
+  it('severity hierarchy: rejected > commented > approved', () => {
+    store.setState({
+      sessions: {
+        s1: {
+          files: [makeFile('a.ts', 1)],
+          loading: false,
+          error: null,
+          annotations: {
+            'a.ts::0': [
+              makeAnnotation('a1', 'approved'),
+              makeAnnotation('a2', 'commented'),
+              makeAnnotation('a3', 'rejected'),
+            ],
+          },
+          focusedHunkKey: null,
+          cachedMode: null,
+          diffUpdated: false,
+        },
+      },
+    })
+
+    const progress = getReviewProgress(store.getState().sessions['s1'])
+    expect(progress.rejected).toBe(1)
+    expect(progress.commented).toBe(0)
+    expect(progress.approved).toBe(0)
+    expect(progress.reviewed).toBe(1)
+  })
+
+  it('empty annotations = 0 reviewed', () => {
+    store.setState({
+      sessions: {
+        s1: {
+          files: [makeFile('a.ts', 3)],
+          loading: false,
+          error: null,
+          annotations: {},
+          focusedHunkKey: null,
+          cachedMode: null,
+          diffUpdated: false,
+        },
+      },
+    })
+
+    const progress = getReviewProgress(store.getState().sessions['s1'])
+    expect(progress).toEqual({ total: 3, reviewed: 0, approved: 0, commented: 0, rejected: 0 })
+  })
+})
+
+describe('multiple sessions isolation', () => {
+  it('annotations in one session do not affect another', () => {
+    store.getState().addAnnotation('s1', 'f::0', makeAnnotation('a1', 'approved'))
+    store.getState().addAnnotation('s2', 'f::0', makeAnnotation('a2', 'rejected'))
+
+    const s1 = store.getState().sessions['s1']
+    const s2 = store.getState().sessions['s2']
+
+    expect(s1.annotations['f::0']).toEqual([makeAnnotation('a1', 'approved')])
+    expect(s2.annotations['f::0']).toEqual([makeAnnotation('a2', 'rejected')])
+  })
+})

--- a/src/renderer/stores/review.ts
+++ b/src/renderer/stores/review.ts
@@ -94,9 +94,30 @@ export const useReviewStore = create<ReviewStore>((set) => ({
       const files = await window.api.getReviewDiff(sessionId, mode, baseBranch)
 
       if (hasCachedData) {
-        const oldJson = JSON.stringify(existing.files)
-        const newJson = JSON.stringify(files)
-        if (oldJson === newJson) return
+        // Quick structural comparison: file count + total hunk count + total line count
+        const oldFiles = existing.files
+        const unchanged =
+          oldFiles.length === files.length &&
+          oldFiles.every(
+            (f, i) =>
+              f.path === files[i].path &&
+              f.hunks.length === files[i].hunks.length &&
+              f.hunks.every((h, j) => h.lines.length === files[i].hunks[j].lines.length)
+          )
+        if (unchanged) {
+          // Clear any stale error even when diff hasn't changed
+          set((state) => {
+            const session = state.sessions[sessionId]
+            if (!session || !session.error) return state
+            return {
+              sessions: {
+                ...state.sessions,
+                [sessionId]: { ...session, error: null },
+              },
+            }
+          })
+          return
+        }
 
         set((state) => ({
           sessions: {

--- a/src/renderer/stores/review.ts
+++ b/src/renderer/stores/review.ts
@@ -70,7 +70,7 @@ function getSession(
   return state[sessionId] ?? emptySession()
 }
 
-export const useReviewStore = create<ReviewStore>((set) => ({
+export const useReviewStore = create<ReviewStore>((set, get) => ({
   sessions: {},
   fetchDiff: async (sessionId, mode, baseBranch) => {
     const existing = useReviewStore.getState().sessions[sessionId]
@@ -93,8 +93,17 @@ export const useReviewStore = create<ReviewStore>((set) => ({
     try {
       const files = await window.api.getReviewDiff(sessionId, mode, baseBranch)
 
+      // Guard against stale async responses: if mode changed while awaiting, discard
+      const currentSession = get().sessions[sessionId]
+      if (
+        currentSession &&
+        currentSession.cachedMode !== null &&
+        currentSession.cachedMode !== mode
+      ) {
+        return
+      }
+
       if (hasCachedData) {
-        // Quick structural comparison: file count + total hunk count + total line count
         const oldFiles = existing.files
         const unchanged =
           oldFiles.length === files.length &&
@@ -102,7 +111,12 @@ export const useReviewStore = create<ReviewStore>((set) => ({
             (f, i) =>
               f.path === files[i].path &&
               f.hunks.length === files[i].hunks.length &&
-              f.hunks.every((h, j) => h.lines.length === files[i].hunks[j].lines.length)
+              f.hunks.every(
+                (h, j) =>
+                  h.lines.length === files[i].hunks[j].lines.length &&
+                  h.header === files[i].hunks[j].header &&
+                  h.lines.every((l, k) => l.content === files[i].hunks[j].lines[k].content)
+              )
           )
         if (unchanged) {
           // Clear any stale error even when diff hasn't changed

--- a/src/renderer/stores/review.ts
+++ b/src/renderer/stores/review.ts
@@ -1,0 +1,215 @@
+import { create } from 'zustand'
+import type { DiffFile, DiffMode, HunkAnnotation } from '../../shared/types'
+
+interface SessionReviewState {
+  files: DiffFile[]
+  loading: boolean
+  error: string | null
+  annotations: Record<string, HunkAnnotation[]>
+  focusedHunkKey: string | null
+  cachedMode: DiffMode | null
+  diffUpdated: boolean
+}
+
+export function getReviewProgress(state: SessionReviewState): {
+  total: number
+  reviewed: number
+  approved: number
+  commented: number
+  rejected: number
+} {
+  let total = 0
+  for (const file of state.files) {
+    total += file.hunks.length
+  }
+  let approved = 0
+  let commented = 0
+  let rejected = 0
+  for (const file of state.files) {
+    for (let i = 0; i < file.hunks.length; i++) {
+      const key = `${file.path}::${i}`
+      const anns = state.annotations[key]
+      if (anns && anns.length > 0) {
+        const hasRejected = anns.some((a) => a.decision === 'rejected')
+        const hasCommented = anns.some((a) => a.decision === 'commented')
+        if (hasRejected) rejected++
+        else if (hasCommented) commented++
+        else approved++
+      }
+    }
+  }
+  return { total, reviewed: approved + commented + rejected, approved, commented, rejected }
+}
+
+interface ReviewStore {
+  sessions: Record<string, SessionReviewState>
+  fetchDiff: (sessionId: string, mode: DiffMode, baseBranch?: string) => Promise<void>
+  clearDiff: (sessionId: string) => void
+  addAnnotation: (sessionId: string, hunkKey: string, annotation: HunkAnnotation) => void
+  removeAnnotation: (sessionId: string, hunkKey: string, annotationId: string) => void
+  clearAnnotations: (sessionId: string) => void
+  setFocusedHunk: (sessionId: string, key: string | null) => void
+}
+
+function emptySession(): SessionReviewState {
+  return {
+    files: [],
+    loading: false,
+    error: null,
+    annotations: {},
+    focusedHunkKey: null,
+    cachedMode: null,
+    diffUpdated: false,
+  }
+}
+
+function getSession(
+  state: Record<string, SessionReviewState>,
+  sessionId: string
+): SessionReviewState {
+  return state[sessionId] ?? emptySession()
+}
+
+export const useReviewStore = create<ReviewStore>((set) => ({
+  sessions: {},
+  fetchDiff: async (sessionId, mode, baseBranch) => {
+    const existing = useReviewStore.getState().sessions[sessionId]
+    const hasCachedData = existing && existing.cachedMode === mode && existing.files.length > 0
+
+    if (!hasCachedData) {
+      set((state) => ({
+        sessions: {
+          ...state.sessions,
+          [sessionId]: {
+            ...emptySession(),
+            ...state.sessions[sessionId],
+            loading: true,
+            error: null,
+          },
+        },
+      }))
+    }
+
+    try {
+      const files = await window.api.getReviewDiff(sessionId, mode, baseBranch)
+
+      if (hasCachedData) {
+        const oldJson = JSON.stringify(existing.files)
+        const newJson = JSON.stringify(files)
+        if (oldJson === newJson) return
+
+        set((state) => ({
+          sessions: {
+            ...state.sessions,
+            [sessionId]: {
+              ...getSession(state.sessions, sessionId),
+              files,
+              cachedMode: mode,
+              diffUpdated: true,
+            },
+          },
+        }))
+        setTimeout(() => {
+          set((state) => {
+            const session = state.sessions[sessionId]
+            if (!session) return state
+            return {
+              sessions: {
+                ...state.sessions,
+                [sessionId]: { ...session, diffUpdated: false },
+              },
+            }
+          })
+        }, 3000)
+      } else {
+        set((state) => ({
+          sessions: {
+            ...state.sessions,
+            [sessionId]: {
+              ...getSession(state.sessions, sessionId),
+              files,
+              loading: false,
+              cachedMode: mode,
+            },
+          },
+        }))
+      }
+    } catch (err) {
+      set((state) => ({
+        sessions: {
+          ...state.sessions,
+          [sessionId]: {
+            ...getSession(state.sessions, sessionId),
+            files: hasCachedData ? getSession(state.sessions, sessionId).files : [],
+            loading: false,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        },
+      }))
+    }
+  },
+  clearDiff: (sessionId) => {
+    set((state) => {
+      const { [sessionId]: _removed, ...rest } = state.sessions
+      void _removed
+      return { sessions: rest }
+    })
+  },
+  addAnnotation: (sessionId, hunkKey, annotation) => {
+    set((state) => {
+      const session = getSession(state.sessions, sessionId)
+      const existing = session.annotations[hunkKey] ?? []
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: {
+            ...session,
+            annotations: { ...session.annotations, [hunkKey]: [...existing, annotation] },
+          },
+        },
+      }
+    })
+  },
+  removeAnnotation: (sessionId, hunkKey, annotationId) => {
+    set((state) => {
+      const session = getSession(state.sessions, sessionId)
+      const list = session.annotations[hunkKey]
+      if (!list) return state
+      const filtered = list.filter((a) => a.id !== annotationId)
+      const newAnnotations = { ...session.annotations }
+      if (filtered.length === 0) {
+        delete newAnnotations[hunkKey]
+      } else {
+        newAnnotations[hunkKey] = filtered
+      }
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...session, annotations: newAnnotations },
+        },
+      }
+    })
+  },
+  clearAnnotations: (sessionId) => {
+    set((state) => {
+      const session = getSession(state.sessions, sessionId)
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...session, annotations: {} },
+        },
+      }
+    })
+  },
+  setFocusedHunk: (sessionId, key) => {
+    set((state) => {
+      const session = getSession(state.sessions, sessionId)
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...session, focusedHunkKey: key },
+        },
+      }
+    })
+  },
+}))

--- a/src/renderer/stores/review.ts
+++ b/src/renderer/stores/review.ts
@@ -139,6 +139,7 @@ export const useReviewStore = create<ReviewStore>((set, get) => ({
             [sessionId]: {
               ...getSession(state.sessions, sessionId),
               files,
+              annotations: {},
               cachedMode: mode,
               diffUpdated: true,
             },

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -21,6 +21,16 @@
   --accent-red: #f87171;
   --accent-blue: #60a5fa;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+
+  --review-bg: #12122a;
+  --review-addition: rgba(74, 222, 128, 0.12);
+  --review-deletion: rgba(248, 113, 113, 0.12);
+  --review-addition-text: #4ade80;
+  --review-deletion-text: #f87171;
+  --review-hunk-header: #1e1e3a;
+  --review-approved: #4ade80;
+  --review-commented: #facc15;
+  --review-rejected: #f87171;
 }
 
 *:focus-visible {
@@ -822,4 +832,785 @@ body,
   width: 12px;
   height: 12px;
   border-radius: 50%;
+}
+
+/* --- Flip animation for Review overlay --- */
+
+.flip-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  perspective: 1200px;
+}
+
+.flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform 400ms ease-in-out;
+}
+
+.flip-inner.flipped {
+  transform: rotateY(180deg);
+}
+
+.flip-front,
+.flip-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
+.flip-front {
+  z-index: 1;
+}
+
+.flip-back {
+  transform: rotateY(180deg);
+  z-index: 2;
+}
+
+.review-overlay {
+  width: 100%;
+  height: 100%;
+  background: var(--review-bg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+  overflow-y: auto;
+}
+
+.review-placeholder {
+  font-size: 24px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.review-error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 32px;
+  max-width: 400px;
+}
+
+.review-error-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--accent-red);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.review-error {
+  color: var(--accent-red);
+  font-size: 14px;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.review-loading {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 60%;
+  max-width: 400px;
+}
+
+.review-loading-bar {
+  height: 16px;
+  background: var(--border);
+  border-radius: 4px;
+  animation: shimmer 1.2s ease-in-out infinite;
+}
+
+.review-loading-bar:nth-child(2) {
+  width: 80%;
+  animation-delay: 0.15s;
+}
+
+.review-loading-bar:nth-child(3) {
+  width: 55%;
+  animation-delay: 0.3s;
+}
+
+@keyframes shimmer {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
+.review-file-list {
+  width: 100%;
+  padding: 16px 24px;
+  align-self: flex-start;
+}
+
+.review-file-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.review-file-item:hover {
+  background: var(--border);
+}
+
+.review-file-status {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.review-file-status--added {
+  background: rgba(74, 222, 128, 0.2);
+  color: var(--review-approved);
+}
+
+.review-file-status--modified {
+  background: rgba(96, 165, 250, 0.2);
+  color: var(--accent-blue);
+}
+
+.review-file-status--deleted {
+  background: rgba(248, 113, 113, 0.2);
+  color: var(--review-rejected);
+}
+
+.review-file-status--renamed {
+  background: rgba(250, 204, 21, 0.2);
+  color: var(--review-commented);
+}
+
+.review-file-path {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.review-file-hunks {
+  color: var(--text-secondary);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+/* --- Review layout --- */
+
+.review-layout {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+.review-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.review-sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  background: var(--bg-sidebar);
+}
+
+.review-main {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* --- ReviewTopBar --- */
+
+.rv-top-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  background: var(--bg-sidebar);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  font-size: 13px;
+}
+
+.rv-top-bar-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent-green);
+}
+
+.rv-top-bar-sep {
+  color: var(--text-secondary);
+}
+
+.rv-top-bar-repo {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.rv-top-bar-branch {
+  color: var(--accent-blue);
+}
+
+.rv-top-bar-files {
+  color: var(--text-secondary);
+  margin-left: auto;
+}
+
+/* --- DiffViewer --- */
+
+.rv-diff-viewer {
+  padding: 0;
+}
+
+.rv-file-section {
+  margin-bottom: 2px;
+}
+
+.rv-file-header {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--bg-main);
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.rv-file-status {
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.rv-file-status--added {
+  background: rgba(74, 222, 128, 0.15);
+  color: var(--review-approved);
+}
+
+.rv-file-status--modified {
+  background: rgba(96, 165, 250, 0.15);
+  color: var(--accent-blue);
+}
+
+.rv-file-status--deleted {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--review-rejected);
+}
+
+.rv-file-status--renamed {
+  background: rgba(250, 204, 21, 0.15);
+  color: var(--review-commented);
+}
+
+.rv-diff-hunk {
+  border-left: 3px solid transparent;
+  margin-bottom: 1px;
+}
+
+.rv-diff-hunk--focused {
+  border-left-color: var(--accent-blue);
+  background: rgba(96, 165, 250, 0.04);
+}
+
+.rv-hunk-header {
+  padding: 4px 16px;
+  background: var(--review-hunk-header);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  position: relative;
+  user-select: none;
+}
+
+.rv-diff-line {
+  display: flex;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.rv-diff-line:hover {
+  filter: brightness(1.15);
+}
+
+.rv-diff-line--addition {
+  background: var(--review-addition);
+}
+
+.rv-diff-line--deletion {
+  background: var(--review-deletion);
+}
+
+.rv-line-gutter {
+  width: 50px;
+  flex-shrink: 0;
+  text-align: right;
+  padding-right: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  opacity: 0.6;
+  user-select: none;
+}
+
+.rv-line-content {
+  flex: 1;
+  padding-left: 8px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.rv-line-prefix {
+  display: inline;
+  user-select: none;
+  color: var(--text-secondary);
+}
+
+/* --- FileTree --- */
+
+.rv-file-tree {
+  padding: 8px 0;
+  font-size: 13px;
+}
+
+.rv-file-tree-dir-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  cursor: pointer;
+  border-radius: 3px;
+  color: var(--text-secondary);
+}
+
+.rv-file-tree-dir-label:hover {
+  background: var(--border);
+}
+
+.rv-file-tree-arrow {
+  width: 12px;
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+.rv-file-tree-dir-name {
+  font-weight: 600;
+}
+
+.rv-file-tree-file {
+  display: flex;
+  align-items: center;
+  padding: 3px 8px;
+  cursor: pointer;
+  border-radius: 3px;
+  color: var(--text-primary);
+}
+
+.rv-file-tree-file:hover {
+  background: var(--border);
+}
+
+.rv-file-tree-file--focused {
+  background: rgba(74, 222, 128, 0.1);
+  color: var(--accent-green);
+}
+
+.rv-file-tree-file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rv-file-tree-dropdown {
+  width: 100%;
+  padding: 6px 8px;
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  border-radius: 4px;
+}
+
+.rv-file-tree-dropdown:focus {
+  border-color: var(--accent-green);
+  outline: none;
+}
+
+/* --- HunkToolbar --- */
+
+.rv-hunk-toolbar {
+  display: flex;
+  gap: 2px;
+  padding: 2px 4px;
+  background: var(--bg-context-menu);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.rv-toolbar-btn {
+  width: 28px;
+  height: 28px;
+  background: none;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-primary);
+}
+
+.rv-toolbar-btn:hover {
+  background: var(--border);
+}
+
+.rv-toolbar-btn--approve:hover {
+  color: var(--review-approved);
+}
+
+.rv-toolbar-btn--comment:hover {
+  color: var(--review-commented);
+}
+
+.rv-toolbar-btn--reject:hover {
+  color: var(--review-rejected);
+}
+
+/* --- FeedbackInput --- */
+
+.rv-feedback-input {
+  position: sticky;
+  bottom: 0;
+  z-index: 10;
+  background: var(--bg-sidebar);
+  border-top: 1px solid var(--border);
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rv-feedback-textarea {
+  width: 100%;
+  min-height: 60px;
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  padding: 8px;
+  resize: vertical;
+}
+
+.rv-feedback-textarea:focus {
+  border-color: var(--accent-green);
+  outline: none;
+}
+
+.rv-feedback-radio-group {
+  display: flex;
+  gap: 16px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.rv-feedback-radio-group label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.rv-feedback-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.rv-feedback-btn {
+  padding: 5px 14px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  cursor: pointer;
+  border: none;
+}
+
+.rv-feedback-btn--submit {
+  background: var(--accent-green);
+  color: var(--text-on-accent);
+  font-weight: 600;
+}
+
+.rv-feedback-btn--submit:hover {
+  opacity: 0.9;
+}
+
+.rv-feedback-btn--cancel {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+
+.rv-feedback-btn--cancel:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+/* --- AnnotationBadge --- */
+
+.rv-annotation-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  margin: 2px 0 2px 56px;
+  border-radius: 4px;
+  font-size: 12px;
+  max-width: calc(100% - 72px);
+}
+
+.rv-annotation-badge--approved {
+  background: rgba(74, 222, 128, 0.1);
+  color: var(--review-approved);
+}
+
+.rv-annotation-badge--commented {
+  background: rgba(250, 204, 21, 0.1);
+  color: var(--review-commented);
+}
+
+.rv-annotation-badge--rejected {
+  background: rgba(248, 113, 113, 0.1);
+  color: var(--review-rejected);
+}
+
+.rv-annotation-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rv-annotation-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.5;
+  font-size: 14px;
+  padding: 0 2px;
+  flex-shrink: 0;
+}
+
+.rv-annotation-remove:hover {
+  opacity: 1;
+}
+
+/* --- Hunk review border colors --- */
+
+.rv-diff-hunk--approved {
+  border-left-color: var(--review-approved);
+}
+
+.rv-diff-hunk--commented {
+  border-left-color: var(--review-commented);
+}
+
+.rv-diff-hunk--rejected {
+  border-left-color: var(--review-rejected);
+}
+
+/* --- ReviewBottomBar --- */
+
+.rv-bottom-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 44px;
+  padding: 0 16px;
+  background: var(--bg-sidebar);
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  font-size: 13px;
+}
+
+.rv-bottom-bar-stats {
+  color: var(--text-secondary);
+}
+
+.rv-bottom-bar-count--approved {
+  color: var(--review-approved);
+}
+
+.rv-bottom-bar-count--commented {
+  color: var(--review-commented);
+}
+
+.rv-bottom-bar-count--rejected {
+  color: var(--review-rejected);
+}
+
+.rv-bottom-bar-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.rv-bottom-bar-btn {
+  padding: 5px 14px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.rv-bottom-bar-btn--primary {
+  background: var(--accent-green);
+  color: var(--text-on-accent);
+  font-weight: 600;
+  border: none;
+}
+
+.rv-bottom-bar-btn--primary:hover {
+  opacity: 0.9;
+}
+
+.rv-bottom-bar-btn--secondary {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+
+.rv-bottom-bar-btn--secondary:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+/* --- Confirm dialog --- */
+
+.rv-confirm-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.rv-confirm-dialog {
+  background: var(--bg-sidebar);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px 24px;
+  max-width: 400px;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.rv-confirm-dialog p {
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.rv-confirm-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+/* --- Diff mode control --- */
+
+.rv-mode-control {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-left: 8px;
+}
+
+.rv-mode-btn {
+  padding: 3px 10px;
+  background: none;
+  border: none;
+  border-right: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.rv-mode-btn:last-child {
+  border-right: none;
+}
+
+.rv-mode-btn:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+.rv-mode-btn--active {
+  background: var(--accent-green);
+  color: var(--text-on-accent);
+  font-weight: 600;
+}
+
+.rv-mode-btn--active:hover {
+  background: var(--accent-green);
+  color: var(--text-on-accent);
+  opacity: 0.9;
+}
+
+.rv-branch-dropdown {
+  padding: 3px 8px;
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  margin-left: 4px;
+}
+
+.rv-branch-dropdown:focus {
+  border-color: var(--accent-green);
+  outline: none;
 }

--- a/src/renderer/styles/swim-lanes.css
+++ b/src/renderer/styles/swim-lanes.css
@@ -89,3 +89,12 @@
   min-height: 0;
   position: relative;
 }
+
+.lane-header--focused {
+  border-bottom-color: var(--accent-green);
+  box-shadow: inset 0 -2px 0 var(--accent-green);
+}
+
+.lane-header--focused .lane-header-name {
+  color: var(--accent-green);
+}

--- a/src/renderer/utils/prompt-generator.test.ts
+++ b/src/renderer/utils/prompt-generator.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect } from 'vitest'
+import { generatePrompt, getHunkDiffText, getHunkKey, formatSelectedText } from './prompt-generator'
+import type { DiffFile, DiffHunk, HunkAnnotation } from '../../shared/types'
+
+function makeHunk(overrides?: Partial<DiffHunk>): DiffHunk {
+  return {
+    header: '@@ -1,3 +1,4 @@',
+    oldStart: 1,
+    oldCount: 3,
+    newStart: 1,
+    newCount: 4,
+    lines: [
+      { content: '  context line', lineType: 'context', oldLineNo: 1, newLineNo: 1 },
+      { content: '  old line', lineType: 'deletion', oldLineNo: 2, newLineNo: null },
+      { content: '  new line', lineType: 'addition', oldLineNo: null, newLineNo: 2 },
+      { content: '  another ctx', lineType: 'context', oldLineNo: 3, newLineNo: 3 },
+    ],
+    ...overrides,
+  }
+}
+
+function makeFile(path: string, hunkCount = 1): DiffFile {
+  const hunks: DiffHunk[] = []
+  for (let i = 0; i < hunkCount; i++) {
+    hunks.push(makeHunk({ header: `@@ -${i * 10 + 1},3 +${i * 10 + 1},4 @@` }))
+  }
+  return { path, oldPath: null, hunks, status: 'modified' }
+}
+
+let idCounter = 0
+function ann(
+  overrides: Partial<HunkAnnotation> & Pick<HunkAnnotation, 'decision'>
+): HunkAnnotation {
+  return {
+    id: `test-${++idCounter}`,
+    ...overrides,
+  }
+}
+
+describe('getHunkKey', () => {
+  it('generates key from path and index', () => {
+    expect(getHunkKey('src/foo.ts', 2)).toBe('src/foo.ts::2')
+  })
+})
+
+describe('formatSelectedText', () => {
+  it('wraps text in backticks', () => {
+    expect(formatSelectedText('some code')).toBe('`some code`')
+  })
+})
+
+describe('getHunkDiffText', () => {
+  it('reconstructs diff text with proper prefixes', () => {
+    const hunk = makeHunk()
+    const result = getHunkDiffText(hunk)
+    expect(result).toBe('   context line\n' + '-  old line\n' + '+  new line\n' + '   another ctx')
+  })
+})
+
+describe('generatePrompt', () => {
+  it('returns empty string for no files', () => {
+    expect(generatePrompt([], {})).toBe('')
+  })
+
+  it('returns all-approved message when all hunks explicitly approved', () => {
+    const files = [makeFile('src/a.ts', 2), makeFile('src/b.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/a.ts::0': [ann({ decision: 'approved' })],
+      'src/a.ts::1': [ann({ decision: 'approved' })],
+      'src/b.ts::0': [ann({ decision: 'approved' })],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toBe("I've reviewed your changes. All 3 hunks approved as-is. Looks good!")
+  })
+
+  it('omits unreviewed hunks', () => {
+    const files = [makeFile('src/a.ts', 1)]
+    const result = generatePrompt(files, {})
+    expect(result).toBe('')
+  })
+
+  it('generates comment with selected text', () => {
+    const files = [makeFile('src/auth.ts', 2)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/auth.ts::0': [ann({ decision: 'approved' })],
+      'src/auth.ts::1': [
+        ann({
+          decision: 'commented',
+          comment: 'This looks suspicious',
+          selectedText: 'doAuth()',
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('1 hunks approved as-is.')
+    expect(result).toContain('The following need attention:')
+    expect(result).toContain('## src/auth.ts — Hunk @@ -11,3 +11,4 @@')
+    expect(result).toContain('**Comment** (`doAuth()`):')
+    expect(result).toContain('This looks suspicious')
+  })
+
+  it('generates comment without selected text', () => {
+    const files = [makeFile('src/auth.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/auth.ts::0': [
+        ann({
+          decision: 'commented',
+          comment: 'General remark',
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('**Comment**:')
+    expect(result).toContain('General remark')
+    expect(result).not.toContain('**Comment** on')
+  })
+
+  it('generates rejection with propose alternative', () => {
+    const files = [makeFile('src/db.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/db.ts::0': [
+        ann({
+          decision: 'rejected',
+          rejectMode: 'propose_alternative',
+          comment: 'Use a connection pool instead',
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('**Rejected** (propose alternative):')
+    expect(result).toContain('```diff')
+    expect(result).toContain('Use a connection pool instead')
+  })
+
+  it('generates rejection with request other possibilities', () => {
+    const files = [makeFile('src/db.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/db.ts::0': [
+        ann({
+          decision: 'rejected',
+          rejectMode: 'request_possibilities',
+          comment: 'Show me other approaches',
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('**Rejected** (request other possibilities):')
+    expect(result).toContain('```diff')
+    expect(result).toContain('Show me other approaches')
+  })
+
+  it('produces mixed output with approved count and actionable items', () => {
+    const files = [makeFile('src/a.ts', 3), makeFile('src/b.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/a.ts::0': [ann({ decision: 'approved' })],
+      'src/a.ts::1': [
+        ann({
+          decision: 'commented',
+          comment: 'Needs docs',
+        }),
+      ],
+      'src/a.ts::2': [
+        ann({
+          decision: 'rejected',
+          rejectMode: 'propose_alternative',
+          comment: 'Try X instead',
+        }),
+      ],
+      'src/b.ts::0': [ann({ decision: 'approved' })],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toMatch(/^I've reviewed your changes\. 2 hunks approved as-is\./)
+    expect(result).toContain('The following need attention:')
+    expect(result).toContain('## src/a.ts — Hunk')
+    expect(result).toContain('**Comment**:')
+    expect(result).toContain('**Rejected** (propose alternative):')
+    expect(result).not.toContain('src/b.ts')
+  })
+
+  it('generates comment with selected lines range', () => {
+    const files = [makeFile('src/auth.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/auth.ts::0': [
+        ann({
+          decision: 'commented',
+          comment: 'This logic is wrong',
+          selectedText: 'doAuth()',
+          selectedLines: { start: 1, end: 3 },
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('**Comment** on lines 1-3 (`doAuth()`):')
+    expect(result).toContain('This logic is wrong')
+  })
+
+  it('generates comment with single selected line', () => {
+    const files = [makeFile('src/auth.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/auth.ts::0': [
+        ann({
+          decision: 'commented',
+          comment: 'Bad name',
+          selectedLines: { start: 2, end: 2 },
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('**Comment** on line 2:')
+    expect(result).toContain('Bad name')
+  })
+
+  it('generates rejection with selectedText shown', () => {
+    const files = [makeFile('src/db.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/db.ts::0': [
+        ann({
+          decision: 'rejected',
+          rejectMode: 'propose_alternative',
+          comment: 'Use pool',
+          selectedText: 'createConnection()',
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('**Rejected** (propose alternative) (`createConnection()`):')
+    expect(result).toContain('Use pool')
+  })
+
+  it('generates rejection with selectedLines filtering diff', () => {
+    const files = [makeFile('src/db.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/db.ts::0': [
+        ann({
+          decision: 'rejected',
+          rejectMode: 'propose_alternative',
+          comment: 'Change this',
+          selectedLines: { start: 2, end: 2 },
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('```diff')
+    expect(result).not.toContain('context line')
+  })
+
+  it('handles multiple annotations on same hunk', () => {
+    const files = [makeFile('src/foo.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/foo.ts::0': [
+        ann({ decision: 'approved', selectedLines: { start: 1, end: 1 } }),
+        ann({
+          decision: 'commented',
+          comment: 'Rename this',
+          selectedLines: { start: 2, end: 2 },
+        }),
+        ann({
+          decision: 'rejected',
+          rejectMode: 'propose_alternative',
+          comment: 'Wrong approach',
+          selectedLines: { start: 3, end: 3 },
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('0 hunks approved as-is.')
+    expect(result).toContain('**Approved** on line 1')
+    expect(result).toContain('**Comment** on line 2:')
+    expect(result).toContain('Rename this')
+    expect(result).toContain('**Rejected** (propose alternative):')
+    expect(result).toContain('Wrong approach')
+  })
+
+  it('hunk with only line-level approvals counts as approved', () => {
+    const files = [makeFile('src/foo.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/foo.ts::0': [ann({ decision: 'approved', selectedLines: { start: 1, end: 3 } })],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toBe("I've reviewed your changes. All 1 hunks approved as-is. Looks good!")
+  })
+
+  it('mixes hunk-level and line-level annotations', () => {
+    const files = [makeFile('src/foo.ts', 1)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/foo.ts::0': [
+        ann({ decision: 'approved' }),
+        ann({
+          decision: 'commented',
+          comment: 'But fix this line',
+          selectedLines: { start: 2, end: 2 },
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('Hunk approved as-is.')
+    expect(result).toContain('**Comment** on line 2:')
+    expect(result).toContain('But fix this line')
+  })
+
+  it('counts only explicitly approved hunks in partial review', () => {
+    const files = [makeFile('src/a.ts', 3)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/a.ts::0': [ann({ decision: 'approved' })],
+      'src/a.ts::2': [
+        ann({
+          decision: 'commented',
+          comment: 'Fix this',
+        }),
+      ],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toContain('1 hunks approved as-is.')
+    expect(result).toContain('The following need attention:')
+    expect(result).not.toContain('src/a.ts — Hunk @@ -11,3 +11,4 @@')
+  })
+
+  it('returns empty string when no annotations at all', () => {
+    const files = [makeFile('src/a.ts', 2), makeFile('src/b.ts', 3)]
+    const result = generatePrompt(files, {})
+    expect(result).toBe('')
+  })
+
+  it('omits unreviewed hunks from output in mixed review', () => {
+    const files = [makeFile('src/a.ts', 3)]
+    const annotations: Record<string, HunkAnnotation[]> = {
+      'src/a.ts::0': [ann({ decision: 'approved' })],
+      'src/a.ts::2': [ann({ decision: 'approved' })],
+    }
+
+    const result = generatePrompt(files, annotations)
+    expect(result).toBe("I've reviewed your changes. All 2 hunks approved as-is. Looks good!")
+  })
+})

--- a/src/renderer/utils/prompt-generator.ts
+++ b/src/renderer/utils/prompt-generator.ts
@@ -1,0 +1,126 @@
+import type { DiffFile, DiffHunk, HunkAnnotation } from '../../shared/types'
+
+export function formatSelectedText(text: string): string {
+  return `\`${text}\``
+}
+
+export function getHunkDiffText(
+  hunk: DiffHunk,
+  selectedLines?: { start: number; end: number }
+): string {
+  const lines = selectedLines
+    ? hunk.lines.filter((line) => {
+        const lineNo = line.newLineNo ?? line.oldLineNo
+        return lineNo != null && lineNo >= selectedLines.start && lineNo <= selectedLines.end
+      })
+    : hunk.lines
+  return lines
+    .map((line) => {
+      switch (line.lineType) {
+        case 'addition':
+          return `+${line.content}`
+        case 'deletion':
+          return `-${line.content}`
+        case 'context':
+          return ` ${line.content}`
+      }
+    })
+    .join('\n')
+}
+
+export function getHunkKey(filePath: string, hunkIndex: number): string {
+  return `${filePath}::${hunkIndex}`
+}
+
+export function generatePrompt(
+  files: DiffFile[],
+  annotations: Record<string, HunkAnnotation[]>
+): string {
+  if (files.length === 0) return ''
+
+  let approvedHunks = 0
+  const actionableItems: string[] = []
+
+  for (const file of files) {
+    for (let i = 0; i < file.hunks.length; i++) {
+      const hunk = file.hunks[i]
+      const key = getHunkKey(file.path, i)
+      const anns = annotations[key]
+
+      if (!anns || anns.length === 0) {
+        // Unreviewed hunks are omitted — not counted
+        continue
+      }
+
+      const allApproved = anns.every((a) => a.decision === 'approved')
+      if (allApproved) {
+        approvedHunks++
+        continue
+      }
+
+      const heading = `## ${file.path} — Hunk ${hunk.header}`
+      const items: string[] = []
+
+      const hunkApprovals = anns.filter((a) => a.decision === 'approved' && !a.selectedLines)
+      const lineApprovals = anns.filter((a) => a.decision === 'approved' && a.selectedLines)
+
+      if (hunkApprovals.length > 0) {
+        items.push('Hunk approved as-is.')
+      }
+
+      for (const ann of lineApprovals) {
+        const linePart =
+          ann.selectedLines!.start === ann.selectedLines!.end
+            ? ` on line ${ann.selectedLines!.start}`
+            : ` on lines ${ann.selectedLines!.start}-${ann.selectedLines!.end}`
+        const textPart = ann.selectedText ? ` (\`${ann.selectedText}\`)` : ''
+        items.push(`**Approved**${linePart}${textPart}`)
+      }
+
+      for (const ann of anns.filter((a) => a.decision === 'commented')) {
+        const linePart = ann.selectedLines
+          ? ann.selectedLines.start === ann.selectedLines.end
+            ? ` on line ${ann.selectedLines.start}`
+            : ` on lines ${ann.selectedLines.start}-${ann.selectedLines.end}`
+          : ''
+        const textPart = ann.selectedText ? ` (\`${ann.selectedText}\`)` : ''
+        items.push(`**Comment**${linePart}${textPart}:\n${ann.comment ?? ''}`)
+      }
+
+      for (const ann of anns.filter((a) => a.decision === 'rejected')) {
+        const diffBlock = '```diff\n' + getHunkDiffText(hunk, ann.selectedLines) + '\n```'
+        const textPart = ann.selectedText ? ` (\`${ann.selectedText}\`)` : ''
+
+        if (ann.rejectMode === 'propose_alternative') {
+          items.push(
+            `**Rejected** (propose alternative)${textPart}:\n${diffBlock}\n${ann.comment ?? ''}`
+          )
+        } else {
+          items.push(
+            `**Rejected** (request other possibilities)${textPart}:\n${diffBlock}\n${ann.comment ?? ''}`
+          )
+        }
+      }
+
+      actionableItems.push(`${heading}\n${items.join('\n\n')}`)
+    }
+  }
+
+  if (actionableItems.length === 0 && approvedHunks > 0) {
+    return `I've reviewed your changes. All ${approvedHunks} hunks approved as-is. Looks good!`
+  }
+
+  if (actionableItems.length === 0 && approvedHunks === 0) {
+    return ''
+  }
+
+  const parts = [
+    `I've reviewed your changes. ${approvedHunks} hunks approved as-is.`,
+    '',
+    'The following need attention:',
+    '',
+    actionableItems.join('\n\n'),
+  ]
+
+  return parts.join('\n')
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,3 +34,45 @@ export interface HookEvent {
   timestamp: number
   data: Record<string, unknown>
 }
+
+// --- Review / Diff types ---
+
+export type LineType = 'addition' | 'deletion' | 'context'
+export type FileStatus = 'added' | 'modified' | 'deleted' | 'renamed'
+
+export interface DiffLine {
+  content: string
+  lineType: LineType
+  oldLineNo: number | null
+  newLineNo: number | null
+}
+
+export interface DiffHunk {
+  header: string
+  oldStart: number
+  oldCount: number
+  newStart: number
+  newCount: number
+  lines: DiffLine[]
+}
+
+export interface DiffFile {
+  path: string
+  oldPath: string | null
+  hunks: DiffHunk[]
+  status: FileStatus
+}
+
+export type DiffMode = 'uncommitted' | 'unpushed' | 'branch'
+
+export type ReviewDecision = 'approved' | 'commented' | 'rejected'
+export type RejectMode = 'propose_alternative' | 'request_possibilities'
+
+export interface HunkAnnotation {
+  id: string
+  decision: ReviewDecision
+  comment?: string
+  rejectMode?: RejectMode
+  selectedText?: string
+  selectedLines?: { start: number; end: number }
+}


### PR DESCRIPTION
## Summary

- Implements the full code review integration from [PRD #2](https://github.com/pmatos/cc-pewpew/issues/2), covering all 8 phases
- Press **Ctrl+R** in Session View or a focused swim lane to flip to a Review overlay with a 3D card-flip animation; the terminal stays fully mounted underneath
- Three diff modes (Uncommitted, Unpushed, Branch) with auto-detected default branch, unified diff parser, annotation workflow (approve/comment/reject), prompt generation, and PTY injection
- Diff caching per session+mode with background re-fetch, inline error states with retry, and confirmation dialogs for destructive actions

### New files (13)
- `src/main/diff-parser.ts` — unified diff parser
- `src/renderer/stores/review.ts` — Zustand review store with caching
- `src/renderer/utils/prompt-generator.ts` — markdown prompt from annotations
- `src/renderer/components/ReviewOverlay.tsx` — main review overlay orchestrator
- `src/renderer/components/review/DiffViewer.tsx` — colored diff with dual gutters
- `src/renderer/components/review/FileTree.tsx` — hierarchical tree with responsive collapse
- `src/renderer/components/review/ReviewTopBar.tsx` — repo info + mode selector
- `src/renderer/components/review/ReviewBottomBar.tsx` — progress + send/copy actions
- `src/renderer/components/review/HunkToolbar.tsx` — approve/comment/reject buttons
- `src/renderer/components/review/FeedbackInput.tsx` — comment/reject form
- 3 test files (51 tests total)

### Modified files (12)
- `src/shared/types.ts` — added DiffFile, DiffHunk, DiffLine, HunkAnnotation, DiffMode types
- `src/main/index.ts` — 3 new IPC handlers (review:get-diff, review:list-branches, review:get-default-branch)
- `src/preload/index.ts` + `src/renderer/env.d.ts` — exposed new IPC channels
- `src/renderer/App.tsx` — rebound Ctrl+R → Ctrl+Shift+R for project refresh
- `src/renderer/components/DetailPane.tsx` — flip container wrapping terminal + review
- `src/renderer/components/Terminal.tsx` — intercept Ctrl+R from xterm
- `src/renderer/SwimLanesApp.tsx` — lane focus tracking + Ctrl+R flip
- `src/renderer/components/LaneHeader.tsx` — focus indicator
- `src/renderer/styles/global.css` — ~790 lines of review CSS
- `src/renderer/styles/swim-lanes.css` — lane focus styles

## Test plan

- [ ] `npx tsc --noEmit` passes clean
- [ ] `npx vitest run` — 51 tests pass (diff parser: 19, review store: 11, prompt generator: 21)
- [ ] `npm run dev` — open a session, press Ctrl+R to flip to review, verify animation and terminal persistence
- [ ] Make changes in a session's worktree, flip to review, verify diff data loads
- [ ] Navigate with j/k, approve with 'a', comment with 'c', reject with 'r'
- [ ] Send prompt to session, verify no trailing newline, auto-flip back
- [ ] Switch diff modes (Uncommitted/Unpushed/Branch), verify re-fetch and annotation clear confirmation
- [ ] Open swim lanes, click a lane to focus, Ctrl+R flips only that lane
- [ ] Verify Ctrl+Shift+R still refreshes projects, tooltip updated
- [ ] Verify `prefers-reduced-motion` suppresses flip animation