### PR TITLE
Remote SSH [1/8]: Host registry + add/test host UI

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
+import type { Host } from '../shared/types'
 
 export interface CanvasState {
   zoom: number
@@ -25,6 +26,7 @@ export interface AppConfig {
   windowState?: WindowState
   sidebarWidth: number
   uiScale: number
+  hosts: Host[]
 }
 
 export const CONFIG_DIR = join(
@@ -41,6 +43,7 @@ const DEFAULT_CONFIG: AppConfig = {
   clusterPositions: {},
   sidebarWidth: 250,
   uiScale: 1.2,
+  hosts: [],
 }
 
 export function resolvePath(p: string): string {

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -33,6 +33,18 @@ function runSsh(argv: string[], timeoutMs: number): Promise<SshRunResult> {
         // timeouts and is kept as a belt-and-braces check.
         const errno = (error ?? null) as (NodeJS.ErrnoException & { killed?: boolean }) | null
         const timedOut = Boolean(errno && (errno.killed === true || errno.code === 'ETIMEDOUT'))
+        // ENOENT means the ssh binary itself couldn't be launched. Surface it
+        // as an exit-127 "command not found" so classifySshExit routes it to
+        // `dep-missing` instead of the generic `unknown`.
+        if (!timedOut && errno && errno.code === 'ENOENT') {
+          resolve({
+            stdout: '',
+            stderr: 'ssh: command not found',
+            code: 127,
+            timedOut: false,
+          })
+          return
+        }
         const code = error
           ? typeof (error as { code?: unknown }).code === 'number'
             ? (error as { code: number }).code

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -1,0 +1,78 @@
+// INVARIANT: callers of exec() pass each path argument as its own argv entry;
+// shellQuote handles POSIX single-quoting for the remote shell. Never concatenate
+// user input into argv strings before passing them in. Both exec() and
+// testConnection() insert `--` before the alias so a host alias beginning with
+// `-` (e.g. from a hand-edited config.json) cannot be interpreted by ssh as an
+// option, even if upstream validation was bypassed.
+
+import { execFile } from 'child_process'
+import { shellQuote } from './shell-quote'
+import { classifySshExit } from './ssh-exit-parser'
+import type { TestConnectionResult } from '../shared/types'
+
+interface ExecResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+interface SshRunResult extends ExecResult {
+  timedOut: boolean
+}
+
+function runSsh(argv: string[], timeoutMs: number): Promise<SshRunResult> {
+  return new Promise((resolve) => {
+    const child = execFile(
+      'ssh',
+      argv,
+      { timeout: timeoutMs, maxBuffer: 64 * 1024 },
+      (error, stdout, stderr) => {
+        const timedOut = Boolean(error && (error as NodeJS.ErrnoException).code === 'ETIMEDOUT')
+        const code = error
+          ? typeof (error as { code?: unknown }).code === 'number'
+            ? (error as { code: number }).code
+            : (child.exitCode ?? 1)
+          : 0
+        resolve({
+          stdout: stdout.toString(),
+          stderr: stderr.toString(),
+          code,
+          timedOut,
+        })
+      }
+    )
+  })
+}
+
+export async function testConnection(
+  alias: string,
+  opts: { timeoutMs?: number } = {}
+): Promise<TestConnectionResult> {
+  const timeoutMs = opts.timeoutMs ?? 15000
+  const argv = ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=5', '--', alias, 'true']
+  const { stderr, code, timedOut } = await runSsh(argv, timeoutMs)
+
+  if (timedOut) {
+    return { ok: false, reason: 'network', message: 'ssh timed out' }
+  }
+  if (code === 0) {
+    return { ok: true }
+  }
+  const { reason, message } = classifySshExit({ exitCode: code, stderr })
+  return { ok: false, reason, message }
+}
+
+// Forward-looking helper for slices 2+. Slice 1 has no caller, but the
+// shell-quote invariant is tested and shipped so later code inherits a correct
+// foundation.
+export async function exec(
+  alias: string,
+  argv: string[],
+  opts: { timeoutMs?: number } = {}
+): Promise<ExecResult> {
+  const timeoutMs = opts.timeoutMs ?? 30000
+  const quoted = argv.map(shellQuote)
+  const sshArgv = ['-o', 'BatchMode=yes', '--', alias, ...quoted]
+  const { stdout, stderr, code } = await runSsh(sshArgv, timeoutMs)
+  return { stdout, stderr, code }
+}

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -27,7 +27,12 @@ function runSsh(argv: string[], timeoutMs: number): Promise<SshRunResult> {
       argv,
       { timeout: timeoutMs, maxBuffer: 64 * 1024 },
       (error, stdout, stderr) => {
-        const timedOut = Boolean(error && (error as NodeJS.ErrnoException).code === 'ETIMEDOUT')
+        // execFile's `timeout` option kills the child with `killSignal` (default
+        // SIGTERM) when it fires. Node sets `error.killed === true` in that
+        // case; `error.code === 'ETIMEDOUT'` only appears for OS-level socket
+        // timeouts and is kept as a belt-and-braces check.
+        const errno = (error ?? null) as (NodeJS.ErrnoException & { killed?: boolean }) | null
+        const timedOut = Boolean(errno && (errno.killed === true || errno.code === 'ETIMEDOUT'))
         const code = error
           ? typeof (error as { code?: unknown }).code === 'number'
             ? (error as { code: number }).code

--- a/src/main/host-registry.test.ts
+++ b/src/main/host-registry.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Host } from '../shared/types'
+
+let fakeHosts: Host[] = []
+const saveConfigSpy = vi.fn()
+
+vi.mock('./config', () => ({
+  CONFIG_DIR: '/tmp/cc-pewpew-test',
+  getConfig: () => ({
+    scanDirs: [],
+    pinnedPaths: [],
+    followSymlinks: true,
+    canvas: { zoom: 1, panX: 0, panY: 0 },
+    clusterPositions: {},
+    sidebarWidth: 250,
+    uiScale: 1,
+    hosts: fakeHosts,
+  }),
+  saveConfig: (cfg: { hosts: Host[] }) => {
+    fakeHosts = cfg.hosts
+    saveConfigSpy(cfg)
+  },
+}))
+
+const fsState = { sessionsJson: null as string | null }
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    existsSync: (p: string) =>
+      p.endsWith('sessions.json') ? fsState.sessionsJson !== null : actual.existsSync(p),
+    readFileSync: (p: string, enc?: BufferEncoding) =>
+      p.endsWith('sessions.json') && fsState.sessionsJson !== null
+        ? fsState.sessionsJson
+        : actual.readFileSync(p, enc),
+  }
+})
+
+import {
+  validateAlias,
+  validateLabel,
+  addHost,
+  updateHost,
+  deleteHost,
+  listHosts,
+  getHost,
+} from './host-registry'
+
+beforeEach(() => {
+  fakeHosts = []
+  fsState.sessionsJson = null
+  saveConfigSpy.mockClear()
+})
+
+describe('validateAlias', () => {
+  it('rejects empty and whitespace-only', () => {
+    expect(() => validateAlias('')).toThrow(/required/)
+    expect(() => validateAlias('   ')).toThrow(/required/)
+  })
+
+  it('rejects leading dash (argv-injection guard)', () => {
+    expect(() => validateAlias('-oProxyCommand=foo')).toThrow(/start with/)
+  })
+
+  it('trims leading/trailing whitespace', () => {
+    expect(validateAlias('  dev  ')).toBe('dev')
+  })
+
+  it('rejects embedded whitespace', () => {
+    expect(() => validateAlias('dev box')).toThrow(/whitespace/)
+    expect(() => validateAlias('dev\tbox')).toThrow(/whitespace/)
+    expect(() => validateAlias('dev\nbox')).toThrow(/whitespace/)
+  })
+
+  it('rejects NUL byte', () => {
+    expect(() => validateAlias('dev\x00box')).toThrow(/NUL/)
+  })
+
+  it('rejects aliases longer than 64 chars', () => {
+    expect(() => validateAlias('a'.repeat(65))).toThrow(/64/)
+    expect(validateAlias('a'.repeat(64))).toBe('a'.repeat(64))
+  })
+})
+
+describe('validateLabel', () => {
+  it('rejects empty', () => {
+    expect(() => validateLabel('')).toThrow(/required/)
+    expect(() => validateLabel('   ')).toThrow(/required/)
+  })
+
+  it('trims and accepts', () => {
+    expect(validateLabel('  ok  ')).toBe('ok')
+  })
+
+  it('rejects labels longer than 40 chars', () => {
+    expect(() => validateLabel('a'.repeat(41))).toThrow(/40/)
+    expect(validateLabel('a'.repeat(40))).toBe('a'.repeat(40))
+  })
+})
+
+describe('addHost', () => {
+  it('persists a new host with a UUID', () => {
+    const host = addHost({ alias: 'dev', label: 'Dev box' })
+    expect(host.alias).toBe('dev')
+    expect(host.label).toBe('Dev box')
+    expect(host.hostId).toMatch(/^[0-9a-f-]{36}$/i)
+    expect(listHosts()).toHaveLength(1)
+    expect(saveConfigSpy).toHaveBeenCalledOnce()
+  })
+
+  it('rejects duplicate alias (exact match)', () => {
+    addHost({ alias: 'dev', label: 'One' })
+    expect(() => addHost({ alias: 'dev', label: 'Two' })).toThrow(/already exists/)
+  })
+
+  it('accepts case-differing alias (matches OpenSSH case sensitivity)', () => {
+    addHost({ alias: 'dev', label: 'lower' })
+    expect(() => addHost({ alias: 'Dev', label: 'Upper' })).not.toThrow()
+    expect(listHosts()).toHaveLength(2)
+  })
+})
+
+describe('updateHost', () => {
+  it('renames label and alias', () => {
+    const h = addHost({ alias: 'dev', label: 'Old' })
+    const updated = updateHost(h.hostId, { alias: 'prod', label: 'New' })
+    expect(updated.alias).toBe('prod')
+    expect(updated.label).toBe('New')
+    expect(getHost(h.hostId)?.alias).toBe('prod')
+  })
+
+  it('allows keeping the same alias (no-op rename)', () => {
+    const h = addHost({ alias: 'dev', label: 'x' })
+    expect(() => updateHost(h.hostId, { alias: 'dev', label: 'y' })).not.toThrow()
+  })
+
+  it('rejects renaming onto another host alias', () => {
+    addHost({ alias: 'a', label: 'A' })
+    const b = addHost({ alias: 'b', label: 'B' })
+    expect(() => updateHost(b.hostId, { alias: 'a', label: 'B' })).toThrow(/already exists/)
+  })
+
+  it('throws on unknown hostId', () => {
+    expect(() => updateHost('nope', { alias: 'x', label: 'y' })).toThrow(/Unknown/)
+  })
+})
+
+describe('deleteHost', () => {
+  it('deletes when sessions.json is missing', () => {
+    const h = addHost({ alias: 'dev', label: 'x' })
+    deleteHost(h.hostId)
+    expect(listHosts()).toHaveLength(0)
+  })
+
+  it('deletes when sessions.json is present but has no hostId binding', () => {
+    fsState.sessionsJson = JSON.stringify([{ session: { id: 's1', status: 'idle' } }])
+    const h = addHost({ alias: 'dev', label: 'x' })
+    expect(() => deleteHost(h.hostId)).not.toThrow()
+  })
+
+  it('refuses delete when a persisted session is bound to the host', () => {
+    const h = addHost({ alias: 'dev', label: 'x' })
+    fsState.sessionsJson = JSON.stringify([{ session: { id: 's1', hostId: h.hostId } }])
+    expect(() => deleteHost(h.hostId)).toThrow(/bound/)
+  })
+
+  it('accepts either sessions-array or wrapped-array shape', () => {
+    const h = addHost({ alias: 'dev', label: 'x' })
+    fsState.sessionsJson = JSON.stringify({ sessions: [{ hostId: h.hostId }] })
+    expect(() => deleteHost(h.hostId)).toThrow(/bound/)
+  })
+
+  it('tolerates malformed sessions.json (treats as no bindings)', () => {
+    fsState.sessionsJson = 'not json'
+    const h = addHost({ alias: 'dev', label: 'x' })
+    expect(() => deleteHost(h.hostId)).not.toThrow()
+  })
+
+  it('throws on unknown hostId', () => {
+    expect(() => deleteHost('nope')).toThrow(/Unknown/)
+  })
+})

--- a/src/main/host-registry.ts
+++ b/src/main/host-registry.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from 'crypto'
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { CONFIG_DIR, getConfig, saveConfig } from './config'
+import type { Host, HostId } from '../shared/types'
+
+const SESSIONS_PATH = join(CONFIG_DIR, 'sessions.json')
+
+const MAX_ALIAS_LEN = 64
+const MAX_LABEL_LEN = 40
+
+export function validateAlias(raw: string): string {
+  const alias = raw.trim()
+  if (!alias) throw new Error('Alias is required')
+  if (alias.length > MAX_ALIAS_LEN)
+    throw new Error(`Alias must be ${MAX_ALIAS_LEN} characters or fewer`)
+  if (alias.startsWith('-')) throw new Error('Alias must not start with "-"')
+  if (/\s/.test(alias)) throw new Error('Alias must not contain whitespace')
+  if (alias.includes('\x00')) throw new Error('Alias must not contain NUL')
+  return alias
+}
+
+export function validateLabel(raw: string): string {
+  const label = raw.trim()
+  if (!label) throw new Error('Label is required')
+  if (label.length > MAX_LABEL_LEN)
+    throw new Error(`Label must be ${MAX_LABEL_LEN} characters or fewer`)
+  return label
+}
+
+export function listHosts(): Host[] {
+  return getConfig().hosts
+}
+
+export function getHost(hostId: HostId): Host | undefined {
+  return listHosts().find((h) => h.hostId === hostId)
+}
+
+export function addHost(input: { alias: string; label: string }): Host {
+  const alias = validateAlias(input.alias)
+  const label = validateLabel(input.label)
+  const config = getConfig()
+  if (config.hosts.some((h) => h.alias === alias)) {
+    throw new Error('Alias already exists')
+  }
+  const host: Host = { hostId: randomUUID(), alias, label }
+  config.hosts = [...config.hosts, host]
+  saveConfig(config)
+  return host
+}
+
+export function updateHost(hostId: HostId, input: { alias: string; label: string }): Host {
+  const alias = validateAlias(input.alias)
+  const label = validateLabel(input.label)
+  const config = getConfig()
+  const idx = config.hosts.findIndex((h) => h.hostId === hostId)
+  if (idx === -1) throw new Error('Unknown host')
+  if (config.hosts.some((h) => h.hostId !== hostId && h.alias === alias)) {
+    throw new Error('Alias already exists')
+  }
+  const updated: Host = { hostId, alias, label }
+  config.hosts = [...config.hosts.slice(0, idx), updated, ...config.hosts.slice(idx + 1)]
+  saveConfig(config)
+  return updated
+}
+
+// Forward-compat: checks persisted sessions for any binding to this host. In
+// slice 1, Session has no hostId field yet, so this guard is inert. Slice 2 will
+// activate it automatically once sessions start carrying a hostId.
+function hasSessionsBoundTo(hostId: HostId): boolean {
+  if (!existsSync(SESSIONS_PATH)) return false
+  try {
+    const raw = readFileSync(SESSIONS_PATH, 'utf-8')
+    const data = JSON.parse(raw) as unknown
+    const entries: unknown[] = Array.isArray(data)
+      ? data
+      : data &&
+          typeof data === 'object' &&
+          Array.isArray((data as { sessions?: unknown[] }).sessions)
+        ? (data as { sessions: unknown[] }).sessions
+        : []
+    return entries.some((entry) => {
+      const session =
+        entry && typeof entry === 'object' && 'session' in entry
+          ? (entry as { session: unknown }).session
+          : entry
+      return (
+        session !== null &&
+        typeof session === 'object' &&
+        'hostId' in session &&
+        (session as { hostId: unknown }).hostId === hostId
+      )
+    })
+  } catch {
+    return false
+  }
+}
+
+export function deleteHost(hostId: HostId): void {
+  if (hasSessionsBoundTo(hostId)) {
+    throw new Error('Cannot delete host: sessions are still bound to it')
+  }
+  const config = getConfig()
+  const next = config.hosts.filter((h) => h.hostId !== hostId)
+  if (next.length === config.hosts.length) throw new Error('Unknown host')
+  config.hosts = next
+  saveConfig(config)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,8 @@ import {
   relocateProject,
 } from './session-manager'
 import { parseDiff, synthesizeUntrackedFile } from './diff-parser'
+import { listHosts, addHost, updateHost, deleteHost, getHost } from './host-registry'
+import { testConnection } from './host-connection'
 import type { DiffMode } from '../shared/types'
 
 // Use native Wayland rendering when available (avoids Xwayland scaling artifacts)
@@ -374,6 +376,18 @@ app.whenReady().then(async () => {
     } else {
       swimWindow.loadFile(join(__dirname, '../../dist/swim-lanes.html'), { search: query })
     }
+  })
+
+  ipcMain.handle('hosts:list', () => listHosts())
+  ipcMain.handle('hosts:add', (_event, alias: string, label: string) => addHost({ alias, label }))
+  ipcMain.handle('hosts:update', (_event, hostId: string, alias: string, label: string) =>
+    updateHost(hostId, { alias, label })
+  )
+  ipcMain.handle('hosts:delete', (_event, hostId: string) => deleteHost(hostId))
+  ipcMain.handle('hosts:test-connection', async (_event, hostId: string) => {
+    const host = getHost(hostId)
+    if (!host) throw new Error('Unknown host')
+    return testConnection(host.alias)
   })
 
   const mainWindow = createWindow()

--- a/src/main/shell-quote.test.ts
+++ b/src/main/shell-quote.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { shellQuote } from './shell-quote'
+
+describe('shellQuote', () => {
+  it('wraps empty string as empty single-quote pair', () => {
+    expect(shellQuote('')).toBe("''")
+  })
+
+  it('wraps plain text without modification inside quotes', () => {
+    expect(shellQuote('hello')).toBe("'hello'")
+  })
+
+  it('wraps path with whitespace', () => {
+    expect(shellQuote('a path with spaces')).toBe("'a path with spaces'")
+  })
+
+  it("escapes a single quote as '\"'\"'", () => {
+    expect(shellQuote("it's")).toBe("'it'\"'\"'s'")
+  })
+
+  it('escapes multiple single quotes', () => {
+    expect(shellQuote("a'b'c")).toBe("'a'\"'\"'b'\"'\"'c'")
+  })
+
+  it('escapes a string containing only a single quote', () => {
+    expect(shellQuote("'")).toBe("''\"'\"''")
+  })
+
+  it('leaves backslashes literal inside single quotes', () => {
+    expect(shellQuote('path\\to\\file')).toBe("'path\\to\\file'")
+  })
+
+  it('leaves double quotes literal inside single quotes', () => {
+    expect(shellQuote('say "hi"')).toBe('\'say "hi"\'')
+  })
+
+  it('preserves trailing newline inside single quotes', () => {
+    expect(shellQuote('foo\n')).toBe("'foo\n'")
+  })
+
+  it('preserves NUL byte (caller responsibility to reject upstream)', () => {
+    expect(shellQuote('a\x00b')).toBe("'a\x00b'")
+  })
+})

--- a/src/main/shell-quote.ts
+++ b/src/main/shell-quote.ts
@@ -1,0 +1,5 @@
+// POSIX shell single-quote wrapper: wraps arg in '...' and escapes any embedded
+// single quotes as '"'"' (close, escaped-quote in double-quotes, reopen).
+export function shellQuote(arg: string): string {
+  return "'" + arg.replace(/'/g, "'\"'\"'") + "'"
+}

--- a/src/main/ssh-exit-parser.test.ts
+++ b/src/main/ssh-exit-parser.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import { classifySshExit } from './ssh-exit-parser'
+import type { SshExitReason } from '../shared/types'
+
+interface Case {
+  name: string
+  exitCode: number | null
+  stderr: string
+  expected: SshExitReason
+}
+
+const cases: Case[] = [
+  // auth failures
+  {
+    name: 'publickey denied',
+    exitCode: 255,
+    stderr: 'Permission denied (publickey).',
+    expected: 'auth-failed',
+  },
+  {
+    name: 'publickey+password denied',
+    exitCode: 255,
+    stderr: 'Permission denied (publickey,password).',
+    expected: 'auth-failed',
+  },
+  {
+    name: 'too many auth failures',
+    exitCode: 255,
+    stderr: 'Received disconnect from 10.0.0.1: Too many authentication failures',
+    expected: 'auth-failed',
+  },
+  {
+    name: 'host key verification failed',
+    exitCode: 255,
+    stderr: 'Host key verification failed.',
+    expected: 'auth-failed',
+  },
+  {
+    name: 'no matching host key type',
+    exitCode: 255,
+    stderr:
+      'Unable to negotiate with 10.0.0.1 port 22: no matching host key type found. Their offer: ssh-rsa',
+    expected: 'auth-failed',
+  },
+  {
+    name: 'no supported auth methods',
+    exitCode: 255,
+    stderr: 'No supported authentication methods available',
+    expected: 'auth-failed',
+  },
+  // network failures
+  {
+    name: 'connection refused',
+    exitCode: 255,
+    stderr: 'ssh: connect to host example.com port 22: Connection refused',
+    expected: 'network',
+  },
+  {
+    name: 'connection timed out',
+    exitCode: 255,
+    stderr: 'ssh: connect to host example.com port 22: Connection timed out',
+    expected: 'network',
+  },
+  {
+    name: 'operation timed out',
+    exitCode: 255,
+    stderr: 'ssh: connect to host x port 22: Operation timed out',
+    expected: 'network',
+  },
+  {
+    name: 'could not resolve hostname',
+    exitCode: 255,
+    stderr: 'ssh: Could not resolve hostname foo: Name or service not known',
+    expected: 'network',
+  },
+  {
+    name: 'no route to host',
+    exitCode: 255,
+    stderr: 'ssh: connect to host 10.0.0.1 port 22: No route to host',
+    expected: 'network',
+  },
+  {
+    name: 'network unreachable',
+    exitCode: 255,
+    stderr: 'ssh: connect to host x port 22: Network is unreachable',
+    expected: 'network',
+  },
+  {
+    name: 'temporary DNS failure',
+    exitCode: 255,
+    stderr: 'ssh: Could not resolve hostname foo: Temporary failure in name resolution',
+    expected: 'network',
+  },
+  // dep-missing
+  {
+    name: 'socat missing (exit 127)',
+    exitCode: 127,
+    stderr: 'bash: socat: command not found',
+    expected: 'dep-missing',
+  },
+  // unknown / defensive
+  { name: 'empty stderr + 255', exitCode: 255, stderr: '', expected: 'unknown' },
+  { name: 'null exit code (signal kill)', exitCode: null, stderr: '', expected: 'unknown' },
+  // robustness: multi-line stderr with debug prefix still classifies by the auth line
+  {
+    name: 'multi-line with debug1 prefix',
+    exitCode: 255,
+    stderr:
+      'debug1: Next authentication method: publickey\ndebug1: Offering public key\nPermission denied (publickey).',
+    expected: 'auth-failed',
+  },
+]
+
+describe('classifySshExit', () => {
+  it.each(cases)('$name → $expected', ({ exitCode, stderr, expected }) => {
+    expect(classifySshExit({ exitCode, stderr }).reason).toBe(expected)
+  })
+
+  it('returns ok message on exit 0', () => {
+    expect(classifySshExit({ exitCode: 0, stderr: '' })).toEqual({
+      reason: 'unknown',
+      message: 'ok',
+    })
+  })
+
+  it('uses the first non-empty stderr line as the message', () => {
+    const result = classifySshExit({
+      exitCode: 255,
+      stderr: '\n  \ndebug1: foo\nPermission denied (publickey).',
+    })
+    expect(result.message).toBe('debug1: foo')
+  })
+
+  it('falls back to "ssh failed: code N" when stderr is empty', () => {
+    expect(classifySshExit({ exitCode: 255, stderr: '' }).message).toBe('ssh failed: code 255')
+    expect(classifySshExit({ exitCode: null, stderr: '' }).message).toBe('ssh failed: code null')
+  })
+})

--- a/src/main/ssh-exit-parser.ts
+++ b/src/main/ssh-exit-parser.ts
@@ -1,0 +1,65 @@
+import type { SshExitReason } from '../shared/types'
+
+export interface SshExitInput {
+  exitCode: number | null
+  stderr: string
+}
+
+export interface SshExitClassification {
+  reason: SshExitReason
+  message: string
+}
+
+const AUTH_MARKERS = [
+  'permission denied',
+  'too many authentication failures',
+  'host key verification failed',
+  'no matching host key',
+  'no supported authentication methods',
+]
+
+const NETWORK_MARKERS = [
+  'connection refused',
+  'connection timed out',
+  'operation timed out',
+  'no route to host',
+  'network is unreachable',
+  'could not resolve hostname',
+  'name or service not known',
+  'temporary failure in name resolution',
+  'connection closed by',
+]
+
+function firstNonEmptyLine(stderr: string): string {
+  for (const raw of stderr.split('\n')) {
+    const line = raw.trim()
+    if (line) return line
+  }
+  return ''
+}
+
+export function classifySshExit({ exitCode, stderr }: SshExitInput): SshExitClassification {
+  const haystack = stderr.toLowerCase()
+  const message = firstNonEmptyLine(stderr) || `ssh failed: code ${exitCode ?? 'null'}`
+
+  if (exitCode === 0) {
+    return { reason: 'unknown', message: 'ok' }
+  }
+
+  if (AUTH_MARKERS.some((m) => haystack.includes(m))) {
+    return { reason: 'auth-failed', message }
+  }
+
+  if (NETWORK_MARKERS.some((m) => haystack.includes(m))) {
+    return { reason: 'network', message }
+  }
+
+  if (
+    exitCode === 127 &&
+    (haystack.includes('command not found') || haystack.includes('not found'))
+  ) {
+    return { reason: 'dep-missing', message }
+  }
+
+  return { reason: 'unknown', message }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -74,4 +74,10 @@ contextBridge.exposeInMainWorld('api', {
   getReviewBranches: (sessionId: string) => ipcRenderer.invoke('review:list-branches', sessionId),
   getReviewDefaultBranch: (sessionId: string) =>
     ipcRenderer.invoke('review:get-default-branch', sessionId),
+  listHosts: () => ipcRenderer.invoke('hosts:list'),
+  addHost: (alias: string, label: string) => ipcRenderer.invoke('hosts:add', alias, label),
+  updateHost: (hostId: string, alias: string, label: string) =>
+    ipcRenderer.invoke('hosts:update', hostId, alias, label),
+  deleteHost: (hostId: string) => ipcRenderer.invoke('hosts:delete', hostId),
+  testHostConnection: (hostId: string) => ipcRenderer.invoke('hosts:test-connection', hostId),
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -58,6 +58,10 @@ export default function App() {
         e.preventDefault()
         scanProjects()
       } else if (e.key === 'Escape') {
+        // Modals handle Escape themselves; don't run global shortcuts when
+        // one is open (avoids side-effect clearing of active session /
+        // selection when dismissing a modal via Escape).
+        if (useHostsStore.getState().dialogOpen) return
         if (activeSessionId) {
           setActiveSessionId(null)
         } else if (useSessionsStore.getState().selectedIds.size > 0) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,12 +3,21 @@ import ProjectTree from './components/ProjectTree'
 import SessionCanvas from './components/SessionCanvas'
 import DetailPane from './components/DetailPane'
 import StatusBar from './components/StatusBar'
+import ManageHostsDialog from './components/ManageHostsDialog'
 import { useProjectsStore } from './stores/projects'
 import { useSessionsStore } from './stores/sessions'
+import { useHostsStore } from './stores/hosts'
 
 export default function App() {
   const { scanProjects, filterReady, toggleFilterReady } = useProjectsStore()
   const { init: initSessions } = useSessionsStore()
+  const hosts = useHostsStore((s) => s.hosts)
+  const openHostsDialog = useHostsStore((s) => s.openDialog)
+  const fetchHosts = useHostsStore((s) => s.fetchHosts)
+
+  useEffect(() => {
+    void fetchHosts()
+  }, [fetchHosts])
 
   useEffect(() => {
     return initSessions()
@@ -166,6 +175,13 @@ export default function App() {
               + New project
             </button>
           )}
+          <button
+            className="new-project-btn hosts-btn"
+            onClick={openHostsDialog}
+            title="Manage SSH hosts"
+          >
+            🌐 Hosts ({hosts.length})
+          </button>
         </div>
       </aside>
 
@@ -188,6 +204,7 @@ export default function App() {
         )}
       </main>
 
+      <ManageHostsDialog />
       <StatusBar />
     </div>
   )

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -145,17 +145,22 @@ export default function ManageHostsDialog() {
 
   useEffect(() => {
     if (!dialogOpen) return
+    // Capture-phase listener so this runs before App's bubble-phase global
+    // Escape handler (which would otherwise clear activeSessionId / selection
+    // as a side effect of dismissing the modal).
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
-      // When an Add/Edit form is open, let the form's own Escape handler cancel
-      // the form. React synthetic events don't stop native propagation, so
-      // without this guard both handlers fire and the whole dialog closes.
       const state = useHostsStore.getState()
+      // When an Add/Edit form is open, let the form's own Escape handler cancel
+      // the form. Still stop propagation so App's global handler doesn't also
+      // fire. React synthetic events don't stop native propagation, so the
+      // form's handler alone isn't enough.
+      e.stopPropagation()
       if (state.addingNew || state.editingHostId !== null) return
       closeDialog()
     }
-    document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
+    document.addEventListener('keydown', handler, true)
+    return () => document.removeEventListener('keydown', handler, true)
   }, [dialogOpen, closeDialog])
 
   if (!dialogOpen) return null

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -146,7 +146,13 @@ export default function ManageHostsDialog() {
   useEffect(() => {
     if (!dialogOpen) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeDialog()
+      if (e.key !== 'Escape') return
+      // When an Add/Edit form is open, let the form's own Escape handler cancel
+      // the form. React synthetic events don't stop native propagation, so
+      // without this guard both handlers fire and the whole dialog closes.
+      const state = useHostsStore.getState()
+      if (state.addingNew || state.editingHostId !== null) return
+      closeDialog()
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -146,13 +146,19 @@ export default function ManageHostsDialog() {
   useEffect(() => {
     if (!dialogOpen) return
     // App.tsx's global Escape handler respects useHostsStore.dialogOpen and
-    // returns early while this modal is open, so we don't need capture-phase
-    // interception — a plain bubble-phase listener is enough and avoids
-    // swallowing the form inputs' own onKeyDown Escape handling.
+    // returns early while this modal is open, so a plain bubble-phase listener
+    // is enough.
+    //
+    // We guard on the DOM event target rather than store state: the form's
+    // React onKeyDown handler fires before this native listener and calls
+    // cancelEdit synchronously, so by the time we'd check store state it
+    // would already be cleared. `target.closest('.hosts-form')` is stable
+    // across that race — if Escape originated inside a form, the form owns
+    // it; otherwise we close the dialog.
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
-      const state = useHostsStore.getState()
-      if (state.addingNew || state.editingHostId !== null) return
+      const target = e.target as HTMLElement | null
+      if (target && target.closest('.hosts-form')) return
       closeDialog()
     }
     document.addEventListener('keydown', handler)

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -145,22 +145,18 @@ export default function ManageHostsDialog() {
 
   useEffect(() => {
     if (!dialogOpen) return
-    // Capture-phase listener so this runs before App's bubble-phase global
-    // Escape handler (which would otherwise clear activeSessionId / selection
-    // as a side effect of dismissing the modal).
+    // App.tsx's global Escape handler respects useHostsStore.dialogOpen and
+    // returns early while this modal is open, so we don't need capture-phase
+    // interception — a plain bubble-phase listener is enough and avoids
+    // swallowing the form inputs' own onKeyDown Escape handling.
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
       const state = useHostsStore.getState()
-      // When an Add/Edit form is open, let the form's own Escape handler cancel
-      // the form. Still stop propagation so App's global handler doesn't also
-      // fire. React synthetic events don't stop native propagation, so the
-      // form's handler alone isn't enough.
-      e.stopPropagation()
       if (state.addingNew || state.editingHostId !== null) return
       closeDialog()
     }
-    document.addEventListener('keydown', handler, true)
-    return () => document.removeEventListener('keydown', handler, true)
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
   }, [dialogOpen, closeDialog])
 
   if (!dialogOpen) return null

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react'
+import { useHostsStore } from '../stores/hosts'
+import type { Host, HostId, TestConnectionResult } from '../../shared/types'
+
+function reasonToLabel(reason: TestConnectionResult['reason']): string {
+  switch (reason) {
+    case 'auth-failed':
+      return 'Auth failed'
+    case 'network':
+      return 'Network error'
+    case 'dep-missing':
+      return 'Missing dep'
+    default:
+      return 'Failed'
+  }
+}
+
+interface HostFormProps {
+  initialAlias?: string
+  initialLabel?: string
+  submitLabel: string
+  onSubmit: (alias: string, label: string) => Promise<void>
+  onCancel: () => void
+}
+
+function HostForm({
+  initialAlias = '',
+  initialLabel = '',
+  submitLabel,
+  onSubmit,
+  onCancel,
+}: HostFormProps) {
+  const [alias, setAlias] = useState(initialAlias)
+  const [label, setLabel] = useState(initialLabel)
+  const [submitting, setSubmitting] = useState(false)
+
+  const canSubmit = alias.trim().length > 0 && label.trim().length > 0 && !submitting
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return
+    setSubmitting(true)
+    try {
+      await onSubmit(alias.trim(), label.trim())
+    } catch {
+      // Error shown via store.error; keep the form open so the user can retry.
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      void handleSubmit()
+    } else if (e.key === 'Escape') {
+      onCancel()
+    }
+  }
+
+  return (
+    <div className="hosts-form">
+      <input
+        autoFocus
+        type="text"
+        className="create-input"
+        placeholder="ssh alias (e.g. devbox)"
+        value={alias}
+        onChange={(e) => setAlias(e.target.value)}
+        onKeyDown={handleKey}
+      />
+      <input
+        type="text"
+        className="create-input"
+        placeholder="Short label (e.g. Dev box)"
+        value={label}
+        onChange={(e) => setLabel(e.target.value)}
+        onKeyDown={handleKey}
+      />
+      <div className="create-actions">
+        <button className="create-btn" disabled={!canSubmit} onClick={handleSubmit}>
+          {submitLabel}
+        </button>
+        <button className="create-btn cancel" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+interface HostRowProps {
+  host: Host
+  testing: boolean
+  result?: TestConnectionResult
+  onTest: () => void
+  onEdit: () => void
+  onDelete: () => void
+}
+
+function HostRow({ host, testing, result, onTest, onEdit, onDelete }: HostRowProps) {
+  return (
+    <div className="hosts-row">
+      <div className="hosts-row-main">
+        <div className="host-label">{host.label}</div>
+        <div className="host-alias">{host.alias}</div>
+        {result && (
+          <div className={`host-test-result ${result.ok ? 'ok' : 'err'}`}>
+            {result.ok
+              ? 'OK'
+              : `${reasonToLabel(result.reason)}${result.message ? `: ${result.message}` : ''}`}
+          </div>
+        )}
+      </div>
+      <div className="host-actions">
+        <button className="create-btn" onClick={onTest} disabled={testing}>
+          {testing ? 'Testing…' : 'Test'}
+        </button>
+        <button className="create-btn" onClick={onEdit}>
+          Edit
+        </button>
+        <button className="create-btn cancel" onClick={onDelete}>
+          Delete
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default function ManageHostsDialog() {
+  const dialogOpen = useHostsStore((s) => s.dialogOpen)
+  const hosts = useHostsStore((s) => s.hosts)
+  const editingHostId = useHostsStore((s) => s.editingHostId)
+  const addingNew = useHostsStore((s) => s.addingNew)
+  const testing = useHostsStore((s) => s.testing)
+  const testResults = useHostsStore((s) => s.testResults)
+  const error = useHostsStore((s) => s.error)
+  const closeDialog = useHostsStore((s) => s.closeDialog)
+  const startEdit = useHostsStore((s) => s.startEdit)
+  const startAdd = useHostsStore((s) => s.startAdd)
+  const cancelEdit = useHostsStore((s) => s.cancelEdit)
+  const addHost = useHostsStore((s) => s.addHost)
+  const updateHost = useHostsStore((s) => s.updateHost)
+  const deleteHost = useHostsStore((s) => s.deleteHost)
+  const testHost = useHostsStore((s) => s.testHost)
+
+  useEffect(() => {
+    if (!dialogOpen) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeDialog()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [dialogOpen, closeDialog])
+
+  if (!dialogOpen) return null
+
+  const editingHost = editingHostId ? hosts.find((h) => h.hostId === editingHostId) : undefined
+
+  const handleDelete = async (hostId: HostId) => {
+    await deleteHost(hostId)
+  }
+
+  return (
+    <div
+      className="hosts-dialog-overlay"
+      onClick={closeDialog}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <div className="hosts-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="hosts-dialog-header">
+          <div className="session-name-label">Manage hosts</div>
+          <button className="create-btn cancel" onClick={closeDialog}>
+            Close
+          </button>
+        </div>
+
+        {error && <div className="hosts-error">{error}</div>}
+
+        <div className="hosts-list">
+          {hosts.length === 0 && !addingNew && (
+            <div className="hosts-empty">No hosts yet. Add one to get started.</div>
+          )}
+          {hosts.map((host) =>
+            editingHostId === host.hostId ? (
+              <HostForm
+                key={host.hostId}
+                initialAlias={host.alias}
+                initialLabel={host.label}
+                submitLabel="Save"
+                onSubmit={(alias, label) => updateHost(host.hostId, alias, label)}
+                onCancel={cancelEdit}
+              />
+            ) : (
+              <HostRow
+                key={host.hostId}
+                host={host}
+                testing={Boolean(testing[host.hostId])}
+                result={testResults[host.hostId]}
+                onTest={() => void testHost(host.hostId)}
+                onEdit={() => startEdit(host.hostId)}
+                onDelete={() => void handleDelete(host.hostId)}
+              />
+            )
+          )}
+        </div>
+
+        {addingNew ? (
+          <HostForm
+            submitLabel="Add"
+            onSubmit={(alias, label) => addHost(alias, label)}
+            onCancel={cancelEdit}
+          />
+        ) : (
+          !editingHost && (
+            <div className="hosts-dialog-footer">
+              <button className="create-btn" onClick={startAdd}>
+                + Add host
+              </button>
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -1,6 +1,13 @@
 /// <reference types="vite/client" />
 
-import type { DiffFile, DiffMode, Project, Session } from '../shared/types'
+import type {
+  DiffFile,
+  DiffMode,
+  Host,
+  Project,
+  Session,
+  TestConnectionResult,
+} from '../shared/types'
 
 declare global {
   interface Window {
@@ -43,6 +50,11 @@ declare global {
       getReviewDiff: (sessionId: string, mode: DiffMode, baseBranch?: string) => Promise<DiffFile[]>
       getReviewBranches: (sessionId: string) => Promise<string[]>
       getReviewDefaultBranch: (sessionId: string) => Promise<string>
+      listHosts: () => Promise<Host[]>
+      addHost: (alias: string, label: string) => Promise<Host>
+      updateHost: (hostId: string, alias: string, label: string) => Promise<Host>
+      deleteHost: (hostId: string) => Promise<void>
+      testHostConnection: (hostId: string) => Promise<TestConnectionResult>
     }
   }
 }

--- a/src/renderer/stores/hosts.ts
+++ b/src/renderer/stores/hosts.ts
@@ -1,0 +1,123 @@
+import { create } from 'zustand'
+import type { Host, HostId, TestConnectionResult } from '../../shared/types'
+
+interface HostsState {
+  hosts: Host[]
+  loading: boolean
+  dialogOpen: boolean
+  editingHostId: HostId | null
+  addingNew: boolean
+  testing: Record<HostId, boolean>
+  testResults: Record<HostId, TestConnectionResult | undefined>
+  error: string | null
+  fetchHosts: () => Promise<void>
+  openDialog: () => void
+  closeDialog: () => void
+  startEdit: (hostId: HostId) => void
+  startAdd: () => void
+  cancelEdit: () => void
+  addHost: (alias: string, label: string) => Promise<void>
+  updateHost: (hostId: HostId, alias: string, label: string) => Promise<void>
+  deleteHost: (hostId: HostId) => Promise<void>
+  testHost: (hostId: HostId) => Promise<void>
+  clearError: () => void
+}
+
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message
+  if (typeof e === 'string') return e
+  return String(e)
+}
+
+export const useHostsStore = create<HostsState>((set, get) => ({
+  hosts: [],
+  loading: false,
+  dialogOpen: false,
+  editingHostId: null,
+  addingNew: false,
+  testing: {},
+  testResults: {},
+  error: null,
+
+  fetchHosts: async () => {
+    set({ loading: true })
+    try {
+      const hosts = await window.api.listHosts()
+      set({ hosts, loading: false })
+    } catch (e) {
+      set({ error: errorMessage(e), loading: false })
+    }
+  },
+
+  openDialog: () => {
+    set({ dialogOpen: true, error: null })
+    void get().fetchHosts()
+  },
+
+  closeDialog: () => {
+    set({
+      dialogOpen: false,
+      editingHostId: null,
+      addingNew: false,
+      error: null,
+      testResults: {},
+    })
+  },
+
+  startEdit: (hostId) => set({ editingHostId: hostId, addingNew: false, error: null }),
+  startAdd: () => set({ addingNew: true, editingHostId: null, error: null }),
+  cancelEdit: () => set({ addingNew: false, editingHostId: null, error: null }),
+
+  addHost: async (alias, label) => {
+    try {
+      await window.api.addHost(alias, label)
+      set({ addingNew: false, error: null })
+      await get().fetchHosts()
+    } catch (e) {
+      set({ error: errorMessage(e) })
+      throw e
+    }
+  },
+
+  updateHost: async (hostId, alias, label) => {
+    try {
+      await window.api.updateHost(hostId, alias, label)
+      set({ editingHostId: null, error: null })
+      await get().fetchHosts()
+    } catch (e) {
+      set({ error: errorMessage(e) })
+      throw e
+    }
+  },
+
+  deleteHost: async (hostId) => {
+    try {
+      await window.api.deleteHost(hostId)
+      set({ error: null })
+      await get().fetchHosts()
+    } catch (e) {
+      set({ error: errorMessage(e) })
+    }
+  },
+
+  testHost: async (hostId) => {
+    set((s) => ({ testing: { ...s.testing, [hostId]: true } }))
+    try {
+      const result = await window.api.testHostConnection(hostId)
+      set((s) => ({
+        testing: { ...s.testing, [hostId]: false },
+        testResults: { ...s.testResults, [hostId]: result },
+      }))
+    } catch (e) {
+      set((s) => ({
+        testing: { ...s.testing, [hostId]: false },
+        testResults: {
+          ...s.testResults,
+          [hostId]: { ok: false, reason: 'unknown', message: errorMessage(e) },
+        },
+      }))
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}))

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -802,6 +802,111 @@ body,
   gap: 8px;
 }
 
+.hosts-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.hosts-dialog {
+  background: var(--bg-sidebar);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  min-width: 480px;
+  max-height: 70vh;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hosts-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.hosts-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.hosts-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.hosts-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.host-label {
+  font-weight: 600;
+}
+
+.host-alias {
+  color: var(--text-secondary);
+  font-family: monospace;
+  font-size: 12px;
+}
+
+/* TODO: replace hardcoded #e07070 with a theme error-colour token once defined. */
+.host-test-result {
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.host-test-result.ok {
+  color: var(--accent-green);
+}
+
+.host-test-result.err {
+  color: #e07070;
+}
+
+.host-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.hosts-error {
+  color: #e07070;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+.hosts-empty {
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 8px;
+  text-align: center;
+}
+
+.hosts-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+}
+
+.hosts-dialog-footer {
+  padding-top: 4px;
+}
+
 .edge-indicators {
   position: absolute;
   inset: 0;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -76,3 +76,21 @@ export interface HunkAnnotation {
   selectedText?: string
   selectedLines?: { start: number; end: number }
 }
+
+// --- Host registry / SSH types ---
+
+export type HostId = string
+
+export interface Host {
+  hostId: HostId
+  alias: string
+  label: string
+}
+
+export type SshExitReason = 'auth-failed' | 'network' | 'dep-missing' | 'unknown'
+
+export interface TestConnectionResult {
+  ok: boolean
+  reason?: SshExitReason
+  message?: string
+}


### PR DESCRIPTION
## Summary

- Adds a foundational host-management layer for the remote-SSH feature (slice 1/8 of PRD #8): a `HostRegistry` persisted in `config.json`, a `HostConnection` module that wraps `ssh` with a shell-quoting helper and a pure exit-signature parser, and a sidebar-accessible Manage Hosts dialog with Add / Edit / Delete / Test Connection.
- Local behaviour is unchanged — no session or project code is wired to `hostId` yet. Slice 2 will add `Session.hostId` and activate the delete-guard that is already in place.
- No credentials of any kind are stored; the registry schema is strictly `{ hostId, alias, label }`.

Closes #9.

## What's in it

- `src/shared/types.ts` — `HostId`, `Host`, `SshExitReason`, `TestConnectionResult`.
- `src/main/config.ts` — `hosts: Host[]` field in `AppConfig` (backfills to `[]` for existing configs via the existing spread-merge).
- `src/main/shell-quote.ts` + `shell-quote.test.ts` — POSIX single-quote wrapper (`single-quote wrap + '"'"'` escape) with 10 cases covering quoting edge cases.
- `src/main/ssh-exit-parser.ts` + `ssh-exit-parser.test.ts` — pure `classifySshExit({ exitCode, stderr })` returning `auth-failed | network | dep-missing | unknown`. Table-driven tests via `it.each` (20 cases) covering realistic OpenSSH stderr strings, multi-line `debug1:` prefixes, and the `exitCode: null` defensive path.
- `src/main/host-connection.ts` — `testConnection(alias)` using `execFile('ssh', ['-o','BatchMode=yes','-o','ConnectTimeout=5','--', alias, 'true'])` with a 15 s Node-side kill timeout, plus a forward-looking `exec(alias, argv)` for slice 2+ that applies `shellQuote` to every argv entry. Both paths pass `--` before the alias so a hand-edited config alias beginning with `-` cannot be interpreted by ssh as an option.
- `src/main/host-registry.ts` + `host-registry.test.ts` — CRUD with `validateAlias`/`validateLabel` (trim, non-empty, length bounds, reject leading `-`, whitespace, NUL), case-sensitive alias uniqueness (matches OpenSSH semantics), and a `deleteHost` guard that reads `sessions.json` and refuses when any persisted session has a matching `hostId`. 22 tests.
- `src/main/index.ts` — five new `ipcMain.handle` channels (`hosts:list`, `hosts:add`, `hosts:update`, `hosts:delete`, `hosts:test-connection`).
- `src/preload/index.ts` + `src/renderer/env.d.ts` — matching preload API surface (`listHosts`, `addHost`, `updateHost`, `deleteHost`, `testHostConnection`).
- `src/renderer/stores/hosts.ts` — Zustand store for the dialog: fetch, open/close, add/edit/delete, per-host test state + result, error surface.
- `src/renderer/components/ManageHostsDialog.tsx` — modal modeled on `BroadcastDialog`: row list with Test/Edit/Delete per host, add/edit form with Enter-to-submit / Escape-to-cancel, inline test-result pill (OK / "Network error: …" / "Auth failed: …"), inline error banner.
- `src/renderer/App.tsx` — adds a "🌐 Hosts (N)" button in the sidebar footer (as a sibling of the existing create-project ternary so it always renders), mounts `<ManageHostsDialog />` before `<StatusBar />`, and fetches hosts on startup.
- `src/renderer/styles/global.css` — `.hosts-dialog*`, `.hosts-row`, `.host-label`, `.host-alias`, `.host-test-result.ok/err`, `.hosts-error`, `.hosts-form` styles (copy-renamed from the existing `.broadcast-dialog` rules; no new design tokens).

## Security notes

- `validateAlias` rejects leading `-`, embedded whitespace, and NUL; `testConnection` and `exec` additionally pass `--` before the alias to defend against bypass (e.g. hand-edited `config.json`).
- The `HostConnection` module comments the invariant that callers of `exec` pass path arguments as individual argv entries (each wrapped by `shellQuote`), never as pre-assembled shell strings.
- `BatchMode=yes` prevents any interactive ssh prompts during "Test connection"; a 15 s Node-side kill timeout backs up ssh's own `ConnectTimeout=5` against DNS hangs.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 103/103 pass (new: 10 shell-quote + 20 ssh-exit-parser + 22 host-registry)
- [x] `npx eslint .` — no new violations (one pre-existing `no-empty` at `src/main/index.ts:201` is unrelated)
- [x] `npx electron-vite build` — production build succeeds
- [x] CDP smoke: Hosts button opens dialog; add with alias `persist-check` / label `Persist` creates a row and the sidebar counter updates to `🌐 Hosts (1)`; Test connection on a non-existent alias runs real `ssh` and surfaces `"Network error: ssh: Could not resolve hostname …"`; attempting to re-add the same alias surfaces `"Alias already exists"` and the row count stays at 1; Delete removes the row and the counter returns to `🌐 Hosts (0)`; `~/.config/cc-pewpew/config.json` shows the expected `{ hostId, alias, label }` record during the test and empty array after cleanup.

## Out of scope (per PRD #8)

- Sessions / projects do not yet carry `hostId` — slice 2.
- No persistent ControlMaster / reverse-socket tunnel — slice 3–4.
- No remote project registration, bootstrap script install, thumbnails, or review pane — later slices.