### PR TITLE
feat: mirror existing worktrees as cc-pewpew sessions

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -27,6 +27,7 @@ export interface AppConfig {
   sidebarWidth: number
   uiScale: number
   hosts: Host[]
+  gitignoreWarned: string[]
 }
 
 export const CONFIG_DIR = join(
@@ -44,6 +45,18 @@ const DEFAULT_CONFIG: AppConfig = {
   sidebarWidth: 250,
   uiScale: 1.2,
   hosts: [],
+  gitignoreWarned: [],
+}
+
+export function shouldWarnGitignore(projectPath: string): boolean {
+  return !getConfig().gitignoreWarned.includes(projectPath)
+}
+
+export function markGitignoreWarned(projectPath: string): void {
+  const config = getConfig()
+  if (config.gitignoreWarned.includes(projectPath)) return
+  config.gitignoreWarned = [...config.gitignoreWarned, projectPath]
+  saveConfig(config)
 }
 
 export function resolvePath(p: string): string {

--- a/src/main/hook-installer.ts
+++ b/src/main/hook-installer.ts
@@ -1,6 +1,10 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, appendFileSync } from 'fs'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { join } from 'path'
 import { CONFIG_DIR } from './config'
+
+const execFileAsync = promisify(execFile)
 
 const NOTIFY_SCRIPT = join(CONFIG_DIR, 'hooks', 'notify.sh')
 
@@ -50,6 +54,19 @@ export async function installHooks(
 
   if (!skipGitignore) {
     ensureGitignore(projectPath, '.claude/settings.local.json')
+  }
+}
+
+export async function isSettingsGitignored(projectPath: string): Promise<boolean> {
+  try {
+    await execFileAsync(
+      'git',
+      ['-C', projectPath, 'check-ignore', '-q', '.claude/settings.local.json'],
+      { timeout: 5000 }
+    )
+    return true
+  } catch {
+    return false
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,9 +2,17 @@ import { app, BrowserWindow, ipcMain, shell, dialog } from 'electron'
 import { join, resolve } from 'path'
 import { copyFileSync, mkdirSync, chmodSync } from 'fs'
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer'
-import { getConfig, saveConfig, resolvePath, CONFIG_DIR, type CanvasState } from './config'
+import {
+  getConfig,
+  saveConfig,
+  resolvePath,
+  CONFIG_DIR,
+  shouldWarnGitignore,
+  markGitignoreWarned,
+  type CanvasState,
+} from './config'
 import { scanProjects } from './project-scanner'
-import { installHooks } from './hook-installer'
+import { installHooks, isSettingsGitignored } from './hook-installer'
 import { startHookServer, stopHookServer } from './hook-server'
 import { createTray } from './tray'
 import { registerWindow, broadcastToAll } from './window-registry'
@@ -20,6 +28,8 @@ import {
 import {
   initSessionManager,
   createSession,
+  createSessionForWorktree,
+  mirrorAllWorktrees,
   createPrSession,
   getSession,
   getSessions,
@@ -168,6 +178,29 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('sessions:create-pr', async (_event, projectPath: string, prNumber: number) => {
     return createPrSession(projectPath, prNumber)
+  })
+
+  async function gitignoreWarning(projectPath: string): Promise<'gitignore' | undefined> {
+    if (!shouldWarnGitignore(projectPath)) return undefined
+    const ignored = await isSettingsGitignored(projectPath)
+    if (ignored) {
+      markGitignoreWarned(projectPath)
+      return undefined
+    }
+    markGitignoreWarned(projectPath)
+    return 'gitignore'
+  }
+
+  ipcMain.handle('sessions:mirror', async (_event, projectPath: string, worktreePath: string) => {
+    const session = await createSessionForWorktree(projectPath, worktreePath)
+    const warning = await gitignoreWarning(projectPath)
+    return { session, warning }
+  })
+
+  ipcMain.handle('sessions:mirror-all', async (_event, projectPath: string) => {
+    const result = await mirrorAllWorktrees(projectPath)
+    const warning = result.mirrored.length > 0 ? await gitignoreWarning(projectPath) : undefined
+    return { result, warning }
   })
 
   ipcMain.handle('sessions:list', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -185,15 +185,16 @@ app.whenReady().then(async () => {
     checkPaths: string[]
   ): Promise<'gitignore' | undefined> {
     if (!shouldWarnGitignore(projectPath) || checkPaths.length === 0) return undefined
-    let anyUnignored = false
     for (const p of checkPaths) {
       if (!(await isSettingsGitignored(p))) {
-        anyUnignored = true
-        break
+        markGitignoreWarned(projectPath)
+        return 'gitignore'
       }
     }
-    markGitignoreWarned(projectPath)
-    return anyUnignored ? 'gitignore' : undefined
+    // All checked worktrees ignore the file. Leave the project un-warned so a
+    // later mirror of a branch that doesn't ignore it can still surface the
+    // prompt.
+    return undefined
   }
 
   ipcMain.handle('sessions:mirror', async (_event, projectPath: string, worktreePath: string) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -180,26 +180,34 @@ app.whenReady().then(async () => {
     return createPrSession(projectPath, prNumber)
   })
 
-  async function gitignoreWarning(projectPath: string): Promise<'gitignore' | undefined> {
-    if (!shouldWarnGitignore(projectPath)) return undefined
-    const ignored = await isSettingsGitignored(projectPath)
-    if (ignored) {
-      markGitignoreWarned(projectPath)
-      return undefined
+  async function gitignoreWarning(
+    projectPath: string,
+    checkPaths: string[]
+  ): Promise<'gitignore' | undefined> {
+    if (!shouldWarnGitignore(projectPath) || checkPaths.length === 0) return undefined
+    let anyUnignored = false
+    for (const p of checkPaths) {
+      if (!(await isSettingsGitignored(p))) {
+        anyUnignored = true
+        break
+      }
     }
     markGitignoreWarned(projectPath)
-    return 'gitignore'
+    return anyUnignored ? 'gitignore' : undefined
   }
 
   ipcMain.handle('sessions:mirror', async (_event, projectPath: string, worktreePath: string) => {
     const session = await createSessionForWorktree(projectPath, worktreePath)
-    const warning = await gitignoreWarning(projectPath)
+    const warning = await gitignoreWarning(projectPath, [session.worktreePath])
     return { session, warning }
   })
 
   ipcMain.handle('sessions:mirror-all', async (_event, projectPath: string) => {
     const result = await mirrorAllWorktrees(projectPath)
-    const warning = result.mirrored.length > 0 ? await gitignoreWarning(projectPath) : undefined
+    const warning = await gitignoreWarning(
+      projectPath,
+      result.mirrored.map((s) => s.worktreePath)
+    )
     return { result, warning }
   })
 

--- a/src/main/project-scanner.test.ts
+++ b/src/main/project-scanner.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { parseWorktreeList } from './project-scanner'
+
+describe('parseWorktreeList', () => {
+  it('returns empty array for empty input', () => {
+    expect(parseWorktreeList('')).toEqual([])
+  })
+
+  it('flags the first worktree as main and others as not main', () => {
+    const stdout = [
+      'worktree /home/user/repo',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /home/user/repo/.claude/worktrees/feat-a',
+      'HEAD def456',
+      'branch refs/heads/cc-pewpew/feat-a',
+      '',
+      'worktree /tmp/external-wt',
+      'HEAD 789abc',
+      'branch refs/heads/external/feature',
+      '',
+    ].join('\n')
+
+    const result = parseWorktreeList(stdout)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({
+      name: 'repo',
+      path: '/home/user/repo',
+      branch: 'main',
+      isMain: true,
+    })
+    expect(result[1]).toEqual({
+      name: 'feat-a',
+      path: '/home/user/repo/.claude/worktrees/feat-a',
+      branch: 'cc-pewpew/feat-a',
+      isMain: false,
+    })
+    expect(result[2]).toEqual({
+      name: 'external-wt',
+      path: '/tmp/external-wt',
+      branch: 'external/feature',
+      isMain: false,
+    })
+  })
+
+  it('falls back to HEAD when no branch line is present (detached HEAD)', () => {
+    const stdout = ['worktree /home/user/repo', 'HEAD abc123', 'detached', ''].join('\n')
+
+    const result = parseWorktreeList(stdout)
+    expect(result).toHaveLength(1)
+    expect(result[0].branch).toBe('HEAD')
+    expect(result[0].isMain).toBe(true)
+  })
+
+  it('handles a single-worktree repository', () => {
+    const stdout = ['worktree /home/user/solo', 'HEAD abc123', 'branch refs/heads/main', ''].join(
+      '\n'
+    )
+
+    const result = parseWorktreeList(stdout)
+    expect(result).toHaveLength(1)
+    expect(result[0].isMain).toBe(true)
+  })
+})

--- a/src/main/project-scanner.ts
+++ b/src/main/project-scanner.ts
@@ -20,40 +20,44 @@ async function gitBranches(repoPath: string): Promise<string[]> {
   }
 }
 
-async function gitWorktrees(repoPath: string): Promise<Worktree[]> {
+export function parseWorktreeList(stdout: string): Worktree[] {
+  const worktrees: Worktree[] = []
+  const blocks = stdout.split('\n\n').filter(Boolean)
+
+  for (const block of blocks) {
+    const lines = block.split('\n')
+    let path = ''
+    let branch = ''
+
+    for (const line of lines) {
+      if (line.startsWith('worktree ')) {
+        path = line.slice('worktree '.length)
+      } else if (line.startsWith('branch ')) {
+        branch = line.slice('branch refs/heads/'.length)
+      }
+    }
+
+    if (path) {
+      worktrees.push({
+        name: basename(path),
+        path,
+        branch: branch || 'HEAD',
+        isMain: worktrees.length === 0,
+      })
+    }
+  }
+
+  return worktrees
+}
+
+export async function gitWorktrees(repoPath: string): Promise<Worktree[]> {
   try {
     const { stdout } = await execFileAsync(
       'git',
       ['-C', repoPath, 'worktree', 'list', '--porcelain'],
       { timeout: 5000 }
     )
-
-    const worktrees: Worktree[] = []
-    const blocks = stdout.split('\n\n').filter(Boolean)
-
-    for (const block of blocks) {
-      const lines = block.split('\n')
-      let path = ''
-      let branch = ''
-
-      for (const line of lines) {
-        if (line.startsWith('worktree ')) {
-          path = line.slice('worktree '.length)
-        } else if (line.startsWith('branch ')) {
-          branch = line.slice('branch refs/heads/'.length)
-        }
-      }
-
-      if (path) {
-        worktrees.push({
-          name: basename(path),
-          path,
-          branch: branch || 'HEAD',
-        })
-      }
-    }
-
-    return worktrees
+    return parseWorktreeList(stdout)
   } catch {
     return []
   }

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -132,6 +132,9 @@ async function adoptWorktree(
     throw new Error(`${worktreePath} is not a valid git worktree`)
   }
 
+  // Store the canonical path so renderer raw-equality matches against
+  // git's canonical porcelain output (the same normalization used for dedupe).
+  const canonical = canonicalPath(worktreePath)
   const id = randomUUID().slice(0, 8)
   const projectName = basename(projectPath)
   const worktreeName = label || (await deriveLabel(worktreePath))
@@ -145,7 +148,7 @@ async function adoptWorktree(
     projectPath,
     projectName,
     worktreeName,
-    worktreePath,
+    worktreePath: canonical,
     pid: 0,
     tmuxSession,
     status: 'running',
@@ -466,7 +469,9 @@ export async function relocateProject(
 
   const fingerprint = await getRepoFingerprint(newProjectPath)
 
-  const oldManagedRoot = join(oldProjectPath, '.claude', 'worktrees') + sep
+  // Stored session paths are canonical, so canonicalize the old managed root
+  // too before prefix-matching (oldProjectPath may be a symlink form).
+  const oldManagedRoot = canonicalPath(join(oldProjectPath, '.claude', 'worktrees')) + sep
   for (const entry of toMigrate) {
     const s = entry.session
     s.projectPath = newProjectPath
@@ -553,6 +558,8 @@ export function restoreSessions(): void {
           }
         }
       }
+      // Migrate legacy symlink-form paths to canonical so renderer matches work.
+      session.worktreePath = canonicalPath(session.worktreePath)
       session.lastActivity = Date.now()
       sessions.set(session.id, { session })
     }

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { readFileSync, writeFileSync, existsSync } from 'fs'
-import { join, basename } from 'path'
+import { join, basename, sep } from 'path'
 import { randomUUID } from 'crypto'
 import { dialog, shell } from 'electron'
 import { broadcastToAll, getMainWindow } from './window-registry'
@@ -74,6 +74,20 @@ async function deriveLabel(worktreePath: string): Promise<string> {
   return basename(worktreePath)
 }
 
+async function isGitWorktree(worktreePath: string): Promise<boolean> {
+  if (!existsSync(worktreePath)) return false
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-C', worktreePath, 'rev-parse', '--is-inside-work-tree'],
+      { timeout: 5000 }
+    )
+    return stdout.trim() === 'true'
+  } catch {
+    return false
+  }
+}
+
 export async function createSessionForWorktree(
   projectPath: string,
   worktreePath: string,
@@ -81,6 +95,10 @@ export async function createSessionForWorktree(
 ): Promise<Session> {
   for (const e of sessions.values()) {
     if (e.session.worktreePath === worktreePath) return e.session
+  }
+
+  if (!(await isGitWorktree(worktreePath))) {
+    throw new Error(`${worktreePath} is not a valid git worktree`)
   }
 
   const id = randomUUID().slice(0, 8)
@@ -417,11 +435,16 @@ export async function relocateProject(
 
   const fingerprint = await getRepoFingerprint(newProjectPath)
 
+  const oldManagedRoot = join(oldProjectPath, '.claude', 'worktrees') + sep
   for (const entry of toMigrate) {
     const s = entry.session
     s.projectPath = newProjectPath
     s.projectName = basename(newProjectPath)
-    s.worktreePath = join(newProjectPath, '.claude', 'worktrees', s.worktreeName)
+    // Only rewrite worktreePath for managed worktrees under the old project's
+    // .claude/worktrees tree. External mirrored paths are kept verbatim.
+    if (s.worktreePath.startsWith(oldManagedRoot)) {
+      s.worktreePath = join(newProjectPath, '.claude', 'worktrees', s.worktreeName)
+    }
     if (fingerprint) s.repoFingerprint = fingerprint
 
     // Recreate PTY so tmux gets the new worktree cwd

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -379,11 +379,8 @@ export async function createPrSession(
   }
 
   const branch = prInfo.headRefName
-  const id = randomUUID().slice(0, 8)
   const worktreeName = `pr-${prNumber}`
-  const projectName = basename(projectPath)
   const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
-  const tmuxSession = `cc-pewpew-${id}`
 
   // Fetch the PR branch
   try {
@@ -413,35 +410,7 @@ export async function createPrSession(
     }
   }
 
-  // Install hooks in the worktree so Claude Code fires events back to cc-pewpew
-  await installHooks(worktreePath, { skipGitignore: true })
-
-  createPty(id, worktreePath)
-
-  const session: Session = {
-    id,
-    projectPath,
-    projectName,
-    worktreeName,
-    worktreePath,
-    pid: 0,
-    tmuxSession,
-    status: 'running',
-    lastActivity: Date.now(),
-    hookEvents: [],
-  }
-
-  sessions.set(id, { session })
-
-  getRepoFingerprint(projectPath).then((fp) => {
-    if (fp) {
-      session.repoFingerprint = fp
-      onSessionsChanged()
-    }
-  })
-
-  onSessionsChanged()
-  return session
+  return createSessionForWorktree(projectPath, worktreePath, worktreeName)
 }
 
 export function getSession(id: string): Session | undefined {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -18,7 +18,7 @@ import {
   discoverTmuxSessions,
   reattachPty,
 } from './pty-manager'
-import { getRepoFingerprint } from './project-scanner'
+import { getRepoFingerprint, gitWorktrees } from './project-scanner'
 import { installHooks } from './hook-installer'
 import type { Session, SessionStatus } from '../shared/types'
 
@@ -59,33 +59,36 @@ export function initSessionManager(): void {
   // No-op — session manager now uses the window registry for IPC
 }
 
-export async function createSession(projectPath: string, name?: string): Promise<Session> {
-  const id = randomUUID().slice(0, 8)
-  const worktreeName = name || `session-${id}`
-  const projectName = basename(projectPath)
-  const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
-  const tmuxSession = `cc-pewpew-${id}`
-
-  // Create worktree
+async function deriveLabel(worktreePath: string): Promise<string> {
   try {
-    await execFileAsync('git', [
-      '-C',
-      projectPath,
-      'worktree',
-      'add',
-      worktreePath,
-      '-b',
-      `cc-pewpew/${worktreeName}`,
-    ])
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'],
+      { timeout: 5000 }
+    )
+    const branch = stdout.trim()
+    if (branch && branch !== 'HEAD') return branch
   } catch {
-    // Branch may already exist — try without -b
-    await execFileAsync('git', ['-C', projectPath, 'worktree', 'add', worktreePath])
+    // fall through to basename
+  }
+  return basename(worktreePath)
+}
+
+export async function createSessionForWorktree(
+  projectPath: string,
+  worktreePath: string,
+  label?: string
+): Promise<Session> {
+  for (const e of sessions.values()) {
+    if (e.session.worktreePath === worktreePath) return e.session
   }
 
-  // Install hooks in the worktree so Claude Code fires events back to cc-pewpew
-  await installHooks(worktreePath, { skipGitignore: true })
+  const id = randomUUID().slice(0, 8)
+  const projectName = basename(projectPath)
+  const worktreeName = label || (await deriveLabel(worktreePath))
+  const tmuxSession = `cc-pewpew-${id}`
 
-  // Create embedded terminal via PTY manager (tmux + node-pty)
+  await installHooks(worktreePath, { skipGitignore: true })
   createPty(id, worktreePath)
 
   const session: Session = {
@@ -113,6 +116,54 @@ export async function createSession(projectPath: string, name?: string): Promise
   onSessionsChanged()
 
   return session
+}
+
+export interface MirrorAllResult {
+  mirrored: Session[]
+  failed: { path: string; error: string }[]
+}
+
+export async function mirrorAllWorktrees(projectPath: string): Promise<MirrorAllResult> {
+  const worktrees = await gitWorktrees(projectPath)
+  const existingPaths = new Set<string>()
+  for (const e of sessions.values()) existingPaths.add(e.session.worktreePath)
+
+  const targets = worktrees.filter((wt) => !wt.isMain && !existingPaths.has(wt.path))
+
+  const results = await Promise.allSettled(
+    targets.map((wt) => createSessionForWorktree(projectPath, wt.path))
+  )
+
+  const mirrored: Session[] = []
+  const failed: { path: string; error: string }[] = []
+  results.forEach((r, i) => {
+    if (r.status === 'fulfilled') mirrored.push(r.value)
+    else failed.push({ path: targets[i].path, error: String(r.reason) })
+  })
+
+  return { mirrored, failed }
+}
+
+export async function createSession(projectPath: string, name?: string): Promise<Session> {
+  const worktreeName = name || `session-${randomUUID().slice(0, 8)}`
+  const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
+
+  try {
+    await execFileAsync('git', [
+      '-C',
+      projectPath,
+      'worktree',
+      'add',
+      worktreePath,
+      '-b',
+      `cc-pewpew/${worktreeName}`,
+    ])
+  } catch {
+    // Branch may already exist — try without -b
+    await execFileAsync('git', ['-C', projectPath, 'worktree', 'add', worktreePath])
+  }
+
+  return createSessionForWorktree(projectPath, worktreePath, worktreeName)
 }
 
 export function handleHookEvent(method: string, params: Record<string, unknown>): void {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
-import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, existsSync, realpathSync } from 'fs'
 import { join, basename, sep } from 'path'
 import { randomUUID } from 'crypto'
 import { dialog, shell } from 'electron'
@@ -74,6 +74,14 @@ async function deriveLabel(worktreePath: string): Promise<string> {
   return basename(worktreePath)
 }
 
+function canonicalPath(p: string): string {
+  try {
+    return realpathSync(p)
+  } catch {
+    return p
+  }
+}
+
 async function isGitWorktree(worktreePath: string): Promise<boolean> {
   if (!existsSync(worktreePath)) return false
   try {
@@ -93,8 +101,9 @@ export async function createSessionForWorktree(
   worktreePath: string,
   label?: string
 ): Promise<Session> {
+  const target = canonicalPath(worktreePath)
   for (const e of sessions.values()) {
-    if (e.session.worktreePath === worktreePath) return e.session
+    if (canonicalPath(e.session.worktreePath) === target) return e.session
   }
 
   if (!(await isGitWorktree(worktreePath))) {
@@ -144,9 +153,9 @@ export interface MirrorAllResult {
 export async function mirrorAllWorktrees(projectPath: string): Promise<MirrorAllResult> {
   const worktrees = await gitWorktrees(projectPath)
   const existingPaths = new Set<string>()
-  for (const e of sessions.values()) existingPaths.add(e.session.worktreePath)
+  for (const e of sessions.values()) existingPaths.add(canonicalPath(e.session.worktreePath))
 
-  const targets = worktrees.filter((wt) => !wt.isMain && !existingPaths.has(wt.path))
+  const targets = worktrees.filter((wt) => !wt.isMain && !existingPaths.has(canonicalPath(wt.path)))
 
   const results = await Promise.allSettled(
     targets.map((wt) => createSessionForWorktree(projectPath, wt.path))
@@ -441,9 +450,12 @@ export async function relocateProject(
     s.projectPath = newProjectPath
     s.projectName = basename(newProjectPath)
     // Only rewrite worktreePath for managed worktrees under the old project's
-    // .claude/worktrees tree. External mirrored paths are kept verbatim.
+    // .claude/worktrees tree, preserving the exact subpath (worktreeName may be
+    // a branch label like "cc-pewpew/feat-x" that doesn't match the dirname).
+    // External mirrored paths are kept verbatim.
     if (s.worktreePath.startsWith(oldManagedRoot)) {
-      s.worktreePath = join(newProjectPath, '.claude', 'worktrees', s.worktreeName)
+      const suffix = s.worktreePath.slice(oldManagedRoot.length)
+      s.worktreePath = join(newProjectPath, '.claude', 'worktrees', suffix)
     }
     if (fingerprint) s.repoFingerprint = fingerprint
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -96,6 +96,11 @@ async function isGitWorktree(worktreePath: string): Promise<boolean> {
   }
 }
 
+// In-flight adoption promises keyed by canonical worktree path. Serializes
+// concurrent mirror requests for the same path (e.g. double-click on + Mirror,
+// racing against mirrorAllWorktrees) so only one session/PTY is created.
+const inflightAdoptions = new Map<string, Promise<Session>>()
+
 export async function createSessionForWorktree(
   projectPath: string,
   worktreePath: string,
@@ -106,6 +111,23 @@ export async function createSessionForWorktree(
     if (canonicalPath(e.session.worktreePath) === target) return e.session
   }
 
+  const inflight = inflightAdoptions.get(target)
+  if (inflight) return inflight
+
+  const promise = adoptWorktree(projectPath, worktreePath, label)
+  inflightAdoptions.set(target, promise)
+  try {
+    return await promise
+  } finally {
+    inflightAdoptions.delete(target)
+  }
+}
+
+async function adoptWorktree(
+  projectPath: string,
+  worktreePath: string,
+  label: string | undefined
+): Promise<Session> {
   if (!(await isGitWorktree(worktreePath))) {
     throw new Error(`${worktreePath} is not a valid git worktree`)
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,6 +17,10 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.invoke('sessions:create', projectPath, name),
   createPrSession: (projectPath: string, prNumber: number) =>
     ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber),
+  mirrorWorktree: (projectPath: string, worktreePath: string) =>
+    ipcRenderer.invoke('sessions:mirror', projectPath, worktreePath),
+  mirrorAllWorktrees: (projectPath: string) =>
+    ipcRenderer.invoke('sessions:mirror-all', projectPath),
   getSessions: () => ipcRenderer.invoke('sessions:list'),
   killSession: (id: string) => ipcRenderer.invoke('sessions:kill', id),
   reviveSession: (id: string) => ipcRenderer.invoke('sessions:revive', id),

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -25,6 +25,12 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const [pendingPrPath, setPendingPrPath] = useState<string | null>(null)
   const [prNumberInput, setPrNumberInput] = useState('')
   const [prError, setPrError] = useState<string | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
+  const showToast = (msg: string) => {
+    setToast(msg)
+    setTimeout(() => setToast((cur) => (cur === msg ? null : cur)), 5000)
+  }
 
   useEffect(() => {
     scanProjects()
@@ -77,6 +83,32 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
           setPendingPrPath(menu.projectPath)
           setPrNumberInput('')
           setPrError(null)
+        },
+      })
+
+      const project = projects.find((p) => p.path === menu.projectPath)
+      const unmirroredCount =
+        project?.worktrees.filter(
+          (wt) => !wt.isMain && !sessions.some((s) => s.worktreePath === wt.path)
+        ).length ?? 0
+      items.push({
+        label:
+          unmirroredCount > 0
+            ? `Mirror all worktrees (${unmirroredCount})`
+            : 'Mirror all worktrees',
+        disabled: unmirroredCount === 0,
+        onClick: async () => {
+          const { result, warning } = await window.api.mirrorAllWorktrees(menu.projectPath)
+          const { mirrored, failed } = result
+          const parts: string[] = []
+          if (mirrored.length > 0) parts.push(`Mirrored ${mirrored.length}`)
+          if (failed.length > 0) parts.push(`${failed.length} failed`)
+          if (parts.length > 0) showToast(parts.join(', '))
+          if (warning === 'gitignore') {
+            showToast(
+              'Note: .claude/settings.local.json is not gitignored in this project — consider ignoring it.'
+            )
+          }
         },
       })
       items.push({
@@ -245,9 +277,8 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
             {isExpanded && (
               <div className="worktree-list">
                 {project.worktrees.map((wt) => {
-                  const matchingSession = sessions.find(
-                    (s) => s.worktreeName === wt.name && s.projectPath === project.path
-                  )
+                  const matchingSession = sessions.find((s) => s.worktreePath === wt.path)
+                  const canMirror = !matchingSession && !wt.isMain
                   return (
                     <div
                       key={wt.path}
@@ -261,8 +292,34 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
                         }
                       }}
                     >
-                      {wt.name}
-                      {wt.branch && <span className="worktree-branch"> ({wt.branch})</span>}
+                      <span className="worktree-label">
+                        {wt.name}
+                        {wt.branch && <span className="worktree-branch"> ({wt.branch})</span>}
+                      </span>
+                      {canMirror && (
+                        <button
+                          className="worktree-mirror-btn"
+                          title="Mirror this worktree as a cc-pewpew session"
+                          onClick={async (e) => {
+                            e.stopPropagation()
+                            try {
+                              const { warning } = await window.api.mirrorWorktree(
+                                project.path,
+                                wt.path
+                              )
+                              if (warning === 'gitignore') {
+                                showToast(
+                                  'Note: .claude/settings.local.json is not gitignored in this project — consider ignoring it.'
+                                )
+                              }
+                            } catch (err) {
+                              showToast(`Mirror failed: ${String(err)}`)
+                            }
+                          }}
+                        >
+                          + Mirror
+                        </button>
+                      )}
                     </div>
                   )
                 })}
@@ -275,6 +332,8 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
       {menu && (
         <ContextMenu x={menu.x} y={menu.y} items={getMenuItems()} onClose={() => setMenu(null)} />
       )}
+
+      {toast && <div className="project-tree-toast">{toast}</div>}
     </div>
   )
 }

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -19,6 +19,14 @@ declare global {
       onHookEvent: (callback: (event: { method: string; params: unknown }) => void) => () => void
       createSession: (projectPath: string, name?: string) => Promise<Session>
       createPrSession: (projectPath: string, prNumber: number) => Promise<Session | string>
+      mirrorWorktree: (
+        projectPath: string,
+        worktreePath: string
+      ) => Promise<{ session: Session; warning?: 'gitignore' }>
+      mirrorAllWorktrees: (projectPath: string) => Promise<{
+        result: { mirrored: Session[]; failed: { path: string; error: string }[] }
+        warning?: 'gitignore'
+      }>
       getSessions: () => Promise<Session[]>
       killSession: (id: string) => Promise<void>
       reviveSession: (id: string) => Promise<void>

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -471,9 +471,40 @@ body,
   padding: 2px 8px;
   font-size: 14px;
   color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.worktree-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.worktree-mirror-btn {
+  flex-shrink: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0 6px;
+  font-size: 11px;
+  line-height: 18px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.worktree-item:hover .worktree-mirror-btn {
+  opacity: 1;
+}
+
+.worktree-mirror-btn:hover {
+  background: var(--border);
+  color: var(--text-primary);
 }
 
 .session-name-dialog {
@@ -504,6 +535,21 @@ body,
 
 .worktree-branch {
   opacity: 0.6;
+}
+
+.project-tree-toast {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  right: 12px;
+  background: var(--bg-context-menu);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 100;
 }
 
 .context-menu {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,6 +12,7 @@ export interface Worktree {
   name: string
   path: string
   branch: string
+  isMain: boolean
 }
 
 export interface Session {


### PR DESCRIPTION
## Summary
- Adopt git worktrees created outside cc-pewpew (including external paths) as managed sessions, either one-by-one via a hover-reveal `+ Mirror` button in the sidebar or in bulk via a new `Mirror all worktrees (N)` context-menu entry per project.
- The project's main worktree is excluded, so the primary checkout never gets adopted accidentally.
- Session identity is now keyed on absolute worktree path rather than basename, which also fixes the sidebar matcher for two worktrees that happened to share a basename.

## Design
- `Worktree.isMain: boolean` — flagged from the first entry of `git worktree list --porcelain`.
- `createSessionForWorktree(projectPath, worktreePath, label?)` is a new primitive: idempotent by path, derives label from the worktree's branch (falling back to basename for detached HEAD), installs hooks, and spawns `claude` the same way managed sessions do. The existing `createSession` now delegates to it after creating the `.claude/worktrees/...` directory.
- `mirrorAllWorktrees(projectPath)` uses `Promise.allSettled` so a failure on one worktree doesn't block the others; results and a one-time per-project gitignore warning are surfaced via an inline toast.
- No `managed`/`mirrored` distinction persisted — mirroring is adoption; subsequent lifecycle matches any other session.

## Test plan
- [x] Unit: `parseWorktreeList` flags first block as main, preserves ordering, handles detached HEAD (4 tests added).
- [x] Manual QA via CDP: verified on this working tree. Created `/tmp/pewpew-mirror-test` via `git worktree add`, confirmed the row shows `+ Mirror`, clicked it, observed a new session card and a sessions.json entry at `worktreePath: /tmp/pewpew-mirror-test` with label `test-mirror-external` (branch-derived); the main worktree row never shows the button.
- [x] `npx tsc --noEmit` and `npx vitest run` both clean (55/55).