### PR TITLE
fix: auto-recover sessions after reboot with claude --continue

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -23,7 +23,7 @@ function flushBuffers(): void {
   }
 }
 
-function checkTmux(): boolean {
+export function isTmuxAvailable(): boolean {
   try {
     execFileSync('which', ['tmux'])
     return true
@@ -52,7 +52,7 @@ export function createPty(
     throw new Error(`Working directory does not exist: ${cwd}`)
   }
 
-  if (!checkTmux()) {
+  if (!isTmuxAvailable()) {
     dialog.showErrorBox(
       'tmux not found',
       'tmux is required for embedded terminals.\nPlease install tmux and restart cc-pewpew.'

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -43,7 +43,11 @@ export function stopPtyManager(): void {
   }
 }
 
-export function createPty(sessionId: string, cwd: string): void {
+export function createPty(
+  sessionId: string,
+  cwd: string,
+  options?: { continueSession?: boolean }
+): void {
   if (!existsSync(cwd)) {
     throw new Error(`Working directory does not exist: ${cwd}`)
   }
@@ -58,6 +62,11 @@ export function createPty(sessionId: string, cwd: string): void {
 
   const tmuxSession = `cc-pewpew-${sessionId}`
 
+  const claudeArgs = ['claude', '--dangerously-skip-permissions']
+  if (options?.continueSession) {
+    claudeArgs.push('--continue')
+  }
+
   // Create a detached tmux session that directly runs claude
   // Using tmux's shell command avoids issues with interactive shell init (omz, etc.)
   execFileSync('tmux', [
@@ -71,8 +80,7 @@ export function createPty(sessionId: string, cwd: string): void {
     '120',
     '-y',
     '30',
-    'claude',
-    '--dangerously-skip-permissions',
+    ...claudeArgs,
   ])
 
   // Attach to it via node-pty

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -14,6 +14,7 @@ import {
   destroyPty,
   hasPty,
   hasTmuxSession,
+  isTmuxAvailable,
   discoverTmuxSessions,
   reattachPty,
 } from './pty-manager'
@@ -407,7 +408,11 @@ export function restoreSessions(): void {
   try {
     const data: Session[] = JSON.parse(readFileSync(SESSIONS_PATH, 'utf-8'))
     const liveTmuxIds = new Set(discoverTmuxSessions())
+    // One-time tmux precheck so we don't fire a blocking error modal per
+    // session on startup when tmux is missing from PATH.
+    const tmuxAvailable = isTmuxAvailable()
     let recoveredCount = 0
+    let skippedForNoTmux = 0
 
     for (const session of data) {
       if (
@@ -424,6 +429,9 @@ export function restoreSessions(): void {
           session.status = resumedStatus
         } else if (!existsSync(session.worktreePath)) {
           session.status = 'dead'
+        } else if (!tmuxAvailable) {
+          session.status = 'dead'
+          skippedForNoTmux++
         } else {
           // tmux server lost the session (e.g., PC reboot) but the worktree
           // survives — auto-recreate and resume the claude conversation.
@@ -439,6 +447,12 @@ export function restoreSessions(): void {
       }
       session.lastActivity = Date.now()
       sessions.set(session.id, { session })
+    }
+
+    if (skippedForNoTmux > 0) {
+      console.warn(
+        `tmux not found — ${skippedForNoTmux} session(s) left as 'dead'. Install tmux to enable auto-recovery.`
+      )
     }
 
     // Reattach ptys after all sessions are in the map. Sessions we just

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -415,8 +415,13 @@ export function restoreSessions(): void {
         session.status === 'idle' ||
         session.status === 'needs_input'
       ) {
+        // Preserve `needs_input` so the tray/status-bar attention signals
+        // (tray.ts, StatusBar.tsx) survive a restart — claude --continue
+        // resumes mid-wait, so the user still needs to answer.
+        const resumedStatus: SessionStatus =
+          session.status === 'needs_input' ? 'needs_input' : 'idle'
         if (liveTmuxIds.has(session.id)) {
-          session.status = 'idle'
+          session.status = resumedStatus
         } else if (!existsSync(session.worktreePath)) {
           session.status = 'dead'
         } else {
@@ -424,7 +429,7 @@ export function restoreSessions(): void {
           // survives — auto-recreate and resume the claude conversation.
           try {
             createPty(session.id, session.worktreePath, { continueSession: true })
-            session.status = 'idle'
+            session.status = resumedStatus
             recoveredCount++
           } catch (err) {
             console.error(`Failed to auto-recover session ${session.id}:`, err)
@@ -440,7 +445,10 @@ export function restoreSessions(): void {
     // recovered already have a node-pty spawned by createPty, so the
     // liveTmuxIds filter here correctly skips them.
     for (const session of data) {
-      if (session.status === 'idle' && liveTmuxIds.has(session.id)) {
+      if (
+        (session.status === 'idle' || session.status === 'needs_input') &&
+        liveTmuxIds.has(session.id)
+      ) {
         try {
           reattachPty(session.id)
         } catch (err) {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -181,7 +181,7 @@ export function reviveSession(id: string): void {
   if (hasTmuxSession(id)) {
     reattachPty(id)
   } else {
-    createPty(id, session.worktreePath)
+    createPty(id, session.worktreePath, { continueSession: true })
   }
   updateSession(id, 'idle')
 }
@@ -407,20 +407,38 @@ export function restoreSessions(): void {
   try {
     const data: Session[] = JSON.parse(readFileSync(SESSIONS_PATH, 'utf-8'))
     const liveTmuxIds = new Set(discoverTmuxSessions())
+    let recoveredCount = 0
 
     for (const session of data) {
-      if (session.status === 'running' || session.status === 'idle') {
+      if (
+        session.status === 'running' ||
+        session.status === 'idle' ||
+        session.status === 'needs_input'
+      ) {
         if (liveTmuxIds.has(session.id)) {
           session.status = 'idle'
-        } else {
+        } else if (!existsSync(session.worktreePath)) {
           session.status = 'dead'
+        } else {
+          // tmux server lost the session (e.g., PC reboot) but the worktree
+          // survives — auto-recreate and resume the claude conversation.
+          try {
+            createPty(session.id, session.worktreePath, { continueSession: true })
+            session.status = 'idle'
+            recoveredCount++
+          } catch (err) {
+            console.error(`Failed to auto-recover session ${session.id}:`, err)
+            session.status = 'dead'
+          }
         }
       }
       session.lastActivity = Date.now()
       sessions.set(session.id, { session })
     }
 
-    // Reattach ptys after all sessions are in the map
+    // Reattach ptys after all sessions are in the map. Sessions we just
+    // recovered already have a node-pty spawned by createPty, so the
+    // liveTmuxIds filter here correctly skips them.
     for (const session of data) {
       if (session.status === 'idle' && liveTmuxIds.has(session.id)) {
         try {
@@ -429,6 +447,10 @@ export function restoreSessions(): void {
           console.error(`Failed to reattach pty for ${session.id}:`, err)
         }
       }
+    }
+
+    if (recoveredCount > 0) {
+      console.log(`Auto-recovered ${recoveredCount} session(s) after reboot`)
     }
 
     onSessionsChanged()


### PR DESCRIPTION
## Summary
- When the app starts and a saved session's tmux is gone (PC reboot killed the server), auto-recreate the tmux session and launch `claude --continue` so the conversation resumes — no per-card "Revive" click.
- `restoreSessions` now also covers `'needs_input'` sessions (previously those became zombie cards after reboot — loaded with no pty attached).
- Manual `reviveSession` also passes `--continue` when it needs to recreate tmux, so kill+revive is consistent with reboot recovery.

If the worktree has been deleted from disk, the session still falls back to `'dead'`. If `createPty` throws during recovery, that one session is marked `'dead'` and the rest continue (one bad entry can't abort the whole restore).

Closes #20

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint src/main/pty-manager.ts src/main/session-manager.ts` passes
- [ ] `npx vitest run` passes
- [ ] Manual: create 2 sessions, give each a prompt, quit app, `tmux kill-server`, relaunch — both cards should come back as `idle` with their Claude conversation resumed.
- [ ] Manual: repeat the above but delete one session's worktree directory first — that one stays `'dead'`, the other recovers.
- [ ] Manual: kill a session via the UI then click "Revive" — claude should resume rather than starting fresh.