### PR TITLE
Remote SSH [2/8]: Register a remote project with host pill in sidebar

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import type { Host } from '../shared/types'
+import type { Host, RemoteProject } from '../shared/types'
 
 export interface CanvasState {
   zoom: number
@@ -28,6 +28,7 @@ export interface AppConfig {
   uiScale: number
   hosts: Host[]
   gitignoreWarned: string[]
+  remoteProjects: RemoteProject[]
 }
 
 export const CONFIG_DIR = join(
@@ -46,6 +47,7 @@ const DEFAULT_CONFIG: AppConfig = {
   uiScale: 1.2,
   hosts: [],
   gitignoreWarned: [],
+  remoteProjects: [],
 }
 
 export function shouldWarnGitignore(projectPath: string): boolean {

--- a/src/main/host-connection.test.ts
+++ b/src/main/host-connection.test.ts
@@ -44,6 +44,12 @@ describe('validateRemoteRepo', () => {
     expect(result).toEqual({ ok: true, fingerprint: 'abc123' })
   })
 
+  it('returns ok without fingerprint for an empty repo (no commits yet)', async () => {
+    nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
+    const result = await validateRemoteRepo('dev', '/srv/empty-repo')
+    expect(result).toEqual({ ok: true, fingerprint: undefined })
+  })
+
   it('returns not-a-git-repo when remote exits non-zero with no ssh markers', async () => {
     nextResult = {
       stdout: '',

--- a/src/main/host-connection.test.ts
+++ b/src/main/host-connection.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { EventEmitter } from 'events'
+
+interface FakeResult {
+  stdout: string
+  stderr: string
+  error: (NodeJS.ErrnoException & { code?: number | string; killed?: boolean }) | null
+  exitCode: number | null
+}
+
+let nextResult: FakeResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
+const execFileCalls: { file: string; args: string[] }[] = []
+
+vi.mock('child_process', () => ({
+  execFile: (
+    file: string,
+    args: string[],
+    _opts: unknown,
+    cb: (
+      error: (NodeJS.ErrnoException & { code?: number | string; killed?: boolean }) | null,
+      stdout: string,
+      stderr: string
+    ) => void
+  ) => {
+    execFileCalls.push({ file, args })
+    const child = new EventEmitter() as EventEmitter & { exitCode: number | null }
+    child.exitCode = nextResult.exitCode
+    setImmediate(() => cb(nextResult.error, nextResult.stdout, nextResult.stderr))
+    return child
+  },
+}))
+
+import { validateRemoteRepo } from './host-connection'
+
+beforeEach(() => {
+  nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
+  execFileCalls.length = 0
+})
+
+describe('validateRemoteRepo', () => {
+  it('returns ok with fingerprint on code=0 stdout', async () => {
+    nextResult = { stdout: 'abc123\n', stderr: '', error: null, exitCode: 0 }
+    const result = await validateRemoteRepo('dev', '/srv/repo')
+    expect(result).toEqual({ ok: true, fingerprint: 'abc123' })
+  })
+
+  it('returns not-a-git-repo when remote exits non-zero with no ssh markers', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: '',
+      error: { name: 'Error', message: 'x', code: 1 } as unknown as NodeJS.ErrnoException,
+      exitCode: 1,
+    }
+    const result = await validateRemoteRepo('dev', '/not/a/repo')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('not-a-git-repo')
+    expect(result.message).toMatch(/git repository/)
+  })
+
+  it('returns auth-failed on Permission denied stderr', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: 'Permission denied (publickey).',
+      error: { name: 'Error', message: 'x', code: 255 } as unknown as NodeJS.ErrnoException,
+      exitCode: 255,
+    }
+    const result = await validateRemoteRepo('dev', '/srv/repo')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('auth-failed')
+  })
+
+  it('returns network on Connection refused stderr', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: 'ssh: connect to host dev port 22: Connection refused',
+      error: { name: 'Error', message: 'x', code: 255 } as unknown as NodeJS.ErrnoException,
+      exitCode: 255,
+    }
+    const result = await validateRemoteRepo('dev', '/srv/repo')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('network')
+  })
+
+  it('returns dep-missing when ssh binary is absent', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: '',
+      error: Object.assign(new Error('ENOENT'), {
+        code: 'ENOENT',
+      }) as NodeJS.ErrnoException,
+      exitCode: null,
+    }
+    const result = await validateRemoteRepo('dev', '/srv/repo')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('dep-missing')
+  })
+
+  it('passes the remote path as a positional argv element (not interpolated)', async () => {
+    nextResult = { stdout: 'abc\n', stderr: '', error: null, exitCode: 0 }
+    await validateRemoteRepo('dev', "/pa'th")
+    const call = execFileCalls[0]
+    expect(call.file).toBe('ssh')
+    // Last argv entry passed to ssh is the shell-quoted remote path; previous
+    // entries cover "sh", "-c", SCRIPT, "_" — each shell-quoted independently.
+    expect(call.args[call.args.length - 1]).toBe("'/pa'\"'\"'th'")
+    expect(call.args).toContain('--')
+    expect(call.args).toContain('dev')
+  })
+})

--- a/src/main/host-connection.test.ts
+++ b/src/main/host-connection.test.ts
@@ -101,6 +101,31 @@ describe('validateRemoteRepo', () => {
     expect(result.reason).toBe('dep-missing')
   })
 
+  it('returns dep-missing when remote git is absent (shell emits 127)', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: 'sh: 1: git: not found',
+      error: { name: 'Error', message: 'x', code: 127 } as unknown as NodeJS.ErrnoException,
+      exitCode: 127,
+    }
+    const result = await validateRemoteRepo('dev', '/srv/repo')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('dep-missing')
+  })
+
+  it('returns network when ssh is killed by the timeout', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: '',
+      error: Object.assign(new Error('timeout'), {
+        killed: true,
+      }) as NodeJS.ErrnoException & { killed?: boolean },
+      exitCode: null,
+    }
+    const result = await validateRemoteRepo('dev', '/srv/repo')
+    expect(result).toEqual({ ok: false, reason: 'network', message: 'ssh timed out' })
+  })
+
   it('passes the remote path as a positional argv element (not interpolated)', async () => {
     nextResult = { stdout: 'abc\n', stderr: '', error: null, exitCode: 0 }
     await validateRemoteRepo('dev', "/pa'th")

--- a/src/main/host-connection.test.ts
+++ b/src/main/host-connection.test.ts
@@ -63,6 +63,20 @@ describe('validateRemoteRepo', () => {
     expect(result.message).toMatch(/git repository/)
   })
 
+  it('rejects subdirectories with the probe stderr message', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: 'Remote path must be the repository root (got subdirectory: sub/)',
+      error: { name: 'Error', message: 'x', code: 2 } as unknown as NodeJS.ErrnoException,
+      exitCode: 2,
+    }
+    const result = await validateRemoteRepo('dev', '/srv/repo/sub')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('not-a-git-repo')
+    expect(result.message).toMatch(/repository root/)
+    expect(result.message).toMatch(/sub\//)
+  })
+
   it('returns auth-failed on Permission denied stderr', async () => {
     nextResult = {
       stdout: '',

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -90,18 +90,23 @@ export async function exec(
   return runSsh(sshArgv, timeoutMs)
 }
 
-// Validates that a remote path is a git repository and extracts its root-commit
-// fingerprint in a single ssh round-trip. The remote path is passed as a
-// positional argument ($1) to `sh -c`, never interpolated into the script text
-// — this keeps the INVARIANT at the top of this file intact even for paths
-// containing shell metacharacters.
+// Validates that a remote path is a git repository ROOT (not a subdirectory)
+// and extracts its root-commit fingerprint in a single ssh round-trip. The
+// remote path is passed as a positional argument ($1) to `sh -c`, never
+// interpolated into the script text — this keeps the INVARIANT at the top of
+// this file intact even for paths containing shell metacharacters.
 //
-// The probe uses `git rev-parse --git-dir` rather than a bare `test -d .git`
-// so that worktrees and submodules (where `.git` is a file pointing at a
-// separate gitdir) are accepted as valid. The fingerprint step is best-effort:
-// an empty repo with no HEAD returns an empty fingerprint, not a rejection.
+// The probe uses `git rev-parse --show-prefix`: it exits 0 with an empty
+// stdout at a repo root, 0 with a non-empty "subdir/" at a subdirectory, and
+// ~128 outside any repo. We reject non-empty prefixes with exit 2 and a
+// diagnostic on stderr so the caller can surface "must be the repository
+// root" instead of a generic error. Worktrees and submodules (where `.git` is
+// a file) are accepted because `rev-parse` resolves them natively.
 //
-// The probe deliberately does NOT swallow stderr on rev-parse and propagates
+// The fingerprint step is best-effort: an empty repo with no HEAD returns
+// an empty fingerprint, not a rejection.
+//
+// The probe deliberately does NOT swallow `rev-parse`'s stderr and propagates
 // the original exit code, so that a missing `git` binary on the remote
 // (shell-level exit 127 + "command not found") remains distinguishable from a
 // path that simply isn't a git repo — `classifySshExit` routes the former to
@@ -112,13 +117,14 @@ export async function validateRemoteRepo(
   opts: { timeoutMs?: number } = {}
 ): Promise<ValidateRemoteRepoResult> {
   const script =
-    'git -C "$1" rev-parse --git-dir >/dev/null\n' +
+    'prefix=$(git -C "$1" rev-parse --show-prefix)\n' +
     'rc=$?\n' +
-    'if [ $rc -eq 0 ]; then\n' +
-    '  git -C "$1" rev-list --max-parents=0 HEAD 2>/dev/null || true\n' +
-    'else\n' +
-    '  exit $rc\n' +
-    'fi'
+    'if [ $rc -ne 0 ]; then exit $rc; fi\n' +
+    'if [ -n "$prefix" ]; then\n' +
+    '  printf "Remote path must be the repository root (got subdirectory: %s)\\n" "$prefix" >&2\n' +
+    '  exit 2\n' +
+    'fi\n' +
+    'git -C "$1" rev-list --max-parents=0 HEAD 2>/dev/null || true'
   const { stdout, stderr, code, timedOut } = await exec(alias, ['sh', '-c', script, '_', path], {
     timeoutMs: opts.timeoutMs ?? 15000,
   })
@@ -136,6 +142,6 @@ export async function validateRemoteRepo(
   return {
     ok: false,
     reason: 'not-a-git-repo',
-    message: 'Path is not a git repository',
+    message: stderr.trim() ? message : 'Path is not a git repository',
   }
 }

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -8,7 +8,7 @@
 import { execFile } from 'child_process'
 import { shellQuote } from './shell-quote'
 import { classifySshExit } from './ssh-exit-parser'
-import type { TestConnectionResult } from '../shared/types'
+import type { TestConnectionResult, ValidateRemoteRepoResult } from '../shared/types'
 
 interface ExecResult {
   stdout: string
@@ -92,4 +92,33 @@ export async function exec(
   const sshArgv = ['-o', 'BatchMode=yes', '--', alias, ...quoted]
   const { stdout, stderr, code } = await runSsh(sshArgv, timeoutMs)
   return { stdout, stderr, code }
+}
+
+// Validates that a remote path is a git repository and extracts its root-commit
+// fingerprint in a single ssh round-trip. The remote path is passed as a
+// positional argument ($1) to `sh -c`, never interpolated into the script text
+// — this keeps the INVARIANT at the top of this file intact even for paths
+// containing shell metacharacters.
+export async function validateRemoteRepo(
+  alias: string,
+  path: string,
+  opts: { timeoutMs?: number } = {}
+): Promise<ValidateRemoteRepoResult> {
+  const script = 'test -d "$1/.git" && git -C "$1" rev-list --max-parents=0 HEAD'
+  const { stdout, stderr, code } = await exec(alias, ['sh', '-c', script, '_', path], {
+    timeoutMs: opts.timeoutMs ?? 15000,
+  })
+  if (code === 0) {
+    const fingerprint = stdout.trim().split('\n')[0] || undefined
+    return { ok: true, fingerprint }
+  }
+  const { reason, message } = classifySshExit({ exitCode: code, stderr })
+  if (reason === 'auth-failed' || reason === 'network' || reason === 'dep-missing') {
+    return { ok: false, reason, message }
+  }
+  return {
+    ok: false,
+    reason: 'not-a-git-repo',
+    message: 'Path is not a git repository (.git not found on remote)',
+  }
 }

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -14,13 +14,10 @@ interface ExecResult {
   stdout: string
   stderr: string
   code: number
-}
-
-interface SshRunResult extends ExecResult {
   timedOut: boolean
 }
 
-function runSsh(argv: string[], timeoutMs: number): Promise<SshRunResult> {
+function runSsh(argv: string[], timeoutMs: number): Promise<ExecResult> {
   return new Promise((resolve) => {
     const child = execFile(
       'ssh',
@@ -90,8 +87,7 @@ export async function exec(
   const timeoutMs = opts.timeoutMs ?? 30000
   const quoted = argv.map(shellQuote)
   const sshArgv = ['-o', 'BatchMode=yes', '--', alias, ...quoted]
-  const { stdout, stderr, code } = await runSsh(sshArgv, timeoutMs)
-  return { stdout, stderr, code }
+  return runSsh(sshArgv, timeoutMs)
 }
 
 // Validates that a remote path is a git repository and extracts its root-commit
@@ -104,17 +100,31 @@ export async function exec(
 // so that worktrees and submodules (where `.git` is a file pointing at a
 // separate gitdir) are accepted as valid. The fingerprint step is best-effort:
 // an empty repo with no HEAD returns an empty fingerprint, not a rejection.
+//
+// The probe deliberately does NOT swallow stderr on rev-parse and propagates
+// the original exit code, so that a missing `git` binary on the remote
+// (shell-level exit 127 + "command not found") remains distinguishable from a
+// path that simply isn't a git repo — `classifySshExit` routes the former to
+// `dep-missing`.
 export async function validateRemoteRepo(
   alias: string,
   path: string,
   opts: { timeoutMs?: number } = {}
 ): Promise<ValidateRemoteRepoResult> {
   const script =
-    'git -C "$1" rev-parse --git-dir >/dev/null 2>&1 || exit 1; ' +
-    'git -C "$1" rev-list --max-parents=0 HEAD 2>/dev/null || true'
-  const { stdout, stderr, code } = await exec(alias, ['sh', '-c', script, '_', path], {
+    'git -C "$1" rev-parse --git-dir >/dev/null\n' +
+    'rc=$?\n' +
+    'if [ $rc -eq 0 ]; then\n' +
+    '  git -C "$1" rev-list --max-parents=0 HEAD 2>/dev/null || true\n' +
+    'else\n' +
+    '  exit $rc\n' +
+    'fi'
+  const { stdout, stderr, code, timedOut } = await exec(alias, ['sh', '-c', script, '_', path], {
     timeoutMs: opts.timeoutMs ?? 15000,
   })
+  if (timedOut) {
+    return { ok: false, reason: 'network', message: 'ssh timed out' }
+  }
   if (code === 0) {
     const fingerprint = stdout.trim().split('\n')[0] || undefined
     return { ok: true, fingerprint }

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -99,12 +99,19 @@ export async function exec(
 // positional argument ($1) to `sh -c`, never interpolated into the script text
 // — this keeps the INVARIANT at the top of this file intact even for paths
 // containing shell metacharacters.
+//
+// The probe uses `git rev-parse --git-dir` rather than a bare `test -d .git`
+// so that worktrees and submodules (where `.git` is a file pointing at a
+// separate gitdir) are accepted as valid. The fingerprint step is best-effort:
+// an empty repo with no HEAD returns an empty fingerprint, not a rejection.
 export async function validateRemoteRepo(
   alias: string,
   path: string,
   opts: { timeoutMs?: number } = {}
 ): Promise<ValidateRemoteRepoResult> {
-  const script = 'test -d "$1/.git" && git -C "$1" rev-list --max-parents=0 HEAD'
+  const script =
+    'git -C "$1" rev-parse --git-dir >/dev/null 2>&1 || exit 1; ' +
+    'git -C "$1" rev-list --max-parents=0 HEAD 2>/dev/null || true'
   const { stdout, stderr, code } = await exec(alias, ['sh', '-c', script, '_', path], {
     timeoutMs: opts.timeoutMs ?? 15000,
   })
@@ -119,6 +126,6 @@ export async function validateRemoteRepo(
   return {
     ok: false,
     reason: 'not-a-git-repo',
-    message: 'Path is not a git repository (.git not found on remote)',
+    message: 'Path is not a git repository',
   }
 }

--- a/src/main/host-registry.test.ts
+++ b/src/main/host-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import type { Host } from '../shared/types'
+import type { Host, RemoteProject } from '../shared/types'
 
 let fakeHosts: Host[] = []
 const saveConfigSpy = vi.fn()
@@ -15,11 +15,16 @@ vi.mock('./config', () => ({
     sidebarWidth: 250,
     uiScale: 1,
     hosts: fakeHosts,
+    remoteProjects: [] as RemoteProject[],
   }),
   saveConfig: (cfg: { hosts: Host[] }) => {
     fakeHosts = cfg.hosts
     saveConfigSpy(cfg)
   },
+}))
+
+vi.mock('./remote-project-registry', () => ({
+  hasRemoteProjectsBoundTo: vi.fn(() => false),
 }))
 
 const fsState = { sessionsJson: null as string | null }
@@ -46,11 +51,13 @@ import {
   listHosts,
   getHost,
 } from './host-registry'
+import { hasRemoteProjectsBoundTo } from './remote-project-registry'
 
 beforeEach(() => {
   fakeHosts = []
   fsState.sessionsJson = null
   saveConfigSpy.mockClear()
+  vi.mocked(hasRemoteProjectsBoundTo).mockReturnValue(false)
 })
 
 describe('validateAlias', () => {
@@ -179,5 +186,11 @@ describe('deleteHost', () => {
 
   it('throws on unknown hostId', () => {
     expect(() => deleteHost('nope')).toThrow(/Unknown/)
+  })
+
+  it('refuses delete when a remote project is bound to the host', () => {
+    const h = addHost({ alias: 'dev', label: 'x' })
+    vi.mocked(hasRemoteProjectsBoundTo).mockReturnValue(true)
+    expect(() => deleteHost(h.hostId)).toThrow(/remote projects/)
   })
 })

--- a/src/main/host-registry.ts
+++ b/src/main/host-registry.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto'
 import { readFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { CONFIG_DIR, getConfig, saveConfig } from './config'
+import { hasRemoteProjectsBoundTo } from './remote-project-registry'
 import type { Host, HostId } from '../shared/types'
 
 const SESSIONS_PATH = join(CONFIG_DIR, 'sessions.json')
@@ -97,6 +98,9 @@ function hasSessionsBoundTo(hostId: HostId): boolean {
 }
 
 export function deleteHost(hostId: HostId): void {
+  if (hasRemoteProjectsBoundTo(hostId)) {
+    throw new Error('Cannot delete host: remote projects are registered on it')
+  }
   if (hasSessionsBoundTo(hostId)) {
     throw new Error('Cannot delete host: sessions are still bound to it')
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,8 +42,14 @@ import {
 } from './session-manager'
 import { parseDiff, synthesizeUntrackedFile } from './diff-parser'
 import { listHosts, addHost, updateHost, deleteHost, getHost } from './host-registry'
-import { testConnection } from './host-connection'
-import type { DiffMode } from '../shared/types'
+import { testConnection, validateRemoteRepo } from './host-connection'
+import {
+  listRemoteProjects,
+  addRemoteProject as persistRemoteProject,
+  removeRemoteProject,
+  toProject as remoteToProject,
+} from './remote-project-registry'
+import type { DiffMode, ValidateRemoteRepoReason } from '../shared/types'
 
 // Use native Wayland rendering when available (avoids Xwayland scaling artifacts)
 app.commandLine.appendSwitch('ozone-platform-hint', 'auto')
@@ -131,7 +137,9 @@ app.whenReady().then(async () => {
     const config = getConfig()
     const dirs = config.scanDirs.map(resolvePath)
     const pinned = (config.pinnedPaths || []).map(resolvePath)
-    return scanProjects(dirs, pinned, config.followSymlinks)
+    const local = await scanProjects(dirs, pinned, config.followSymlinks)
+    const remote = listRemoteProjects().map(remoteToProject)
+    return [...local, ...remote].sort((a, b) => a.name.localeCompare(b.name))
   })
 
   ipcMain.handle('projects:pick-directory', async () => {
@@ -151,6 +159,32 @@ app.whenReady().then(async () => {
       config.pinnedPaths.push(resolved)
       saveConfig(config)
     }
+  })
+
+  ipcMain.handle('projects:add-remote', async (_event, input: { hostId: string; path: string }) => {
+    const host = getHost(input.hostId)
+    if (!host) throw new Error('Unknown host')
+    const result = await validateRemoteRepo(host.alias, input.path)
+    if (!result.ok) {
+      const labels: Record<ValidateRemoteRepoReason, string> = {
+        'not-a-git-repo': 'Not a git repository',
+        'auth-failed': 'Auth failed',
+        network: 'Network error',
+        'dep-missing': 'Missing dependency',
+        unknown: 'ssh error',
+      }
+      const label = labels[result.reason ?? 'unknown']
+      throw new Error(`${label}: ${result.message ?? 'unknown'}`)
+    }
+    return persistRemoteProject({
+      hostId: input.hostId,
+      path: input.path,
+      repoFingerprint: result.fingerprint,
+    })
+  })
+
+  ipcMain.handle('projects:remove-remote', async (_event, hostId: string, path: string) => {
+    removeRemoteProject(hostId, path)
   })
 
   ipcMain.handle('projects:setup', async (_event, projectPath: string) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -48,6 +48,7 @@ import {
   addRemoteProject as persistRemoteProject,
   removeRemoteProject,
   toProject as remoteToProject,
+  validateRemotePath,
 } from './remote-project-registry'
 import type { DiffMode, ValidateRemoteRepoReason } from '../shared/types'
 
@@ -164,7 +165,10 @@ app.whenReady().then(async () => {
   ipcMain.handle('projects:add-remote', async (_event, input: { hostId: string; path: string }) => {
     const host = getHost(input.hostId)
     if (!host) throw new Error('Unknown host')
-    const result = await validateRemoteRepo(host.alias, input.path)
+    // Normalize the path before the SSH probe so the remote check, dedup,
+    // and persistence all see the same canonical form.
+    const path = validateRemotePath(input.path)
+    const result = await validateRemoteRepo(host.alias, path)
     if (!result.ok) {
       const labels: Record<ValidateRemoteRepoReason, string> = {
         'not-a-git-repo': 'Not a git repository',
@@ -178,7 +182,7 @@ app.whenReady().then(async () => {
     }
     return persistRemoteProject({
       hostId: input.hostId,
-      path: input.path,
+      path,
       repoFingerprint: result.fingerprint,
     })
   })

--- a/src/main/project-scanner.ts
+++ b/src/main/project-scanner.ts
@@ -136,6 +136,7 @@ async function enrichRepo(repo: { name: string; path: string }): Promise<Project
     branches,
     worktrees,
     setupState: detectSetupState(repo.path),
+    hostId: null,
   }
 }
 

--- a/src/main/remote-project-registry.test.ts
+++ b/src/main/remote-project-registry.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Host, RemoteProject } from '../shared/types'
+
+let fakeHosts: Host[] = []
+let fakeRemoteProjects: RemoteProject[] = []
+const saveConfigSpy = vi.fn()
+
+vi.mock('./config', () => ({
+  CONFIG_DIR: '/tmp/cc-pewpew-test',
+  getConfig: () => ({
+    scanDirs: [],
+    pinnedPaths: [],
+    followSymlinks: true,
+    canvas: { zoom: 1, panX: 0, panY: 0 },
+    clusterPositions: {},
+    sidebarWidth: 250,
+    uiScale: 1,
+    hosts: fakeHosts,
+    remoteProjects: fakeRemoteProjects,
+  }),
+  saveConfig: (cfg: { hosts: Host[]; remoteProjects: RemoteProject[] }) => {
+    fakeHosts = cfg.hosts
+    fakeRemoteProjects = cfg.remoteProjects
+    saveConfigSpy(cfg)
+  },
+}))
+
+vi.mock('./host-registry', () => ({
+  getHost: (hostId: string) => fakeHosts.find((h) => h.hostId === hostId),
+}))
+
+import {
+  validateRemotePath,
+  listRemoteProjects,
+  addRemoteProject,
+  removeRemoteProject,
+  hasRemoteProjectsBoundTo,
+  toProject,
+} from './remote-project-registry'
+
+function seedHost(hostId = 'h1', alias = 'dev', label = 'Dev'): Host {
+  const host: Host = { hostId, alias, label }
+  fakeHosts = [...fakeHosts, host]
+  return host
+}
+
+beforeEach(() => {
+  fakeHosts = []
+  fakeRemoteProjects = []
+  saveConfigSpy.mockClear()
+})
+
+describe('validateRemotePath', () => {
+  it('rejects empty and whitespace-only', () => {
+    expect(() => validateRemotePath('')).toThrow(/required/)
+    expect(() => validateRemotePath('   ')).toThrow(/required/)
+  })
+
+  it('requires absolute path', () => {
+    expect(() => validateRemotePath('relative/path')).toThrow(/absolute/)
+  })
+
+  it('rejects leading dash (argv-injection guard)', () => {
+    expect(() => validateRemotePath('-oProxyCommand=foo')).toThrow(/start with/)
+  })
+
+  it('rejects NUL', () => {
+    expect(() => validateRemotePath('/foo\x00bar')).toThrow(/NUL/)
+  })
+
+  it('trims whitespace', () => {
+    expect(validateRemotePath('  /repo  ')).toBe('/repo')
+  })
+})
+
+describe('addRemoteProject', () => {
+  it('persists a new remote project with derived name', () => {
+    const host = seedHost()
+    const project = addRemoteProject({ hostId: host.hostId, path: '/srv/repo' })
+    expect(project).toEqual({ hostId: host.hostId, path: '/srv/repo', name: 'repo' })
+    expect(listRemoteProjects()).toHaveLength(1)
+    expect(saveConfigSpy).toHaveBeenCalledOnce()
+  })
+
+  it('uses provided name when given', () => {
+    const host = seedHost()
+    const project = addRemoteProject({ hostId: host.hostId, path: '/srv/repo', name: 'My Repo' })
+    expect(project.name).toBe('My Repo')
+  })
+
+  it('stores repoFingerprint when provided', () => {
+    const host = seedHost()
+    const project = addRemoteProject({
+      hostId: host.hostId,
+      path: '/srv/repo',
+      repoFingerprint: 'abc123',
+    })
+    expect(project.repoFingerprint).toBe('abc123')
+  })
+
+  it('rejects unknown hostId', () => {
+    expect(() => addRemoteProject({ hostId: 'nope', path: '/srv/repo' })).toThrow(/Unknown host/)
+  })
+
+  it('rejects duplicate (hostId, path)', () => {
+    const host = seedHost()
+    addRemoteProject({ hostId: host.hostId, path: '/srv/repo' })
+    expect(() => addRemoteProject({ hostId: host.hostId, path: '/srv/repo' })).toThrow(
+      /already registered/
+    )
+  })
+
+  it('allows the same path on a different host', () => {
+    const h1 = seedHost('h1', 'a', 'A')
+    const h2 = seedHost('h2', 'b', 'B')
+    addRemoteProject({ hostId: h1.hostId, path: '/srv/repo' })
+    expect(() => addRemoteProject({ hostId: h2.hostId, path: '/srv/repo' })).not.toThrow()
+  })
+
+  it('rejects non-absolute path before checking host', () => {
+    expect(() => addRemoteProject({ hostId: 'nope', path: 'relative' })).toThrow(/absolute/)
+  })
+})
+
+describe('removeRemoteProject', () => {
+  it('removes the matching entry', () => {
+    const host = seedHost()
+    addRemoteProject({ hostId: host.hostId, path: '/a' })
+    addRemoteProject({ hostId: host.hostId, path: '/b' })
+    removeRemoteProject(host.hostId, '/a')
+    expect(listRemoteProjects().map((p) => p.path)).toEqual(['/b'])
+  })
+
+  it('is idempotent on missing entry', () => {
+    const host = seedHost()
+    expect(() => removeRemoteProject(host.hostId, '/nope')).not.toThrow()
+    expect(saveConfigSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('hasRemoteProjectsBoundTo', () => {
+  it('returns false when no projects reference the host', () => {
+    seedHost('h1')
+    expect(hasRemoteProjectsBoundTo('h1')).toBe(false)
+  })
+
+  it('returns true when at least one project references the host', () => {
+    const host = seedHost('h1')
+    addRemoteProject({ hostId: host.hostId, path: '/x' })
+    expect(hasRemoteProjectsBoundTo('h1')).toBe(true)
+    expect(hasRemoteProjectsBoundTo('h2')).toBe(false)
+  })
+})
+
+describe('toProject', () => {
+  it('maps RemoteProject to a Project with empty worktrees/branches and ready setup', () => {
+    const p = toProject({ hostId: 'h1', path: '/x', name: 'x' })
+    expect(p).toEqual({
+      name: 'x',
+      path: '/x',
+      branches: [],
+      worktrees: [],
+      setupState: 'ready',
+      hostId: 'h1',
+    })
+  })
+})

--- a/src/main/remote-project-registry.test.ts
+++ b/src/main/remote-project-registry.test.ts
@@ -71,6 +71,17 @@ describe('validateRemotePath', () => {
   it('trims whitespace', () => {
     expect(validateRemotePath('  /repo  ')).toBe('/repo')
   })
+
+  it('strips a trailing slash but preserves the root "/"', () => {
+    expect(validateRemotePath('/srv/repo/')).toBe('/srv/repo')
+    expect(validateRemotePath('/')).toBe('/')
+  })
+
+  it('collapses duplicate slashes and resolves "." / ".."', () => {
+    expect(validateRemotePath('/srv//repo')).toBe('/srv/repo')
+    expect(validateRemotePath('/srv/./repo')).toBe('/srv/repo')
+    expect(validateRemotePath('/srv/a/../repo')).toBe('/srv/repo')
+  })
 })
 
 describe('addRemoteProject', () => {
@@ -106,6 +117,20 @@ describe('addRemoteProject', () => {
     const host = seedHost()
     addRemoteProject({ hostId: host.hostId, path: '/srv/repo' })
     expect(() => addRemoteProject({ hostId: host.hostId, path: '/srv/repo' })).toThrow(
+      /already registered/
+    )
+  })
+
+  it('rejects duplicates that differ only by trailing slash or "." segments', () => {
+    const host = seedHost()
+    addRemoteProject({ hostId: host.hostId, path: '/srv/repo' })
+    expect(() => addRemoteProject({ hostId: host.hostId, path: '/srv/repo/' })).toThrow(
+      /already registered/
+    )
+    expect(() => addRemoteProject({ hostId: host.hostId, path: '/srv/./repo' })).toThrow(
+      /already registered/
+    )
+    expect(() => addRemoteProject({ hostId: host.hostId, path: '/srv/a/../repo' })).toThrow(
       /already registered/
     )
   })

--- a/src/main/remote-project-registry.ts
+++ b/src/main/remote-project-registry.ts
@@ -13,7 +13,11 @@ export function validateRemotePath(raw: string): string {
   if (!path.startsWith('/')) throw new Error('Path must be absolute (start with "/")')
   if (path.startsWith('-')) throw new Error('Path must not start with "-"')
   if (path.includes('\x00')) throw new Error('Path must not contain NUL')
-  return path
+  // Collapse `.`, `..`, and duplicate slashes, then strip any trailing slash
+  // (preserving the root `/`). Keeps duplicate-detection robust against
+  // equivalent forms like `/srv/repo` vs `/srv/repo/` vs `/srv/a/../repo`.
+  const normalized = posix.normalize(path)
+  return normalized.length > 1 && normalized.endsWith('/') ? normalized.slice(0, -1) : normalized
 }
 
 export function listRemoteProjects(): RemoteProject[] {

--- a/src/main/remote-project-registry.ts
+++ b/src/main/remote-project-registry.ts
@@ -1,0 +1,68 @@
+import { posix } from 'path'
+import { getConfig, saveConfig } from './config'
+import { getHost } from './host-registry'
+import type { HostId, Project, RemoteProject } from '../shared/types'
+
+const MAX_PATH_LEN = 4096
+
+export function validateRemotePath(raw: string): string {
+  const path = raw.trim()
+  if (!path) throw new Error('Path is required')
+  if (path.length > MAX_PATH_LEN)
+    throw new Error(`Path must be ${MAX_PATH_LEN} characters or fewer`)
+  if (!path.startsWith('/')) throw new Error('Path must be absolute (start with "/")')
+  if (path.startsWith('-')) throw new Error('Path must not start with "-"')
+  if (path.includes('\x00')) throw new Error('Path must not contain NUL')
+  return path
+}
+
+export function listRemoteProjects(): RemoteProject[] {
+  return getConfig().remoteProjects
+}
+
+export function addRemoteProject(input: {
+  hostId: HostId
+  path: string
+  name?: string
+  repoFingerprint?: string
+}): RemoteProject {
+  const path = validateRemotePath(input.path)
+  if (!getHost(input.hostId)) throw new Error('Unknown host')
+  const config = getConfig()
+  if (config.remoteProjects.some((p) => p.hostId === input.hostId && p.path === path)) {
+    throw new Error('Remote project already registered')
+  }
+  const name = (input.name ?? posix.basename(path)).trim() || posix.basename(path)
+  const project: RemoteProject = {
+    hostId: input.hostId,
+    path,
+    name,
+    ...(input.repoFingerprint ? { repoFingerprint: input.repoFingerprint } : {}),
+  }
+  config.remoteProjects = [...config.remoteProjects, project]
+  saveConfig(config)
+  return project
+}
+
+export function removeRemoteProject(hostId: HostId, path: string): void {
+  const config = getConfig()
+  const next = config.remoteProjects.filter((p) => !(p.hostId === hostId && p.path === path))
+  if (next.length === config.remoteProjects.length) return
+  config.remoteProjects = next
+  saveConfig(config)
+}
+
+export function hasRemoteProjectsBoundTo(hostId: HostId): boolean {
+  return listRemoteProjects().some((p) => p.hostId === hostId)
+}
+
+export function toProject(rp: RemoteProject): Project {
+  return {
+    name: rp.name,
+    path: rp.path,
+    branches: [],
+    worktrees: [],
+    setupState: 'ready',
+    hostId: rp.hostId,
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -84,4 +84,8 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.invoke('hosts:update', hostId, alias, label),
   deleteHost: (hostId: string) => ipcRenderer.invoke('hosts:delete', hostId),
   testHostConnection: (hostId: string) => ipcRenderer.invoke('hosts:test-connection', hostId),
+  addRemoteProject: (input: { hostId: string; path: string }) =>
+    ipcRenderer.invoke('projects:add-remote', input),
+  removeRemoteProject: (hostId: string, path: string) =>
+    ipcRenderer.invoke('projects:remove-remote', hostId, path),
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,12 +5,14 @@ import DetailPane from './components/DetailPane'
 import StatusBar from './components/StatusBar'
 import ManageHostsDialog from './components/ManageHostsDialog'
 import ZoomOpenMorph from './components/ZoomOpenMorph'
+import AddRemoteProjectDialog from './components/AddRemoteProjectDialog'
 import { useProjectsStore } from './stores/projects'
 import { useSessionsStore } from './stores/sessions'
 import { useHostsStore } from './stores/hosts'
 
 export default function App() {
   const { scanProjects, filterReady, toggleFilterReady } = useProjectsStore()
+  const openAddRemoteDialog = useProjectsStore((s) => s.openAddRemoteDialog)
   const { init: initSessions } = useSessionsStore()
   const hosts = useHostsStore((s) => s.hosts)
   const openHostsDialog = useHostsStore((s) => s.openDialog)
@@ -69,6 +71,7 @@ export default function App() {
         // one is open (avoids side-effect clearing of active session /
         // selection when dismissing a modal via Escape).
         if (useHostsStore.getState().dialogOpen) return
+        if (useProjectsStore.getState().addRemoteDialogOpen) return
         if (morphPayload && !activeSessionId) {
           // Cancel zoom-open mid-morph: abort the transition and stay on canvas.
           setMorphPayload(null)
@@ -196,6 +199,13 @@ export default function App() {
           >
             🌐 Hosts ({hosts.length})
           </button>
+          <button
+            className="new-project-btn"
+            onClick={openAddRemoteDialog}
+            title="Register a remote git project"
+          >
+            📡 Remote project
+          </button>
         </div>
       </aside>
 
@@ -221,6 +231,7 @@ export default function App() {
       </main>
 
       <ManageHostsDialog />
+      <AddRemoteProjectDialog />
       {morphPayload && (
         <ZoomOpenMorph
           startRect={morphPayload.startRect}

--- a/src/renderer/components/AddRemoteProjectDialog.tsx
+++ b/src/renderer/components/AddRemoteProjectDialog.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react'
+import { useProjectsStore } from '../stores/projects'
+import { useHostsStore } from '../stores/hosts'
+
+export default function AddRemoteProjectDialog() {
+  const dialogOpen = useProjectsStore((s) => s.addRemoteDialogOpen)
+  const error = useProjectsStore((s) => s.addRemoteError)
+  const submitting = useProjectsStore((s) => s.addRemoteSubmitting)
+  const closeDialog = useProjectsStore((s) => s.closeAddRemoteDialog)
+  const addRemoteProject = useProjectsStore((s) => s.addRemoteProject)
+  const clearError = useProjectsStore((s) => s.clearAddRemoteError)
+
+  const hosts = useHostsStore((s) => s.hosts)
+  const openHostsDialog = useHostsStore((s) => s.openDialog)
+
+  const [selectedHostId, setSelectedHostId] = useState('')
+  const [remotePath, setRemotePath] = useState('')
+
+  // Reset form when the dialog opens, and pick a sensible default host.
+  useEffect(() => {
+    if (!dialogOpen) return
+    setRemotePath('')
+    setSelectedHostId((prev) => {
+      if (hosts.some((h) => h.hostId === prev)) return prev
+      return hosts[0]?.hostId ?? ''
+    })
+  }, [dialogOpen, hosts])
+
+  // Escape handling mirrors ManageHostsDialog: bubble-phase listener with a
+  // DOM-topology guard so the form's own input Escape wins.
+  useEffect(() => {
+    if (!dialogOpen) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      const target = e.target as HTMLElement | null
+      if (target && target.closest('.add-remote-form')) return
+      closeDialog()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [dialogOpen, closeDialog])
+
+  if (!dialogOpen) return null
+
+  const canSubmit = selectedHostId !== '' && remotePath.trim().length > 0 && !submitting
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return
+    await addRemoteProject({ hostId: selectedHostId, path: remotePath.trim() })
+  }
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      void handleSubmit()
+    } else if (e.key === 'Escape') {
+      closeDialog()
+    }
+  }
+
+  return (
+    <div
+      className="hosts-dialog-overlay"
+      onClick={closeDialog}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <div className="hosts-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="hosts-dialog-header">
+          <div className="session-name-label">Add remote project</div>
+          <button className="create-btn cancel" onClick={closeDialog}>
+            Close
+          </button>
+        </div>
+
+        {error && (
+          <div className="hosts-error" onClick={clearError}>
+            {error}
+          </div>
+        )}
+
+        {hosts.length === 0 ? (
+          <div className="add-remote-empty">
+            <p>No hosts configured. Add a host first.</p>
+            <button
+              className="create-btn"
+              onClick={() => {
+                closeDialog()
+                openHostsDialog()
+              }}
+            >
+              Manage hosts
+            </button>
+          </div>
+        ) : (
+          <div className="add-remote-form hosts-form">
+            <select
+              autoFocus
+              className="create-input"
+              value={selectedHostId}
+              onChange={(e) => setSelectedHostId(e.target.value)}
+              onKeyDown={handleKey}
+            >
+              {hosts.map((h) => (
+                <option key={h.hostId} value={h.hostId}>
+                  {h.label} ({h.alias})
+                </option>
+              ))}
+            </select>
+            <input
+              type="text"
+              className="create-input"
+              placeholder="/absolute/path/on/remote"
+              value={remotePath}
+              onChange={(e) => setRemotePath(e.target.value)}
+              onKeyDown={handleKey}
+            />
+            <div className="create-actions">
+              <button className="create-btn" disabled={!canSubmit} onClick={handleSubmit}>
+                {submitting ? 'Validating…' : 'Add'}
+              </button>
+              <button className="create-btn cancel" onClick={closeDialog} disabled={submitting}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useProjectsStore } from '../stores/projects'
 import { useSessionsStore } from '../stores/sessions'
+import { useHostsStore } from '../stores/hosts'
 import ContextMenu, { type MenuItem } from './ContextMenu'
 
 interface MenuState {
@@ -8,6 +9,7 @@ interface MenuState {
   y: number
   projectPath: string
   setupState: 'unsetup' | 'ready'
+  hostId: string | null
 }
 
 interface TreeProps {
@@ -16,7 +18,9 @@ interface TreeProps {
 
 export default function ProjectTree({ onOpenSession }: TreeProps) {
   const { projects, loading, scanProjects, filterReady } = useProjectsStore()
+  const removeRemoteProject = useProjectsStore((s) => s.removeRemoteProject)
   const { sessions } = useSessionsStore()
+  const hosts = useHostsStore((s) => s.hosts)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [menu, setMenu] = useState<MenuState | null>(null)
   const [pendingSessionPath, setPendingSessionPath] = useState<string | null>(null)
@@ -51,15 +55,27 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const handleContextMenu = (
     e: React.MouseEvent,
     projectPath: string,
-    setupState: 'unsetup' | 'ready'
+    setupState: 'unsetup' | 'ready',
+    hostId: string | null
   ) => {
     e.preventDefault()
-    setMenu({ x: e.clientX, y: e.clientY, projectPath, setupState })
+    setMenu({ x: e.clientX, y: e.clientY, projectPath, setupState, hostId })
   }
 
   const getMenuItems = (): MenuItem[] => {
     if (!menu) return []
     const items: MenuItem[] = []
+
+    if (menu.hostId !== null) {
+      const hostId = menu.hostId
+      items.push({
+        label: 'Remove remote project',
+        onClick: () => void removeRemoteProject(hostId, menu.projectPath),
+      })
+      items.push({ label: '', separator: true, onClick: () => {} })
+      items.push({ label: 'Rescan', onClick: () => scanProjects() })
+      return items
+    }
 
     if (menu.setupState === 'unsetup') {
       items.push({
@@ -251,27 +267,36 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
       {displayProjects.map((project) => {
         const isExpanded = expanded.has(project.path)
         const hasWorktrees = project.worktrees.length > 1
+        const host = project.hostId ? hosts.find((h) => h.hostId === project.hostId) : null
 
         return (
-          <div key={project.path} className="project-node">
+          <div key={`${project.hostId ?? 'local'}:${project.path}`} className="project-node">
             <div
               className="project-row"
               onClick={() => hasWorktrees && toggle(project.path)}
-              onContextMenu={(e) => handleContextMenu(e, project.path, project.setupState)}
+              onContextMenu={(e) =>
+                handleContextMenu(e, project.path, project.setupState, project.hostId)
+              }
             >
               <span className="project-toggle">
                 {hasWorktrees ? (isExpanded ? '▼' : '▶') : ' '}
               </span>
               <span className="project-name">{project.name}</span>
-              {project.setupState === 'ready' ? (
-                <span className="badge-ready" title="cc-pewpew hooks installed">
-                  ●
-                </span>
-              ) : (
-                <span className="badge-unsetup" title="Not set up">
-                  [Setup]
+              {host && (
+                <span className="host-pill" title={`Remote on ${host.alias}`}>
+                  {host.label}
                 </span>
               )}
+              {project.hostId === null &&
+                (project.setupState === 'ready' ? (
+                  <span className="badge-ready" title="cc-pewpew hooks installed">
+                    ●
+                  </span>
+                ) : (
+                  <span className="badge-unsetup" title="Not set up">
+                    [Setup]
+                  </span>
+                ))}
             </div>
 
             {isExpanded && (

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -5,6 +5,7 @@ import type {
   DiffMode,
   Host,
   Project,
+  RemoteProject,
   Session,
   TestConnectionResult,
 } from '../shared/types'
@@ -63,6 +64,8 @@ declare global {
       updateHost: (hostId: string, alias: string, label: string) => Promise<Host>
       deleteHost: (hostId: string) => Promise<void>
       testHostConnection: (hostId: string) => Promise<TestConnectionResult>
+      addRemoteProject: (input: { hostId: string; path: string }) => Promise<RemoteProject>
+      removeRemoteProject: (hostId: string, path: string) => Promise<void>
     }
   }
 }

--- a/src/renderer/stores/projects.ts
+++ b/src/renderer/stores/projects.ts
@@ -5,14 +5,31 @@ interface ProjectsState {
   projects: Project[]
   loading: boolean
   filterReady: boolean
+  addRemoteDialogOpen: boolean
+  addRemoteError: string | null
+  addRemoteSubmitting: boolean
   scanProjects: () => Promise<void>
   toggleFilterReady: () => void
+  openAddRemoteDialog: () => void
+  closeAddRemoteDialog: () => void
+  clearAddRemoteError: () => void
+  addRemoteProject: (input: { hostId: string; path: string }) => Promise<void>
+  removeRemoteProject: (hostId: string, path: string) => Promise<void>
 }
 
-export const useProjectsStore = create<ProjectsState>((set) => ({
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message
+  if (typeof e === 'string') return e
+  return String(e)
+}
+
+export const useProjectsStore = create<ProjectsState>((set, get) => ({
   projects: [],
   loading: false,
   filterReady: false,
+  addRemoteDialogOpen: false,
+  addRemoteError: null,
+  addRemoteSubmitting: false,
   toggleFilterReady: () => set((state) => ({ filterReady: !state.filterReady })),
   scanProjects: async () => {
     set({ loading: true })
@@ -22,6 +39,29 @@ export const useProjectsStore = create<ProjectsState>((set) => ({
     } catch (err) {
       console.error('scanProjects failed:', err)
       set({ loading: false })
+    }
+  },
+  openAddRemoteDialog: () =>
+    set({ addRemoteDialogOpen: true, addRemoteError: null, addRemoteSubmitting: false }),
+  closeAddRemoteDialog: () =>
+    set({ addRemoteDialogOpen: false, addRemoteError: null, addRemoteSubmitting: false }),
+  clearAddRemoteError: () => set({ addRemoteError: null }),
+  addRemoteProject: async (input) => {
+    set({ addRemoteSubmitting: true, addRemoteError: null })
+    try {
+      await window.api.addRemoteProject(input)
+      set({ addRemoteSubmitting: false, addRemoteDialogOpen: false, addRemoteError: null })
+      await get().scanProjects()
+    } catch (e) {
+      set({ addRemoteSubmitting: false, addRemoteError: errorMessage(e) })
+    }
+  },
+  removeRemoteProject: async (hostId, path) => {
+    try {
+      await window.api.removeRemoteProject(hostId, path)
+      await get().scanProjects()
+    } catch (e) {
+      console.error('removeRemoteProject failed:', e)
     }
   },
 }))

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -513,6 +513,27 @@ body,
   opacity: 0.7;
 }
 
+.host-pill {
+  flex-shrink: 0;
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--border);
+  color: var(--text-secondary);
+  max-width: 72px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.add-remote-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 0;
+}
+
 .worktree-list {
   padding-left: 26px;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,6 +6,7 @@ export interface Project {
   branches: string[]
   worktrees: Worktree[]
   setupState: 'unsetup' | 'ready'
+  hostId: string | null
 }
 
 export interface Worktree {
@@ -96,5 +97,26 @@ export type SshExitReason = 'auth-failed' | 'network' | 'dep-missing' | 'unknown
 export interface TestConnectionResult {
   ok: boolean
   reason?: SshExitReason
+  message?: string
+}
+
+export interface RemoteProject {
+  hostId: HostId
+  path: string
+  name: string
+  repoFingerprint?: string
+}
+
+export type ValidateRemoteRepoReason =
+  | 'not-a-git-repo'
+  | 'auth-failed'
+  | 'network'
+  | 'dep-missing'
+  | 'unknown'
+
+export interface ValidateRemoteRepoResult {
+  ok: boolean
+  fingerprint?: string
+  reason?: ValidateRemoteRepoReason
   message?: string
 }


### PR DESCRIPTION
## Summary

- Adds `Project.hostId: string | null` (required); local scanner returns `hostId: null`, remote projects carry a hostId.
- Persists remote projects in a new `AppConfig.remoteProjects: RemoteProject[]` array in `config.json`. Existing configs backfill via the existing default-merge; zero migration.
- New **📡 Remote project** button opens an Add Remote Project dialog (host dropdown + absolute path input). A single SSH round-trip validates `.git` exists and extracts the root-commit fingerprint, then persists — invalid paths surface a clear error before the project is added.
- Sidebar renders remote projects inline with local ones, with a compact `.host-pill` badge (live label from the hosts store). Local entries are unchanged.
- Context menu on a remote project shows only **Remove remote project** + **Rescan**; local project menu is unchanged.
- `deleteHost` now refuses when a remote project references the host (mirrors the existing session-binding guard).
- `project-scanner` stays local-only.

## Architecture notes

- SSH validation uses the safe positional-arg pattern `sh -c 'test -d "$1/.git" && git -C "$1" rev-list --max-parents=0 HEAD' _ <path>` — path is an argv element, never interpolated into the script. Reuses the `HostConnection.exec` + `shellQuote` + `classifySshExit` foundation from #9.
- Dialog Escape handling copies the pattern established by #9's recent fixes: bubble-phase listener + DOM-topology guard (`target.closest('.add-remote-form')`). App.tsx's global Escape also early-returns while the dialog is open.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean (also fixes a pre-existing empty-catch the ESLint 10 bump started flagging)
- [x] `npx vitest run` — 127/127 passing, of which 23 new:
  - `src/main/remote-project-registry.test.ts` (17): path validation, add/remove, duplicate detection, cross-host same-path, binding guard, `toProject`
  - `src/main/host-connection.test.ts` (6): `validateRemoteRepo` success, not-a-git-repo, auth-failed, network, dep-missing, argv safety (shell-quoted path)
  - `src/main/host-registry.test.ts` (+1): refuses deletion when a remote project is bound to the host
- [ ] Manual CDP smoke: add a host → click 📡 Remote project → register path → verify pill renders → right-click Remove → restart app → verify persistence.

## Blocked-by

#9 (merged).

## Out of scope for this slice (per PRD #8)

- Session creation on remote projects.
- Remote worktree discovery / review pane.
- Edit dialog for remote projects (remove + re-add for now).
- Cascade-delete UX on host removal (currently throws).

Closes #10.