### PR TITLE
fix: make review flip rotate forward on return

### DIFF
--- a/src/renderer/SwimLanesApp.tsx
+++ b/src/renderer/SwimLanesApp.tsx
@@ -15,7 +15,9 @@ export default function SwimLanesApp() {
   const [sessionIds] = useState(parseSessionIds)
   const [sessions, setSessions] = useState<Session[]>([])
   const [focusedLane, setFocusedLane] = useState<string | null>(null)
-  const [reviewOpenLanes, setReviewOpenLanes] = useState<Set<string>>(new Set())
+  // Per-lane monotonic flip count: each toggle increments by 1, rotating +180deg.
+  // Keeps the return flip in the same direction as the opening flip.
+  const [laneFlipCounts, setLaneFlipCounts] = useState<Map<string, number>>(new Map())
 
   useEffect(() => {
     window.api.getSessions().then((all) => {
@@ -30,18 +32,18 @@ export default function SwimLanesApp() {
   }, [sessionIds])
 
   const toggleReview = useCallback((laneId: string) => {
-    setReviewOpenLanes((prev) => {
-      const next = new Set(prev)
-      if (next.has(laneId)) {
-        next.delete(laneId)
+    setLaneFlipCounts((prev) => {
+      const next = new Map(prev)
+      const count = (prev.get(laneId) ?? 0) + 1
+      next.set(laneId, count)
+      if (count % 2 === 0) {
+        // Flipping back to terminal — refocus after animation
         setTimeout(() => {
           const term = document.querySelector<HTMLElement>(
             `[data-lane-id="${laneId}"] .xterm-helper-textarea`
           )
           term?.focus()
         }, 420)
-      } else {
-        next.add(laneId)
       }
       return next
     })
@@ -72,7 +74,8 @@ export default function SwimLanesApp() {
         {sessionIds.map((id) => {
           const session = sessions.find((s) => s.id === id)
           const isDead = session?.status === 'dead' || session?.status === 'error'
-          const isReviewOpen = reviewOpenLanes.has(id)
+          const flipCount = laneFlipCounts.get(id) ?? 0
+          const isReviewOpen = flipCount % 2 === 1
 
           return (
             <div key={id} className="lane" data-lane-id={id} onClick={() => setFocusedLane(id)}>
@@ -91,7 +94,10 @@ export default function SwimLanesApp() {
                   </div>
                 ) : (
                   <div className="flip-container">
-                    <div className={`flip-inner${isReviewOpen ? ' flipped' : ''}`}>
+                    <div
+                      className="flip-inner"
+                      style={{ transform: `rotateY(${flipCount * 180}deg)` }}
+                    >
                       <div className="flip-front">
                         <Terminal sessionId={id} />
                       </div>

--- a/src/renderer/components/DetailPane.tsx
+++ b/src/renderer/components/DetailPane.tsx
@@ -13,11 +13,13 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
   const session = useSessionsStore((s) => s.sessions.find((s) => s.id === sessionId))
   const isDead = session?.status === 'dead'
   const [reviving, setReviving] = useState(false)
-  const [reviewOpen, setReviewOpen] = useState(false)
+  // Monotonic flip count — each toggle increments by 1, rotating +180deg.
+  // Using a counter (instead of a boolean) keeps the rotation going in the
+  // same direction on return instead of reversing.
+  const [flipCount, setFlipCount] = useState(0)
+  const reviewOpen = flipCount % 2 === 1
 
-  const closeReview = useCallback(() => {
-    setReviewOpen(false)
-    // Return focus to the terminal after the flip animation
+  const refocusTerminal = useCallback(() => {
     setTimeout(() => {
       const term = document.querySelector<HTMLElement>(
         '.detail-pane-terminal .xterm-helper-textarea'
@@ -26,22 +28,23 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
     }, 420)
   }, [])
 
+  const closeReview = useCallback(() => {
+    setFlipCount((c) => (c % 2 === 1 ? c + 1 : c))
+    refocusTerminal()
+  }, [refocusTerminal])
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.key === 'r') {
         e.preventDefault()
         e.stopPropagation()
-        setReviewOpen((prev) => {
-          if (prev) {
-            // Flipping back — refocus terminal after animation
-            setTimeout(() => {
-              const term = document.querySelector<HTMLElement>(
-                '.detail-pane-terminal .xterm-helper-textarea'
-              )
-              term?.focus()
-            }, 420)
+        setFlipCount((c) => {
+          const next = c + 1
+          if (next % 2 === 0) {
+            // Flipping back to terminal — refocus after animation
+            refocusTerminal()
           }
-          return !prev
+          return next
         })
         return
       }
@@ -63,7 +66,7 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
     }
     document.addEventListener('keydown', handler, true)
     return () => document.removeEventListener('keydown', handler, true)
-  }, [onClose, reviewOpen, closeReview])
+  }, [onClose, reviewOpen, closeReview, refocusTerminal])
 
   const handleRevive = async () => {
     setReviving(true)
@@ -104,7 +107,7 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
           </div>
         ) : (
           <div className="flip-container">
-            <div className={`flip-inner${reviewOpen ? ' flipped' : ''}`}>
+            <div className="flip-inner" style={{ transform: `rotateY(${flipCount * 180}deg)` }}>
               <div className="flip-front">
                 <Terminal sessionId={sessionId} />
               </div>

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -851,10 +851,6 @@ body,
   transition: transform 400ms ease-in-out;
 }
 
-.flip-inner.flipped {
-  transform: rotateY(180deg);
-}
-
 .flip-front,
 .flip-back {
   position: absolute;


### PR DESCRIPTION
Closes #17.

## Summary
- The `Ctrl-R` flip between the Claude Code terminal and the Review overlay toggled a boolean `.flipped` class, so the return transition interpolated from `rotateY(180deg)` back to `rotateY(0deg)` — reversing direction and feeling unsmooth.
- Switched to a monotonic `flipCount` counter driving `transform: rotateY(${flipCount * 180}deg)` inline, so the rotation always continues forward (0°, 180°, 360°, 540°, …) regardless of direction of toggle.
- Dropped the now-unused `.flip-inner.flipped` CSS rule and factored out a `refocusTerminal` helper for the post-animation terminal focus.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `npx electron-vite build` clean
- [ ] Manual: open a session, `Ctrl-R` → flip to Review, `Ctrl-R` again → flip continues in the same direction back to terminal (no reversal)
- [ ] Manual: `Esc` while on Review also uses the forward rotation