### PR TITLE
ci: bump checkout to v5 and force Node 24 for JS actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,12 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+env:
+  # Force Node.js 24 for any JS-based actions still pinned to Node 20
+  # (e.g. oven-sh/setup-bun pulled in transitively by anthropics/claude-code-action).
+  # Node 20 is removed from runners on 2026-09-16.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -27,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -41,4 +47,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,12 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  # Force Node.js 24 for any JS-based actions still pinned to Node 20
+  # (e.g. oven-sh/setup-bun pulled in transitively by anthropics/claude-code-action).
+  # Node 20 is removed from runners on 2026-09-16.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   claude:
     if: |
@@ -26,7 +32,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -47,4 +53,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from `v4` to `v5` in both `.github/workflows/claude-code-review.yml` and `.github/workflows/claude.yml` (v5 ships Node.js 24).
- Adds workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` env to both workflows, which forces Node 24 for any JS-based action still pinned to Node 20 — notably the transitive `oven-sh/setup-bun` pulled in by `anthropics/claude-code-action@v1`, which we can't pin from our side.

Background: GitHub is removing Node 20 from runners on 2026-09-16; from 2026-06-02 actions are forced to Node 24 by default. The `FORCE_*` env becomes a harmless no-op after that date.

Closes #19

## Test plan
- [ ] CI runs on this PR show no Node 20 deprecation warning in either workflow
- [ ] `Claude Code Review` job still passes (verifies `claude-code-action` works under forced Node 24)