### PR TITLE
fix: disable xterm WebGL renderer on Linux

### DIFF
--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -110,24 +110,32 @@ export default function Terminal({ sessionId }: Props) {
         if (aborted) return
 
         term.open(container)
-        try {
-          const addon = new WebglAddon()
-          addon.onContextLoss(() => {
-            // GPU process crashed or GL context was lost (common on dual-GPU
-            // Linux systems). Dispose the WebGL addon so xterm.js falls back
-            // to its built-in canvas renderer — garbled output otherwise.
-            try {
-              addon.dispose()
-            } catch {
-              // Already disposed
-            }
-            webglAddon = null
-            term.refresh(0, term.rows - 1)
-          })
-          term.loadAddon(addon)
-          webglAddon = addon
-        } catch {
-          // WebGL not available, fall back to default canvas renderer
+        // Skip WebglAddon on Linux. ANGLE's Vulkan backend (enabled in
+        // src/main/index.ts for dual-GPU support) can't always import the
+        // Ozone DMA-BUF shared-image backing into a Vulkan texture, producing
+        // silent WebGL errors (`ProduceGLTexturePassthrough: incompatible
+        // backing`) that leave the glyph atlas invalid. xterm.js never sees a
+        // context-loss event, so glyphs render as garbled/scattered text. The
+        // canvas renderer is marginally slower but reliable across Linux GPU
+        // stacks.
+        const isLinux = navigator.userAgent.includes('Linux')
+        if (!isLinux) {
+          try {
+            const addon = new WebglAddon()
+            addon.onContextLoss(() => {
+              try {
+                addon.dispose()
+              } catch {
+                // Already disposed
+              }
+              webglAddon = null
+              term.refresh(0, term.rows - 1)
+            })
+            term.loadAddon(addon)
+            webglAddon = addon
+          } catch {
+            // WebGL not available, fall back to default canvas renderer
+          }
         }
         termRef.current = term
         fitRef.current = fitAddon


### PR DESCRIPTION
## Summary
- On Linux, xterm.js rendered glyphs as garbled/scattered text (see reported screenshot) while Electron's GPU process logged `GL_INVALID_OPERATION: invalid mailbox name` and `SharedImageManager::ProduceGLTexturePassthrough: incompatible backing: OzoneImageBacking`.
- Root cause: ANGLE's Vulkan backend (enabled in #2 for dual-GPU support) can't always import the Ozone DMA-BUF shared-image into a Vulkan texture (`DmaBufImageSiblingVkLinux.cpp` returns `VK_ERROR_FEATURE_NOT_PRESENT`). The WebGL texture atlas ends up invalid, but no context-loss event fires — so `WebglAddon.onContextLoss` never triggers and glyphs keep rendering to a broken atlas.
- Fix: skip `WebglAddon` on Linux and use xterm.js's canvas renderer. The `use-angle=vulkan` switch stays in `src/main/index.ts` (still needed for dual-GPU init); we just don't route glyph rendering through WebGL anymore.

## Test plan
- [ ] Launch on Linux, open a session, verify terminal text renders cleanly
- [ ] Confirm `GL_INVALID_OPERATION` / `ProduceGLTexturePassthrough` spam no longer appears in the console
- [ ] Spot-check on macOS/Windows to confirm WebGL path still engages there