### PR TITLE
fix: avoid ARG_MAX overflow in notify.sh hook payload

### DIFF
--- a/hooks/notify.sh
+++ b/hooks/notify.sh
@@ -25,9 +25,8 @@ case "$EVENT_NAME" in
   *)              exit 0 ;;
 esac
 
-PAYLOAD=$(jq -cn \
+PAYLOAD=$(printf '%s' "$INPUT" | jq -c \
   --arg method "$METHOD" \
-  --argjson params "$INPUT" \
-  '{"jsonrpc":"2.0","method":$method,"params":$params,"id":null}')
+  '{jsonrpc:"2.0",method:$method,params:.,id:null}')
 
 echo "$PAYLOAD" | socat - UNIX-CONNECT:"$SOCKET" >/dev/null 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `hooks/notify.sh` built the JSON-RPC payload with `jq -cn --argjson params "$INPUT"`, passing the full hook payload as an argv item. On `PostToolUse:Read` of a large file, `tool_response.content` pushed argv past Linux's `ARG_MAX` (~128KB), causing `execve` to fail with `E2BIG` and Claude Code to surface `jq: Argument list too long`.
- Switched to `printf '%s' "$INPUT" | jq -c --arg method ... '{...,params:.,...}'` so the payload flows via stdin (no argv limit). `printf` is a bash builtin, so no fork/exec.

## Test plan
- [x] Reproduced with a 250KB synthetic payload — old script fails with `E2BIG`, new script exits 0
- [x] Verified small payloads still produce identical JSON-RPC output
- [ ] Observe no more `PostToolUse:Read hook error` after reading large files in a live session