### PR TITLE
feat: zoom canvas past a card to auto-open it as session view

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -215,6 +215,7 @@ export default function App() {
               setActiveSessionName(name)
             }}
             onZoomOpen={handleZoomOpen}
+            morphActive={morphPayload !== null}
           />
         )}
       </main>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import ProjectTree from './components/ProjectTree'
-import SessionCanvas from './components/SessionCanvas'
+import SessionCanvas, { type ZoomOpenPayload } from './components/SessionCanvas'
 import DetailPane from './components/DetailPane'
 import StatusBar from './components/StatusBar'
 import ManageHostsDialog from './components/ManageHostsDialog'
+import ZoomOpenMorph from './components/ZoomOpenMorph'
 import { useProjectsStore } from './stores/projects'
 import { useSessionsStore } from './stores/sessions'
 import { useHostsStore } from './stores/hosts'
@@ -40,6 +41,12 @@ export default function App() {
   const [sidebarWidth, setSidebarWidth] = useState(250)
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const [activeSessionName, setActiveSessionName] = useState('')
+  const [morphPayload, setMorphPayload] = useState<ZoomOpenPayload | null>(null)
+
+  const handleZoomOpen = useCallback((payload: ZoomOpenPayload) => {
+    // Keep canvas rendered during the morph; mount DetailPane only on morph grown.
+    setMorphPayload(payload)
+  }, [])
   const resizing = useRef(false)
   const resizeStart = useRef({ x: 0, width: 0 })
 
@@ -62,7 +69,10 @@ export default function App() {
         // one is open (avoids side-effect clearing of active session /
         // selection when dismissing a modal via Escape).
         if (useHostsStore.getState().dialogOpen) return
-        if (activeSessionId) {
+        if (morphPayload && !activeSessionId) {
+          // Cancel zoom-open mid-morph: abort the transition and stay on canvas.
+          setMorphPayload(null)
+        } else if (activeSessionId) {
           setActiveSessionId(null)
         } else if (useSessionsStore.getState().selectedIds.size > 0) {
           useSessionsStore.getState().clearSelection()
@@ -73,7 +83,7 @@ export default function App() {
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
-  }, [scanProjects, activeSessionId])
+  }, [scanProjects, activeSessionId, morphPayload])
 
   const handleCreate = async () => {
     const name = newProjectName.trim()
@@ -204,11 +214,23 @@ export default function App() {
               setActiveSessionId(id)
               setActiveSessionName(name)
             }}
+            onZoomOpen={handleZoomOpen}
           />
         )}
       </main>
 
       <ManageHostsDialog />
+      {morphPayload && (
+        <ZoomOpenMorph
+          startRect={morphPayload.startRect}
+          onGrown={() => {
+            setActiveSessionId(morphPayload.sessionId)
+            setActiveSessionName(morphPayload.sessionName)
+          }}
+          onDone={() => setMorphPayload(null)}
+        />
+      )}
+
       <StatusBar />
     </div>
   )

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -225,8 +225,10 @@ export default function App() {
         <ZoomOpenMorph
           startRect={morphPayload.startRect}
           onGrown={() => {
-            setActiveSessionId(morphPayload.sessionId)
-            setActiveSessionName(morphPayload.sessionName)
+            // If the user already opened a different session during the morph
+            // window (e.g. clicked another card), keep that selection.
+            setActiveSessionId((prev) => prev ?? morphPayload.sessionId)
+            setActiveSessionName((prev) => prev || morphPayload.sessionName)
           }}
           onDone={() => setMorphPayload(null)}
         />

--- a/src/renderer/components/SessionCanvas.tsx
+++ b/src/renderer/components/SessionCanvas.tsx
@@ -7,12 +7,28 @@ import EdgeIndicators from './EdgeIndicators'
 import BroadcastDialog from './BroadcastDialog'
 
 const MIN_ZOOM = 0.3
-const MAX_ZOOM = 1.0
+const RESTING_MAX_ZOOM = 1.0
 const ZOOM_SENSITIVITY = 0.001
 const KEYBOARD_ZOOM_STEP = 0.1
 const DOT_SPACING = 30
 const DOT_COLOR = '#2a2a4a'
 const DOT_RADIUS = 1.5
+
+// Source of truth in SessionCluster.tsx — keep in sync.
+const CARD_WIDTH = 240
+const CARD_HEIGHT = 230
+
+// Ceiling for wheel/keyboard zoom. Must exceed what zoom-to-open needs so the
+// gesture can push a card past the 95% fill threshold.
+function computeMaxZoom(viewportW: number, viewportH: number): number {
+  if (viewportW <= 0 || viewportH <= 0) return RESTING_MAX_ZOOM
+  return Math.max(viewportW / CARD_WIDTH, viewportH / CARD_HEIGHT) * 1.05
+}
+
+// Zoom-to-open: fire when card reaches this fraction of either viewport dimension,
+// sustained for DWELL_MS (filters accidental wheel flicks).
+const FILL_THRESHOLD = 0.95
+const DWELL_MS = 120
 
 const ACCENT_COLORS = [
   '#4ade80',
@@ -36,12 +52,21 @@ function hashColor(path: string): string {
 const CLUSTER_WIDTH = 510
 const CLUSTER_GAP = 40
 
-interface CanvasProps {
-  onOpenSession?: (id: string, name: string) => void
+export interface ZoomOpenPayload {
+  sessionId: string
+  sessionName: string
+  startRect: { left: number; top: number; width: number; height: number }
+  thumbnail: string | undefined
 }
 
-export default function SessionCanvas({ onOpenSession }: CanvasProps) {
+interface CanvasProps {
+  onOpenSession?: (id: string, name: string) => void
+  onZoomOpen?: (payload: ZoomOpenPayload) => void
+}
+
+export default function SessionCanvas({ onOpenSession, onZoomOpen }: CanvasProps) {
   const { sessions, thumbnails, toggleSelect, rangeSelect, clearSelection } = useSessionsStore()
+  const broadcastDialogOpen = useSessionsStore((s) => s.broadcastDialogOpen)
   const projects = useProjectsStore((s) => s.projects)
   const knownPaths = useMemo(() => new Set(projects.map((p) => p.path)), [projects])
   const viewportRef = useRef<HTMLDivElement>(null)
@@ -68,6 +93,13 @@ export default function SessionCanvas({ onOpenSession }: CanvasProps) {
   panXRef.current = panX
   panYRef.current = panY
   zoomRef.current = zoom
+
+  // Zoom-to-open state
+  const thresholdCrossedAtRef = useRef<number | null>(null)
+  const isAnimatingPanRef = useRef(false)
+  const zoomOpenFiredRef = useRef(false)
+  const broadcastDialogOpenRef = useRef(broadcastDialogOpen)
+  broadcastDialogOpenRef.current = broadcastDialogOpen
 
   // Group sessions by project
   const clusters = useMemo(() => {
@@ -138,6 +170,7 @@ export default function SessionCanvas({ onOpenSession }: CanvasProps) {
       const startTime = performance.now()
       const duration = 350
 
+      isAnimatingPanRef.current = true
       const animate = (now: number) => {
         const t = Math.min(1, (now - startTime) / duration)
         const ease = 1 - Math.pow(1 - t, 3)
@@ -148,7 +181,12 @@ export default function SessionCanvas({ onOpenSession }: CanvasProps) {
         if (t < 1) {
           requestAnimationFrame(animate)
         } else {
-          window.api.saveCanvasState({ zoom: zoomRef.current, panX: targetPanX, panY: targetPanY })
+          isAnimatingPanRef.current = false
+          window.api.saveCanvasState({
+            zoom: Math.min(zoomRef.current, RESTING_MAX_ZOOM),
+            panX: targetPanX,
+            panY: targetPanY,
+          })
         }
       }
       requestAnimationFrame(animate)
@@ -157,7 +195,8 @@ export default function SessionCanvas({ onOpenSession }: CanvasProps) {
     setPanToCluster(panToClusterFn)
   }, [clusterPositions, setPanToCluster])
 
-  // Track viewport size
+  // Track viewport size. Depends on `loaded` because pre-load renders null (ref
+  // is unattached); effect must re-run once the DOM mounts.
   useEffect(() => {
     const viewport = viewportRef.current
     if (!viewport) return
@@ -169,15 +208,31 @@ export default function SessionCanvas({ onOpenSession }: CanvasProps) {
     const observer = new ResizeObserver(updateSize)
     observer.observe(viewport)
     return () => observer.disconnect()
-  }, [])
+  }, [loaded])
 
-  // Persist canvas with debounce
-  const persistCanvas = useCallback((z: number, px: number, py: number) => {
-    if (saveTimer.current) clearTimeout(saveTimer.current)
-    saveTimer.current = setTimeout(() => {
-      window.api.saveCanvasState({ zoom: z, panX: px, panY: py })
-    }, 500)
-  }, [])
+  // Persist canvas with debounce. Clamp zoom to RESTING_MAX_ZOOM so a
+  // mid-gesture extreme zoom is never restored on next launch. When clamping,
+  // also recompute pan so the viewport-center world point stays fixed — otherwise
+  // on remount the user lands in empty world space far from their content.
+  const persistCanvas = useCallback(
+    (z: number, px: number, py: number) => {
+      if (saveTimer.current) clearTimeout(saveTimer.current)
+      saveTimer.current = setTimeout(() => {
+        let saveZoom = z
+        let savePanX = px
+        let savePanY = py
+        if (z > RESTING_MAX_ZOOM && viewportSize.width > 0 && viewportSize.height > 0) {
+          const worldCx = (viewportSize.width / 2 - px) / z
+          const worldCy = (viewportSize.height / 2 - py) / z
+          saveZoom = RESTING_MAX_ZOOM
+          savePanX = viewportSize.width / 2 - worldCx * RESTING_MAX_ZOOM
+          savePanY = viewportSize.height / 2 - worldCy * RESTING_MAX_ZOOM
+        }
+        window.api.saveCanvasState({ zoom: saveZoom, panX: savePanX, panY: savePanY })
+      }, 500)
+    },
+    [viewportSize.width, viewportSize.height]
+  )
 
   // Draw dot grid
   useEffect(() => {
@@ -236,8 +291,9 @@ export default function SessionCanvas({ onOpenSession }: CanvasProps) {
         persistCanvas(0.7, 0, 0)
       } else if (e.key === '=' || e.key === '+') {
         e.preventDefault()
+        const cap = computeMaxZoom(viewportSize.width, viewportSize.height)
         setZoom((prev) => {
-          const next = Math.min(MAX_ZOOM, prev + KEYBOARD_ZOOM_STEP)
+          const next = Math.min(cap, prev + KEYBOARD_ZOOM_STEP)
           persistCanvas(next, panX, panY)
           return next
         })
@@ -252,7 +308,7 @@ export default function SessionCanvas({ onOpenSession }: CanvasProps) {
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
-  }, [panX, panY, persistCanvas])
+  }, [panX, panY, persistCanvas, viewportSize.width, viewportSize.height])
 
   const handleWheel = useCallback(
     (e: React.WheelEvent) => {
@@ -263,18 +319,79 @@ export default function SessionCanvas({ onOpenSession }: CanvasProps) {
       const cx = e.clientX - rect.left
       const cy = e.clientY - rect.top
 
+      const cap = computeMaxZoom(rect.width, rect.height)
+      let committedZoom = zoomRef.current
       setZoom((prevZoom) => {
         const zoomDelta = -e.deltaY * ZOOM_SENSITIVITY * prevZoom
-        const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, prevZoom + zoomDelta))
+        const newZoom = Math.max(MIN_ZOOM, Math.min(cap, prevZoom + zoomDelta))
         const newPanX = cx - (cx - panX) * (newZoom / prevZoom)
         const newPanY = cy - (cy - panY) * (newZoom / prevZoom)
         setPanX(newPanX)
         setPanY(newPanY)
         persistCanvas(newZoom, newPanX, newPanY)
+        committedZoom = newZoom
         return newZoom
       })
+
+      // Zoom-to-open detection (wheel-only path).
+      // Guards: no modal, not mid-drag, no automated pan, not already fired.
+      const armed =
+        !broadcastDialogOpenRef.current &&
+        !dragging &&
+        !isAnimatingPanRef.current &&
+        !zoomOpenFiredRef.current
+      if (!armed) {
+        thresholdCrossedAtRef.current = null
+        return
+      }
+
+      // Target card: whichever .session-card sits under the cursor.
+      const hit = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null
+      const cardEl = hit?.closest('.session-card') as HTMLElement | null
+      if (!cardEl) {
+        thresholdCrossedAtRef.current = null
+        return
+      }
+
+      // Threshold: either dimension of the rendered card >= FILL_THRESHOLD of viewport.
+      const renderedW = CARD_WIDTH * committedZoom
+      const renderedH = CARD_HEIGHT * committedZoom
+      const filled =
+        renderedW >= rect.width * FILL_THRESHOLD || renderedH >= rect.height * FILL_THRESHOLD
+      if (!filled) {
+        thresholdCrossedAtRef.current = null
+        return
+      }
+
+      // Dwell: commit only after DWELL_MS of sustained threshold crossing.
+      const now = performance.now()
+      if (thresholdCrossedAtRef.current === null) {
+        thresholdCrossedAtRef.current = now
+        return
+      }
+      if (now - thresholdCrossedAtRef.current < DWELL_MS) return
+
+      // Fire.
+      const sessionId = cardEl.dataset.sessionId
+      if (!sessionId) return
+      const sessionRec = sessions.find((s) => s.id === sessionId)
+      if (!sessionRec) return
+      const cardRect = cardEl.getBoundingClientRect()
+      zoomOpenFiredRef.current = true
+      thresholdCrossedAtRef.current = null
+      onZoomOpen?.({
+        sessionId,
+        sessionName: `${sessionRec.projectName}/${sessionRec.worktreeName}`,
+        startRect: {
+          left: cardRect.left,
+          top: cardRect.top,
+          width: cardRect.width,
+          height: cardRect.height,
+        },
+        thumbnail: thumbnails[sessionId],
+      })
     },
-    [panX, panY, persistCanvas]
+    [panX, panY, persistCanvas, dragging, sessions, thumbnails, onZoomOpen]
   )
 
   const handleSelect = useCallback(

--- a/src/renderer/components/SessionCanvas.tsx
+++ b/src/renderer/components/SessionCanvas.tsx
@@ -62,9 +62,10 @@ export interface ZoomOpenPayload {
 interface CanvasProps {
   onOpenSession?: (id: string, name: string) => void
   onZoomOpen?: (payload: ZoomOpenPayload) => void
+  morphActive?: boolean
 }
 
-export default function SessionCanvas({ onOpenSession, onZoomOpen }: CanvasProps) {
+export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }: CanvasProps) {
   const { sessions, thumbnails, toggleSelect, rangeSelect, clearSelection } = useSessionsStore()
   const broadcastDialogOpen = useSessionsStore((s) => s.broadcastDialogOpen)
   const projects = useProjectsStore((s) => s.projects)
@@ -98,8 +99,21 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen }: CanvasProps
   const thresholdCrossedAtRef = useRef<number | null>(null)
   const isAnimatingPanRef = useRef(false)
   const zoomOpenFiredRef = useRef(false)
+  const prevMorphActiveRef = useRef(false)
   const broadcastDialogOpenRef = useRef(broadcastDialogOpen)
   broadcastDialogOpenRef.current = broadcastDialogOpen
+
+  // Reset the zoom-open latch when a morph ends without the session opening
+  // (cancel via Escape). If the session opens, SessionCanvas unmounts so this
+  // effect never runs — the ref resets naturally on the next mount.
+  useEffect(() => {
+    const active = morphActive ?? false
+    if (prevMorphActiveRef.current && !active) {
+      zoomOpenFiredRef.current = false
+      thresholdCrossedAtRef.current = null
+    }
+    prevMorphActiveRef.current = active
+  }, [morphActive])
 
   // Group sessions by project
   const clusters = useMemo(() => {
@@ -182,11 +196,19 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen }: CanvasProps
           requestAnimationFrame(animate)
         } else {
           isAnimatingPanRef.current = false
-          window.api.saveCanvasState({
-            zoom: Math.min(zoomRef.current, RESTING_MAX_ZOOM),
-            panX: targetPanX,
-            panY: targetPanY,
-          })
+          // Clamp zoom to RESTING_MAX_ZOOM on persist. When clamping, recompute
+          // pan for the clamped zoom so the target cluster stays at viewport
+          // center — matches persistCanvas and avoids cluster landing off-screen.
+          const saveZoom = Math.min(zoomRef.current, RESTING_MAX_ZOOM)
+          const savePanX =
+            zoomRef.current > RESTING_MAX_ZOOM
+              ? -pos.x * RESTING_MAX_ZOOM + rect.width / 2
+              : targetPanX
+          const savePanY =
+            zoomRef.current > RESTING_MAX_ZOOM
+              ? -pos.y * RESTING_MAX_ZOOM + rect.height / 2
+              : targetPanY
+          window.api.saveCanvasState({ zoom: saveZoom, panX: savePanX, panY: savePanY })
         }
       }
       requestAnimationFrame(animate)

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -136,7 +136,13 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
     .join(' ')
 
   return (
-    <div className={classes} onClick={handleClick} onContextMenu={handleContextMenu} style={style}>
+    <div
+      className={classes}
+      data-session-id={session.id}
+      onClick={handleClick}
+      onContextMenu={handleContextMenu}
+      style={style}
+    >
       <div className="session-card-thumb">
         {thumbnail ? <pre className="session-card-text-thumb">{thumbnail}</pre> : null}
       </div>

--- a/src/renderer/components/ZoomOpenMorph.tsx
+++ b/src/renderer/components/ZoomOpenMorph.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react'
+
+export interface ZoomOpenMorphProps {
+  startRect: { left: number; top: number; width: number; height: number }
+  // Called when the growth animation finishes. Parent should mount the DetailPane
+  // now so xterm has time to init during the fade.
+  onGrown: () => void
+  // Called after the fade completes. Parent should unmount this layer.
+  onDone: () => void
+}
+
+const MORPH_DURATION_MS = 180
+
+export default function ZoomOpenMorph({ startRect, onGrown, onDone }: ZoomOpenMorphProps) {
+  const [phase, setPhase] = useState<'start' | 'end' | 'fade'>('start')
+  const layerRef = useRef<HTMLDivElement>(null)
+  const grownFiredRef = useRef(false)
+
+  const fireGrown = () => {
+    if (grownFiredRef.current) return
+    grownFiredRef.current = true
+    onGrown()
+  }
+
+  // Trigger the transition on next frame so the browser registers the start rect first.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setPhase('end'))
+    return () => cancelAnimationFrame(id)
+  }, [])
+
+  // Safety timer: if transitionend never fires (reduced motion, interrupted), finish anyway.
+  useEffect(() => {
+    if (phase !== 'end') return
+    const t = setTimeout(() => {
+      fireGrown()
+      setPhase('fade')
+    }, MORPH_DURATION_MS + 50)
+    return () => clearTimeout(t)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase])
+
+  useEffect(() => {
+    if (phase !== 'fade') return
+    const t = setTimeout(onDone, 60)
+    return () => clearTimeout(t)
+  }, [phase, onDone])
+
+  const style: React.CSSProperties =
+    phase === 'start'
+      ? {
+          left: startRect.left,
+          top: startRect.top,
+          width: startRect.width,
+          height: startRect.height,
+          opacity: 1,
+        }
+      : phase === 'end'
+        ? { left: 0, top: 0, width: '100vw', height: '100vh', opacity: 1 }
+        : { left: 0, top: 0, width: '100vw', height: '100vh', opacity: 0 }
+
+  return (
+    <div
+      ref={layerRef}
+      className="zoom-open-morph"
+      style={style}
+      onTransitionEnd={(e) => {
+        if (e.propertyName === 'width' && phase === 'end') {
+          fireGrown()
+          setPhase('fade')
+        }
+      }}
+    ></div>
+  )
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1715,3 +1715,19 @@ body,
   border-color: var(--accent-green);
   outline: none;
 }
+
+.zoom-open-morph {
+  position: fixed;
+  z-index: 9999;
+  background: var(--bg-terminal);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  pointer-events: none;
+  transition:
+    left 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    top 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    width 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    height 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 60ms linear;
+}


### PR DESCRIPTION
## Summary

- Wheel-zoom past a card's 95% viewport fill (sustained 120ms) auto-opens it as the session view, via a shared-element morph from the card's rect to fullscreen.
- Zoom ceiling is dynamic (max of viewport/card width or height × 1.05) so the trigger is always reachable — even on ultrawide displays.
- Persisted canvas state clamps zoom to 1.0 and recomputes pan to preserve the world-point at viewport center, so closing the opened session returns the user to a sane canvas view instead of empty space.
- Escape mid-morph cancels the transition and leaves the user on the canvas.

## Implementation

- `SessionCanvas.tsx` — dynamic `computeMaxZoom`, cursor-anchored target detection via `elementFromPoint` + `data-session-id`, 120ms dwell on `FILL_THRESHOLD = 0.95`, guards on modal / drag / automated pan, `onZoomOpen` payload to parent.
- `ZoomOpenMorph.tsx` — fixed-position overlay animating `left/top/width/height` from card rect to viewport (180ms), then fading out (60ms). Fires `onGrown` on completion so parent mounts DetailPane and xterm inits in parallel with the fade.
- `App.tsx` — wires `handleZoomOpen` → `morphPayload` → conditional render; Escape-during-morph clears morph state without mounting DetailPane.
- `SessionCard.tsx` — adds `data-session-id` attribute for hit-testing.

Design decisions were walked through in a /grill-me interview: cursor-anchored targeting, 95% threshold with 120ms dwell, shared-element morph, instant cut on Escape, dynamic ceiling, wheel-only arming.

### Drive-by fix

Pre-existing bug: `SessionCanvas` renders `null` until persisted state loads, so the viewport-size tracking `useEffect` ran once with a null ref, bailed, and never reattached its `ResizeObserver`. `viewportSize` was stuck at `{0, 0}`, which broke EdgeIndicators and would have broken the new zoom ceiling computation. Added `loaded` to the effect's deps.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/renderer/` clean
- [x] `npx vitest run` — 51 tests pass
- [x] Manual: wheel-zoom past a card → morph → DetailPane with live xterm
- [x] Manual: close from DetailPane → canvas returns at zoom 1.0 with 7/8 cards visible (pan preservation works)
- [ ] Manual on ultrawide display (verify dynamic ceiling reaches threshold)
- [ ] Manual: confirm broadcast-dialog-open suppresses the feature
- [ ] Manual: confirm Escape mid-morph cancels cleanly