### PR TITLE
feat: show branch, issue, and PR on session cards

### DIFF
--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -54,6 +54,22 @@ function resolveBranchFromWorktree(worktreePath: string, worktreeName: string): 
   return `cc-pewpew/${worktreeName}`
 }
 
+// Extract the owner segment from a GitHub `origin` remote URL. Used to
+// disambiguate `gh pr list --head <branch>` results when a fork has opened a
+// PR whose head branch name collides with a local branch.
+function getOriginOwner(projectPath: string): string | undefined {
+  try {
+    const url = execFileSync('git', ['-C', projectPath, 'remote', 'get-url', 'origin'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+    }).trim()
+    const m = url.match(/(?:[:/])([^/:]+)\/[^/]+?(?:\.git)?\/?$/)
+    return m?.[1]
+  } catch {
+    return undefined
+  }
+}
+
 interface SessionEntry {
   session: Session
 }
@@ -76,11 +92,31 @@ async function lookupPrForBranch(projectPath: string, branch: string): Promise<n
   try {
     const { stdout } = await execFileAsync(
       'gh',
-      ['pr', 'list', '--head', branch, '--state', 'open', '--json', 'number', '--limit', '1'],
+      [
+        'pr',
+        'list',
+        '--head',
+        branch,
+        '--state',
+        'open',
+        '--json',
+        'number,headRepositoryOwner',
+        '--limit',
+        '10',
+      ],
       { cwd: projectPath }
     )
-    const parsed = JSON.parse(stdout) as { number: number }[]
-    const num = parsed[0]?.number
+    const parsed = JSON.parse(stdout) as {
+      number: number
+      headRepositoryOwner?: { login?: string } | null
+    }[]
+    // `gh pr list --head <branch>` filters by branch name only (owner:branch
+    // isn't supported), so in repos that accept fork PRs a common branch name
+    // like `main` or `fix` can return an unrelated PR. Match on the local
+    // origin's owner to pick the PR that belongs to this clone.
+    const owner = getOriginOwner(projectPath)
+    const match = owner ? parsed.find((p) => p.headRepositoryOwner?.login === owner) : parsed[0]
+    const num = match?.number
     prLookupCache.set(key, { value: num ?? null, checkedAt: Date.now() })
     return num
   } catch {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'child_process'
+import { execFile, execFileSync } from 'child_process'
 import { promisify } from 'util'
 import { readFileSync, writeFileSync, existsSync, realpathSync } from 'fs'
 import { join, basename, sep } from 'path'
@@ -25,11 +25,78 @@ import type { Session, SessionStatus } from '../shared/types'
 const execFileAsync = promisify(execFile)
 const SESSIONS_PATH = join(CONFIG_DIR, 'sessions.json')
 
+// Matches "issue37", "issue-37", "issue_37", "issue/37", "issue#37", "issue 37"
+// anywhere in a string. Case-insensitive. Captures the number.
+const ISSUE_REGEX = /issue[-_/#\s]?(\d+)/i
+
+function parseIssueNumber(...sources: (string | undefined)[]): number | undefined {
+  for (const src of sources) {
+    if (!src) continue
+    const m = src.match(ISSUE_REGEX)
+    if (m) return parseInt(m[1], 10)
+  }
+  return undefined
+}
+
+// Read the actual branch checked out in a worktree. Falls back to the
+// cc-pewpew-conventional name if the worktree is missing or git fails.
+function resolveBranchFromWorktree(worktreePath: string, worktreeName: string): string {
+  if (existsSync(worktreePath)) {
+    try {
+      const out = execFileSync('git', ['-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'], {
+        encoding: 'utf-8',
+      }).trim()
+      if (out && out !== 'HEAD') return out
+    } catch {
+      // fall through to default
+    }
+  }
+  return `cc-pewpew/${worktreeName}`
+}
+
 interface SessionEntry {
   session: Session
 }
 
 const sessions = new Map<string, SessionEntry>()
+
+// Cache: `${projectPath}::${branch}` -> pr number (or null for "checked, none found")
+const prLookupCache = new Map<string, number | null>()
+
+async function lookupPrForBranch(projectPath: string, branch: string): Promise<number | undefined> {
+  const key = `${projectPath}::${branch}`
+  if (prLookupCache.has(key)) {
+    return prLookupCache.get(key) ?? undefined
+  }
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['pr', 'list', '--head', branch, '--state', 'open', '--json', 'number', '--limit', '1'],
+      { cwd: projectPath }
+    )
+    const parsed = JSON.parse(stdout) as { number: number }[]
+    const num = parsed[0]?.number
+    prLookupCache.set(key, num ?? null)
+    return num
+  } catch {
+    prLookupCache.set(key, null)
+    return undefined
+  }
+}
+
+function resolvePrNumberAsync(sessionId: string): void {
+  const entry = sessions.get(sessionId)
+  if (!entry || entry.session.prNumber !== undefined) return
+  const { projectPath, branch } = entry.session
+  if (!branch) return
+  lookupPrForBranch(projectPath, branch).then((num) => {
+    if (num === undefined) return
+    const current = sessions.get(sessionId)
+    if (!current || current.session.prNumber !== undefined) return
+    current.session.prNumber = num
+    onSessionsChanged()
+  })
+}
 
 function persistSessions(): void {
   const data = Array.from(sessions.values()).map((e) => e.session)
@@ -139,6 +206,7 @@ async function adoptWorktree(
   const projectName = basename(projectPath)
   const worktreeName = label || (await deriveLabel(worktreePath))
   const tmuxSession = `cc-pewpew-${id}`
+  const branch = resolveBranchFromWorktree(worktreePath, worktreeName)
 
   await installHooks(worktreePath, { skipGitignore: true })
   createPty(id, worktreePath)
@@ -149,6 +217,8 @@ async function adoptWorktree(
     projectName,
     worktreeName,
     worktreePath: canonical,
+    branch,
+    issueNumber: parseIssueNumber(worktreeName, branch),
     pid: 0,
     tmuxSession,
     status: 'running',
@@ -164,6 +234,8 @@ async function adoptWorktree(
       onSessionsChanged()
     }
   })
+
+  resolvePrNumberAsync(id)
 
   onSessionsChanged()
 
@@ -410,7 +482,16 @@ export async function createPrSession(
     }
   }
 
-  return createSessionForWorktree(projectPath, worktreePath, worktreeName)
+  const session = await createSessionForWorktree(projectPath, worktreePath, worktreeName)
+  // We already know the PR number; set it directly so it shows immediately
+  // (the async lookup fired by adoptWorktree will no-op since prNumber is set).
+  session.prNumber = prNumber
+  // Prefer an issue number parsed from the PR title if the name/branch didn't yield one.
+  if (session.issueNumber === undefined) {
+    session.issueNumber = parseIssueNumber(prInfo.title)
+  }
+  onSessionsChanged()
+  return session
 }
 
 export function getSession(id: string): Session | undefined {
@@ -529,6 +610,22 @@ export function restoreSessions(): void {
       }
       // Migrate legacy symlink-form paths to canonical so renderer matches work.
       session.worktreePath = canonicalPath(session.worktreePath)
+      // Backfill / reconcile fields added in later versions. Read the real
+      // branch from git when the worktree exists — an earlier version of this
+      // code persisted an incorrect default that we self-heal. If the worktree
+      // is gone, keep whatever was persisted (or the default fallback).
+      if (existsSync(session.worktreePath)) {
+        session.branch = resolveBranchFromWorktree(session.worktreePath, session.worktreeName)
+      } else if (!session.branch) {
+        session.branch = `cc-pewpew/${session.worktreeName}`
+      }
+      if (session.issueNumber === undefined) {
+        session.issueNumber = parseIssueNumber(session.worktreeName, session.branch)
+      }
+      if (session.prNumber === undefined) {
+        const m = session.worktreeName.match(/^pr-(\d+)$/)
+        if (m) session.prNumber = parseInt(m[1], 10)
+      }
       session.lastActivity = Date.now()
       sessions.set(session.id, { session })
     }
@@ -557,6 +654,11 @@ export function restoreSessions(): void {
 
     if (recoveredCount > 0) {
       console.log(`Auto-recovered ${recoveredCount} session(s) after reboot`)
+    }
+
+    // Lazily resolve PR numbers for any restored session that doesn't have one
+    for (const session of data) {
+      if (session.prNumber === undefined) resolvePrNumberAsync(session.id)
     }
 
     onSessionsChanged()

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -112,10 +112,12 @@ async function lookupPrForBranch(projectPath: string, branch: string): Promise<n
     }[]
     // `gh pr list --head <branch>` filters by branch name only (owner:branch
     // isn't supported), so in repos that accept fork PRs a common branch name
-    // like `main` or `fix` can return an unrelated PR. Match on the local
-    // origin's owner to pick the PR that belongs to this clone.
+    // like `main` or `fix` can return an unrelated PR. Prefer the entry whose
+    // head repo owner matches the local origin's owner; fall back to the top
+    // result so upstream clones tracking a contributor's branch (where the
+    // head owner differs from origin) still get a PR number.
     const owner = getOriginOwner(projectPath)
-    const match = owner ? parsed.find((p) => p.headRepositoryOwner?.login === owner) : parsed[0]
+    const match = (owner && parsed.find((p) => p.headRepositoryOwner?.login === owner)) || parsed[0]
     const num = match?.number
     prLookupCache.set(key, { value: num ?? null, checkedAt: Date.now() })
     return num

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -60,13 +60,18 @@ interface SessionEntry {
 
 const sessions = new Map<string, SessionEntry>()
 
-// Cache: `${projectPath}::${branch}` -> pr number (or null for "checked, none found")
-const prLookupCache = new Map<string, number | null>()
+// Positive hits are cached forever; negative hits (no PR yet / gh transient
+// error) are retained only for NEGATIVE_CACHE_TTL_MS so a PR opened after the
+// session was created can be picked up without requiring an app restart.
+const NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000
+const prLookupCache = new Map<string, { value: number | null; checkedAt: number }>()
 
 async function lookupPrForBranch(projectPath: string, branch: string): Promise<number | undefined> {
   const key = `${projectPath}::${branch}`
-  if (prLookupCache.has(key)) {
-    return prLookupCache.get(key) ?? undefined
+  const cached = prLookupCache.get(key)
+  if (cached) {
+    if (cached.value !== null) return cached.value
+    if (Date.now() - cached.checkedAt < NEGATIVE_CACHE_TTL_MS) return undefined
   }
   try {
     const { stdout } = await execFileAsync(
@@ -76,10 +81,10 @@ async function lookupPrForBranch(projectPath: string, branch: string): Promise<n
     )
     const parsed = JSON.parse(stdout) as { number: number }[]
     const num = parsed[0]?.number
-    prLookupCache.set(key, num ?? null)
+    prLookupCache.set(key, { value: num ?? null, checkedAt: Date.now() })
     return num
   } catch {
-    prLookupCache.set(key, null)
+    // Don't cache transient gh failures — next call retries immediately.
     return undefined
   }
 }
@@ -122,8 +127,16 @@ function updateSession(id: string, status: SessionStatus): void {
   onSessionsChanged()
 }
 
+// Re-probe PR numbers for sessions that don't have one yet, so a PR opened
+// after session creation shows up without an app restart.
+const PR_REFRESH_INTERVAL_MS = 5 * 60 * 1000
+
 export function initSessionManager(): void {
-  // No-op — session manager now uses the window registry for IPC
+  setInterval(() => {
+    for (const entry of sessions.values()) {
+      if (entry.session.prNumber === undefined) resolvePrNumberAsync(entry.session.id)
+    }
+  }, PR_REFRESH_INTERVAL_MS).unref()
 }
 
 async function deriveLabel(worktreePath: string): Promise<string> {

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -148,6 +148,22 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
       </div>
       <div className="session-card-body">
         <div className="session-card-header">{sessionName}</div>
+        <div className="session-card-chips">
+          <span className="session-card-chip chip-branch" title={`branch: ${session.branch}`}>
+            <span className="chip-icon">⎇</span>
+            {session.branch}
+          </span>
+          {session.issueNumber !== undefined && (
+            <span className="session-card-chip chip-issue" title={`issue #${session.issueNumber}`}>
+              issue #{session.issueNumber}
+            </span>
+          )}
+          {session.prNumber !== undefined && (
+            <span className="session-card-chip chip-pr" title={`PR #${session.prNumber}`}>
+              PR #{session.prNumber}
+            </span>
+          )}
+        </div>
         <div className="session-card-status">
           <span className={`status-dot ${statusClass}`} />
           <span>{label}</span>

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -366,6 +366,56 @@ body,
   white-space: nowrap;
 }
 
+.session-card-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 2px 0;
+}
+
+.session-card-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  max-width: 100%;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+  border: 1px solid transparent;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-card-chip .chip-icon {
+  font-size: 10px;
+  opacity: 0.8;
+}
+
+.session-card-chip.chip-branch {
+  background: rgba(96, 165, 250, 0.1);
+  border-color: rgba(96, 165, 250, 0.35);
+  color: var(--accent-blue);
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.session-card-chip.chip-issue {
+  background: rgba(250, 204, 21, 0.1);
+  border-color: rgba(250, 204, 21, 0.35);
+  color: var(--accent-yellow);
+  flex: 0 0 auto;
+}
+
+.session-card-chip.chip-pr {
+  background: rgba(74, 222, 128, 0.1);
+  border-color: rgba(74, 222, 128, 0.35);
+  color: var(--accent-green);
+  flex: 0 0 auto;
+}
+
 .session-card-status {
   display: flex;
   align-items: center;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -21,6 +21,9 @@ export interface Session {
   projectName: string
   worktreeName: string
   worktreePath: string
+  branch: string
+  prNumber?: number
+  issueNumber?: number
   pid: number
   tmuxSession: string
   status: SessionStatus


### PR DESCRIPTION
## Summary
- Adds `branch`, `prNumber`, and `issueNumber` to `Session` and renders them as chips under the card header — the card no longer shows only project/worktree.
- Populates fields at creation time (branch is known, PR number is known for PR sessions, issue number is parsed from the worktree/branch name with a narrow `issue[-_/#]?N` regex).
- Adds a lazy `gh pr list --head <branch>` lookup so branch-only sessions surface their PR once it exists. Results are cached per `(projectPath, branch)`.
- Reconciles legacy persisted sessions against the real git HEAD on restore, self-healing wrong branch data that an earlier version would have stored.

Closes #37

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (51 passed)
- [x] `npx eslint .`
- [x] Built and launched via CDP; verified card rendering for an `issue37`-style session, a `pr-6` session (chip shows real branch `cc-pewpew/sessionforwt` + `PR #6`), and a `ci-improv` session where the PR (`#38`) is resolved lazily.