### PR TITLE
[codex] fix eslint 10 react hooks rules

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     build: {
       outDir: 'dist-electron/main',
       rollupOptions: {
+        external: ['electron', 'node-pty'],
         input: {
           index: resolve(__dirname, 'src/main/index.ts'),
         },
@@ -22,6 +23,7 @@ export default defineConfig({
         entry: resolve(__dirname, 'src/preload/index.ts'),
       },
       rollupOptions: {
+        external: ['electron'],
         output: {
           format: 'cjs',
           entryFileNames: 'index.js',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,6 @@
 import { app, BrowserWindow, ipcMain, shell, dialog } from 'electron'
 import { join, resolve } from 'path'
 import { copyFileSync, mkdirSync, chmodSync } from 'fs'
-import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer'
 import {
   getConfig,
   saveConfig,
@@ -126,6 +125,8 @@ function createWindow(): BrowserWindow {
 app.whenReady().then(async () => {
   if (process.env.ELECTRON_RENDERER_URL) {
     try {
+      const { default: installExtension, REACT_DEVELOPER_TOOLS } =
+        await import('electron-devtools-installer')
       await installExtension(REACT_DEVELOPER_TOOLS)
     } catch {
       // React DevTools install can fail in some environments

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,20 @@ export default function App() {
   const openHostsDialog = useHostsStore((s) => s.openDialog)
   const fetchHosts = useHostsStore((s) => s.fetchHosts)
 
+  const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [newProjectName, setNewProjectName] = useState('')
+  const [sidebarWidth, setSidebarWidth] = useState(250)
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
+  const [activeSessionName, setActiveSessionName] = useState('')
+  const [morphPayload, setMorphPayload] = useState<ZoomOpenPayload | null>(null)
+
+  const handleZoomOpen = useCallback((payload: ZoomOpenPayload) => {
+    // Keep canvas rendered during the morph; mount DetailPane only on morph grown.
+    setMorphPayload(payload)
+  }, [])
+  const resizing = useRef(false)
+  const resizeStart = useRef({ x: 0, width: 0 })
+
   useEffect(() => {
     void fetchHosts()
   }, [fetchHosts])
@@ -37,20 +51,6 @@ export default function App() {
       }
     })
   }, [])
-
-  const [showCreateDialog, setShowCreateDialog] = useState(false)
-  const [newProjectName, setNewProjectName] = useState('')
-  const [sidebarWidth, setSidebarWidth] = useState(250)
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
-  const [activeSessionName, setActiveSessionName] = useState('')
-  const [morphPayload, setMorphPayload] = useState<ZoomOpenPayload | null>(null)
-
-  const handleZoomOpen = useCallback((payload: ZoomOpenPayload) => {
-    // Keep canvas rendered during the morph; mount DetailPane only on morph grown.
-    setMorphPayload(payload)
-  }, [])
-  const resizing = useRef(false)
-  const resizeStart = useRef({ x: 0, width: 0 })
 
   // Load sidebar width
   useEffect(() => {

--- a/src/renderer/components/AddRemoteProjectDialog.tsx
+++ b/src/renderer/components/AddRemoteProjectDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import type { Host } from '../../shared/types'
 import { useProjectsStore } from '../stores/projects'
 import { useHostsStore } from '../stores/hosts'
 
@@ -12,19 +13,6 @@ export default function AddRemoteProjectDialog() {
 
   const hosts = useHostsStore((s) => s.hosts)
   const openHostsDialog = useHostsStore((s) => s.openDialog)
-
-  const [selectedHostId, setSelectedHostId] = useState('')
-  const [remotePath, setRemotePath] = useState('')
-
-  // Reset form when the dialog opens, and pick a sensible default host.
-  useEffect(() => {
-    if (!dialogOpen) return
-    setRemotePath('')
-    setSelectedHostId((prev) => {
-      if (hosts.some((h) => h.hostId === prev)) return prev
-      return hosts[0]?.hostId ?? ''
-    })
-  }, [dialogOpen, hosts])
 
   // Escape handling mirrors ManageHostsDialog: bubble-phase listener with a
   // DOM-topology guard so the form's own input Escape wins.
@@ -42,11 +30,48 @@ export default function AddRemoteProjectDialog() {
 
   if (!dialogOpen) return null
 
-  const canSubmit = selectedHostId !== '' && remotePath.trim().length > 0 && !submitting
+  return (
+    <AddRemoteProjectDialogContent
+      hosts={hosts}
+      error={error}
+      submitting={submitting}
+      closeDialog={closeDialog}
+      addRemoteProject={addRemoteProject}
+      clearError={clearError}
+      openHostsDialog={openHostsDialog}
+    />
+  )
+}
+
+interface AddRemoteProjectDialogContentProps {
+  hosts: Host[]
+  error: string | null
+  submitting: boolean
+  closeDialog: () => void
+  addRemoteProject: (input: { hostId: string; path: string }) => Promise<void>
+  clearError: () => void
+  openHostsDialog: () => void
+}
+
+function AddRemoteProjectDialogContent({
+  hosts,
+  error,
+  submitting,
+  closeDialog,
+  addRemoteProject,
+  clearError,
+  openHostsDialog,
+}: AddRemoteProjectDialogContentProps) {
+  const [selectedHostId, setSelectedHostId] = useState(() => hosts[0]?.hostId ?? '')
+  const [remotePath, setRemotePath] = useState('')
+
+  const selectedHostAvailable = hosts.some((h) => h.hostId === selectedHostId)
+  const activeHostId = selectedHostAvailable ? selectedHostId : (hosts[0]?.hostId ?? '')
+  const canSubmit = activeHostId !== '' && remotePath.trim().length > 0 && !submitting
 
   const handleSubmit = async () => {
     if (!canSubmit) return
-    await addRemoteProject({ hostId: selectedHostId, path: remotePath.trim() })
+    await addRemoteProject({ hostId: activeHostId, path: remotePath.trim() })
   }
 
   const handleKey = (e: React.KeyboardEvent) => {
@@ -96,7 +121,7 @@ export default function AddRemoteProjectDialog() {
             <select
               autoFocus
               className="create-input"
-              value={selectedHostId}
+              value={activeHostId}
               onChange={(e) => setSelectedHostId(e.target.value)}
               onKeyDown={handleKey}
             >

--- a/src/renderer/components/BroadcastDialog.tsx
+++ b/src/renderer/components/BroadcastDialog.tsx
@@ -5,16 +5,6 @@ export default function BroadcastDialog() {
   const open = useSessionsStore((s) => s.broadcastDialogOpen)
   const selectedIds = useSessionsStore((s) => s.selectedIds)
   const closeBroadcastDialog = useSessionsStore((s) => s.closeBroadcastDialog)
-  const clearSelection = useSessionsStore((s) => s.clearSelection)
-  const [command, setCommand] = useState('')
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    if (open) {
-      setCommand('')
-      setTimeout(() => inputRef.current?.focus(), 0)
-    }
-  }, [open])
 
   useEffect(() => {
     if (open && selectedIds.size === 0) {
@@ -23,6 +13,21 @@ export default function BroadcastDialog() {
   }, [open, selectedIds.size, closeBroadcastDialog])
 
   if (!open) return null
+
+  return <BroadcastDialogContent />
+}
+
+function BroadcastDialogContent() {
+  const selectedIds = useSessionsStore((s) => s.selectedIds)
+  const closeBroadcastDialog = useSessionsStore((s) => s.closeBroadcastDialog)
+  const clearSelection = useSessionsStore((s) => s.clearSelection)
+  const [command, setCommand] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => inputRef.current?.focus(), 0)
+    return () => clearTimeout(timeout)
+  }, [])
 
   const handleSend = async () => {
     if (!command.trim()) return

--- a/src/renderer/components/SessionCanvas.tsx
+++ b/src/renderer/components/SessionCanvas.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
+import { useEffect, useRef, useState, useCallback, useMemo, useLayoutEffect } from 'react'
 import { useSessionsStore } from '../stores/sessions'
 import { useProjectsStore } from '../stores/projects'
 import { useCanvasStore } from '../stores/canvas'
@@ -91,17 +91,18 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
   const panXRef = useRef(panX)
   const panYRef = useRef(panY)
   const zoomRef = useRef(zoom)
-  panXRef.current = panX
-  panYRef.current = panY
-  zoomRef.current = zoom
 
   // Zoom-to-open state
   const thresholdCrossedAtRef = useRef<number | null>(null)
   const isAnimatingPanRef = useRef(false)
   const zoomOpenFiredRef = useRef(false)
   const prevMorphActiveRef = useRef(false)
-  const broadcastDialogOpenRef = useRef(broadcastDialogOpen)
-  broadcastDialogOpenRef.current = broadcastDialogOpen
+
+  useLayoutEffect(() => {
+    panXRef.current = panX
+    panYRef.current = panY
+    zoomRef.current = zoom
+  }, [panX, panY, zoom])
 
   // Reset the zoom-open latch when a morph ends without the session opening
   // (cancel via Escape). If the session opens, SessionCanvas unmounts so this
@@ -126,6 +127,30 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
     return map
   }, [sessions])
 
+  const { positions: resolvedClusterPositions, hasDefaultedPositions } = useMemo(() => {
+    const positions = { ...clusterPositions }
+    let changed = false
+    let idx = Object.keys(positions).length
+
+    for (const projectPath of clusters.keys()) {
+      if (!positions[projectPath]) {
+        positions[projectPath] = {
+          x: (idx % 3) * (CLUSTER_WIDTH + CLUSTER_GAP) + CLUSTER_GAP,
+          y: Math.floor(idx / 3) * 400 + CLUSTER_GAP,
+        }
+        idx++
+        changed = true
+      }
+    }
+
+    return { positions, hasDefaultedPositions: changed }
+  }, [clusters, clusterPositions])
+  const clusterPositionsRef = useRef<Record<string, { x: number; y: number }>>({})
+
+  useLayoutEffect(() => {
+    clusterPositionsRef.current = resolvedClusterPositions
+  }, [resolvedClusterPositions])
+
   // Load persisted state
   useEffect(() => {
     Promise.all([window.api.getCanvasState(), window.api.getClusterPositions()]).then(
@@ -143,34 +168,16 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
     )
   }, [])
 
-  // Assign default positions to new clusters
+  // Persist default positions for new clusters.
   useEffect(() => {
-    if (!loaded) return
-    let changed = false
-    const updated = { ...clusterPositions }
-    let idx = Object.keys(updated).length
-
-    for (const projectPath of clusters.keys()) {
-      if (!updated[projectPath]) {
-        updated[projectPath] = {
-          x: (idx % 3) * (CLUSTER_WIDTH + CLUSTER_GAP) + CLUSTER_GAP,
-          y: Math.floor(idx / 3) * 400 + CLUSTER_GAP,
-        }
-        idx++
-        changed = true
-      }
-    }
-
-    if (changed) {
-      setClusterPositions(updated)
-      window.api.saveClusterPositions(updated)
-    }
-  }, [clusters, loaded, clusterPositions])
+    if (!loaded || !hasDefaultedPositions) return
+    window.api.saveClusterPositions(resolvedClusterPositions)
+  }, [hasDefaultedPositions, loaded, resolvedClusterPositions])
 
   // Register panToCluster in canvas store
   useEffect(() => {
     const panToClusterFn = (projectPath: string) => {
-      const pos = clusterPositions[projectPath]
+      const pos = resolvedClusterPositions[projectPath]
       if (!pos) return
       const viewport = viewportRef.current
       if (!viewport) return
@@ -215,7 +222,7 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
     }
 
     setPanToCluster(panToClusterFn)
-  }, [clusterPositions, setPanToCluster])
+  }, [resolvedClusterPositions, setPanToCluster])
 
   // Track viewport size. Depends on `loaded` because pre-load renders null (ref
   // is unattached); effect must re-run once the DOM mounts.
@@ -358,10 +365,7 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
       // Zoom-to-open detection (wheel-only path).
       // Guards: no modal, not mid-drag, no automated pan, not already fired.
       const armed =
-        !broadcastDialogOpenRef.current &&
-        !dragging &&
-        !isAnimatingPanRef.current &&
-        !zoomOpenFiredRef.current
+        !broadcastDialogOpen && !dragging && !isAnimatingPanRef.current && !zoomOpenFiredRef.current
       if (!armed) {
         thresholdCrossedAtRef.current = null
         return
@@ -413,7 +417,7 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
         thumbnail: thumbnails[sessionId],
       })
     },
-    [panX, panY, persistCanvas, dragging, sessions, thumbnails, onZoomOpen]
+    [panX, panY, persistCanvas, broadcastDialogOpen, dragging, sessions, thumbnails, onZoomOpen]
   )
 
   const handleSelect = useCallback(
@@ -465,12 +469,14 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
   }, [dragging, zoom, panX, panY, persistCanvas])
 
   const handleClusterDrag = useCallback((projectPath: string, pos: { x: number; y: number }) => {
-    setClusterPositions((prev) => ({ ...prev, [projectPath]: pos }))
+    const next = { ...clusterPositionsRef.current, [projectPath]: pos }
+    clusterPositionsRef.current = next
+    setClusterPositions(next)
   }, [])
 
   const handleClusterDragEnd = useCallback(() => {
-    window.api.saveClusterPositions(clusterPositions)
-  }, [clusterPositions])
+    window.api.saveClusterPositions(clusterPositionsRef.current)
+  }, [])
 
   if (!loaded) return null
 
@@ -505,7 +511,7 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
             sessions={clusterSessions}
             thumbnails={thumbnails}
             accentColor={hashColor(projectPath)}
-            position={clusterPositions[projectPath] || { x: 0, y: 0 }}
+            position={resolvedClusterPositions[projectPath] || { x: 0, y: 0 }}
             zoom={zoom}
             isOrphaned={!knownPaths.has(projectPath)}
             onDrag={handleClusterDrag}
@@ -519,7 +525,7 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
         clusters={Array.from(clusters.entries()).map(([projectPath, clusterSessions]) => ({
           projectPath,
           projectName: clusterSessions[0].projectName,
-          position: clusterPositions[projectPath] || { x: 0, y: 0 },
+          position: resolvedClusterPositions[projectPath] || { x: 0, y: 0 },
           color: hashColor(projectPath),
         }))}
         zoom={zoom}


### PR DESCRIPTION
## Summary

Fixes the ESLint failures that reproduce under the fresh CI dependency install with ESLint 10, and fixes the Linux production smoke-test startup failures exposed on the PR.

## What Changed

- Moved `App` state initialization before the IPC subscription that uses the state setters.
- Moved dialog-local form state into mounted-only inner components so opening a dialog no longer resets state synchronously in an effect.
- Updated `SessionCanvas` to avoid render-time ref writes and to derive default cluster positions without a synchronous `setState` effect.
- Externalized Electron runtime modules in the Electron Vite build so production startup loads `electron` and native `node-pty` correctly from the runtime/install tree.
- Made React DevTools installation a dev-only dynamic import so production startup does not eagerly evaluate devtools installer code.

## Root Cause

Local `node_modules` had been resolving ESLint 9, while CI runs `npm ci` and uses ESLint 10 plus stricter React hooks rules. Refreshing dependencies locally reproduced the CI lint failures.

The smoke test also showed the production main bundle was bundling the `electron` npm package and `node-pty` native loader. In CI this crashed during app load before the renderer registered.

## Validation

- `npx eslint .`
- `npx prettier --check .`
- `npx tsc --noEmit`
- `npx vitest run`
- `npx electron-vite build`
- `xvfb-run --auto-servernum --server-args='-screen 0 1280x800x24' node .github/scripts/smoke-test.mjs`