### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to automate dependency updates for npm (the project's package manager) and github-actions
- Mirrors the layout used in [pmatos/jsse](https://github.com/pmatos/jsse/blob/main/.github/dependabot.yml), swapping `cargo` for `npm` since cc-pewpew is a Node/Electron project
- Daily schedule; caps at 10 open npm PRs and 5 open github-actions PRs

## Test plan
- [ ] Confirm Dependabot picks up the config on merge (check the repo's Insights → Dependency graph → Dependabot tab)