### PR TITLE
[codex] launch remote sessions

### DIFF
--- a/plans/issue-11-remote-sessions.md
+++ b/plans/issue-11-remote-sessions.md
@@ -1,0 +1,172 @@
+# Plan: Remote Sessions End-to-End
+
+> Source issue: [pmatos/cc-pewpew#11](https://github.com/pmatos/cc-pewpew/issues/11)  
+> Parent PRD: [pmatos/cc-pewpew#8](https://github.com/pmatos/cc-pewpew/issues/8)  
+> Prerequisite: [pmatos/cc-pewpew#10](https://github.com/pmatos/cc-pewpew/issues/10) is closed and its remote-project registry/UI work is present on `origin/main`.
+
+## Current Baseline
+
+- `Project.hostId` and the remote project registry are present. `src/main/remote-project-registry.ts` maps remote projects into sidebar `Project` records with empty local worktree data.
+- `Session` does not yet persist `hostId` or connection state. All creation, revive, restore, kill, thumbnail, and review paths assume local filesystem + local `tmux`.
+- `src/main/host-connection.ts` is a stateless SSH helper for host tests and remote repo validation. It does not yet maintain a ControlMaster, reverse tunnel, persistent state, or PTY attach process.
+- `src/main/hook-server.ts` listens on one local socket only and dispatches events without origin tagging.
+- `src/main/hook-installer.ts` installs local hooks into a local worktree and references a local `notify.sh`.
+- Renderer session cards already have chip/pill styling patterns, but session cards and detail view do not know host labels or remote connection state.
+
+## Architectural Decisions
+
+- **Session host identity**: Add `Session.hostId: string | null`. Missing legacy values load as `null`. Remote sessions inherit host identity from the selected project.
+- **Connection state**: Add a narrow session-visible connection state, separate from Claude activity status: `pending | live | offline | auth-failed | unreachable`. Local sessions can report `live` while active and do not show remote-only recovery UI.
+- **HostConnection owner**: Keep all SSH process shape inside `HostConnection`. Callers ask for `ensureLive(hostId)`, `exec(hostId, argv, opts)`, `spawnAttach(hostId, argv, opts)`, and `release(hostId)`.
+- **Control connection lifetime**: Open lazily on first remote session use, retain while sessions reference the host, and release on app quit or when the last live session for that host is torn down.
+- **Remote shell safety**: Preserve the current invariant that user paths are argv entries, not string-concatenated shell snippets. Any unavoidable `sh -c` script receives paths through positional parameters.
+- **Hook origin boundary**: Refactor the hook server around origin sockets. Every accepted event is tagged with `originHostId`, and session events are dropped if their matched session has a different `hostId`.
+- **Remote bootstrap**: New `HostBootstrap` module performs dependency checks, StreamLocalBindUnlink validation, versioned notify script install, and remote breadcrumb install before creating the first remote session on a host.
+- **Review remains local-only**: For issue 11, disable review UI/actions for remote sessions with a clear disabled state. Remote git diff/list-branch handlers stay out of scope.
+
+## Phase 1: Shared Model and Host Lookup
+
+### What to build
+
+Extend shared types and session manager plumbing so local and remote sessions can be represented without changing behavior yet. Add helpers to resolve a project path to either a local project or a persisted remote project/host pair. Make all old persisted sessions load as local.
+
+### Acceptance criteria
+
+- [ ] `Session.hostId: string | null` is defined in `src/shared/types.ts`.
+- [ ] `Session.connectionState` or equivalent remote-state field is defined without overloading `SessionStatus`.
+- [ ] `restoreSessions()` backfills missing `hostId` as `null`.
+- [ ] `createSession()` can resolve remote project metadata by `(hostId, projectPath)` while preserving the existing local call shape from the renderer.
+- [ ] Host deletion protection in `host-registry.ts` becomes active for newly persisted remote sessions.
+- [ ] Local session creation, restore, revive, kill, and remove behavior remains unchanged.
+
+## Phase 2: Persistent HostConnection
+
+### What to build
+
+Turn `HostConnection` from standalone functions into a process-owning manager while retaining the existing `testConnection()` and `validateRemoteRepo()` behavior. Introduce ControlPath and per-host IPC socket path allocation under `CONFIG_DIR`.
+
+### Acceptance criteria
+
+- [ ] `HostConnection.ensureLive(host)` starts `ssh -N` with `ControlMaster=yes`, `ControlPersist=10m`, `ExitOnForwardFailure=yes`, keepalives, and `-R /tmp/cc-pewpew-{uid}.sock:<local ipc-host socket>`.
+- [ ] Repeated `ensureLive()` calls for the same host reuse the in-flight/live connection.
+- [ ] `exec(host, argv)` multiplexes through the host's ControlPath and preserves argv quoting.
+- [ ] `spawnAttach(host, argv)` returns a child suitable for `node-pty` bridging via local `ssh ... tmux attach-session ...`.
+- [ ] SSH failures are classified through the existing exit parser and surfaced as typed errors.
+- [ ] `release(hostId)` tears down only when no session still references the host.
+- [ ] Existing `testConnection()` and `validateRemoteRepo()` tests still pass.
+
+## Phase 3: Multi-Origin HookIpcServer
+
+### What to build
+
+Replace the single module-level hook server with a multi-socket server that owns the local socket plus one socket per connected host. Route origin-tagged events into session-manager validation before broadcasting.
+
+### Acceptance criteria
+
+- [ ] The existing local `ipc.sock` and `socket-path` breadcrumb still work for local sessions.
+- [ ] `listenHost(hostId)` creates/listens on `ipc-{hostId}.sock` and returns the socket path used by `HostConnection`.
+- [ ] Every dispatched hook event includes `originHostId: string | null`.
+- [ ] `handleHookEvent()` receives origin and rejects mismatched-origin session events.
+- [ ] Mismatch drops are logged with session id, expected host, and origin host.
+- [ ] Unit tests use real Unix sockets in temp directories for local and host origins.
+- [ ] Local hook behavior remains unchanged end-to-end.
+
+## Phase 4: Remote Bootstrap
+
+### What to build
+
+Add `src/main/host-bootstrap.ts` as a deterministic orchestration module around a minimal connection interface. Bootstrap checks remote dependencies and installs the versioned hook artifacts.
+
+### Acceptance criteria
+
+- [ ] Probes `tmux`, `git`, `jq`, `socat`, and `claude` on the remote PATH.
+- [ ] Checks whether sshd supports the required StreamLocalBindUnlink behavior for the reverse Unix socket.
+- [ ] Installs `~/.config/cc-pewpew/hooks/notify-v1.sh` if absent or wrong version.
+- [ ] Writes a remote breadcrumb pointing at `/tmp/cc-pewpew-{uid}.sock`.
+- [ ] Returns typed, actionable errors for missing deps and StreamLocalBindUnlink failure.
+- [ ] Caches successful bootstrap per host per app session.
+- [ ] Unit tests cover all-deps-present, selective missing dependency, and already-installed script cases with fake exec responses.
+
+## Phase 5: Remote Session Creation and PTY Attach
+
+### What to build
+
+Branch session creation on `hostId`. For remote projects, create the worktree and tmux session on the remote host, install per-worktree hooks pointing at the versioned remote notify script, and attach via SSH-backed PTY.
+
+### Acceptance criteria
+
+- [ ] Remote `git worktree add` runs on the remote host under `{projectPath}/.claude/worktrees/{worktreeName}`.
+- [ ] Remote branch fallback mirrors local behavior: try `-b cc-pewpew/{worktreeName}`, then retry without `-b`.
+- [ ] Remote hook config is installed into `{worktreePath}/.claude/settings.local.json`.
+- [ ] The hook command uses the absolute remote `notify-v1.sh` path.
+- [ ] Remote tmux creation runs `tmux new-session -d -s cc-pewpew-{id} -c {worktreePath} claude --dangerously-skip-permissions`.
+- [ ] Remote attach streams into the existing renderer terminal data path.
+- [ ] Missing dependency/bootstrap errors block creation and surface a specific message.
+- [ ] Concurrent sessions on the same remote project get independent worktree hook files.
+
+## Phase 6: Remote Session Lifecycle
+
+### What to build
+
+Make kill, revive, remove, restore, thumbnails, and cleanup respect host identity. Keep v1 lazy: app startup does not connect to remote hosts automatically.
+
+### Acceptance criteria
+
+- [ ] `restoreSessions()` materializes remote sessions without opening SSH connections.
+- [ ] Restored remote sessions show a non-live state until user-initiated open/revive.
+- [ ] Opening/reviving a remote session ensures host connection, probes tmux, and attaches or recreates with `claude --continue`.
+- [ ] Killing a remote session detaches PTY and kills the remote tmux session, leaving the remote worktree intact.
+- [ ] Removing a remote session removes the remote worktree only when the current remove-worktree action is requested.
+- [ ] Thumbnail capture includes remote sessions via `tmux capture-pane` over the multiplexed connection.
+- [ ] App quit releases host connections and stops all origin sockets.
+- [ ] Local lifecycle behavior remains unchanged.
+
+## Phase 7: Renderer Host and Connection UI
+
+### What to build
+
+Surface host identity and connection state in the canvas and detail view using the existing host registry store and current visual language.
+
+### Acceptance criteria
+
+- [ ] Session card thumbnail shows a bottom-left host pill for remote sessions only.
+- [ ] Session card shows a connection-status dot for remote sessions that reflects `pending`, `live`, `offline`, `auth-failed`, or `unreachable`.
+- [ ] Detail pane header/status area shows host label plus connection state.
+- [ ] Dead/unreachable remote sessions show a reconnect/restart action that calls the existing revive/open path.
+- [ ] Review overlay entry is disabled for remote sessions with a concise "coming soon" state.
+- [ ] Local session cards do not gain extra host noise.
+
+## Phase 8: Tests and Validation
+
+### What to build
+
+Land tests around the new deep modules and run the existing compile/test suite. Use CDP smoke testing only if the UI changes go beyond static rendering or interaction states.
+
+### Acceptance criteria
+
+- [ ] `src/main/host-bootstrap.test.ts` covers dependency and install scenarios with fake connection responses.
+- [ ] `src/main/hook-server.test.ts` covers multi-origin listening, origin tagging, invalid JSON response handling, and host mismatch rejection.
+- [ ] Existing host validation and remote project tests pass.
+- [ ] `npm run type-check` passes.
+- [ ] `npx vitest run` passes, or any failures are documented as pre-existing and unrelated.
+- [ ] Manual smoke: create a local session to confirm unchanged behavior.
+- [ ] Manual remote smoke with a configured SSH alias: add/use remote project, create session, see terminal output, receive hook state, kill session.
+
+## Suggested Implementation Order
+
+1. Model fields and compatibility loaders.
+2. `HostConnection` manager shape with tests around command argv/control path construction.
+3. `HookIpcServer` refactor plus socket tests.
+4. `HostBootstrap` and remote notify script rendering.
+5. Remote branches in `session-manager` and `pty-manager`.
+6. Thumbnail/lifecycle cleanup.
+7. Renderer host/status affordances.
+8. Full validation pass.
+
+## Known Risks
+
+- The current `pty-manager` stores only `node-pty` entries and local tmux names. Remote PTY entries need enough host metadata to kill/capture/reattach the right tmux session.
+- `handleHookEvent()` currently matches primarily by `cwd.startsWith(worktreePath)`. That remains useful for remote events, but origin validation must run after matching and before mutation.
+- `spawnAttach()` with `node-pty` will run a local `ssh` process, not a local tmux process. Resize/write paths should continue to work, but exit classification needs to account for SSH termination.
+- `removeSession()` currently calls both `destroyPty()` and `removeWorktree()`, and `promptCleanup()` may call `removeSession()` after already removing the worktree. Remote implementation should avoid double remote calls where possible.
+- The remote review pane is out of scope; all renderer entry points that open review need a remote guard.

--- a/src/main/hook-installer.ts
+++ b/src/main/hook-installer.ts
@@ -3,13 +3,14 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { join } from 'path'
 import { CONFIG_DIR } from './config'
+import type { ExecResult } from './host-connection'
 
 const execFileAsync = promisify(execFile)
 
 const NOTIFY_SCRIPT = join(CONFIG_DIR, 'hooks', 'notify.sh')
 
-function buildHooks(): Record<string, unknown[]> {
-  const hook = { type: 'command', command: NOTIFY_SCRIPT }
+function buildHooks(notifyScript: string): Record<string, unknown[]> {
+  const hook = { type: 'command', command: notifyScript }
   return {
     SessionStart: [{ hooks: [hook] }],
     Stop: [{ hooks: [hook] }],
@@ -17,6 +18,10 @@ function buildHooks(): Record<string, unknown[]> {
     SessionEnd: [{ hooks: [hook] }],
     Notification: [{ hooks: [hook] }],
   }
+}
+
+function ccPewpewHookJson(notifyScript: string): string {
+  return JSON.stringify(buildHooks(notifyScript))
 }
 
 export async function installHooks(
@@ -37,7 +42,7 @@ export async function installHooks(
     }
   }
 
-  const newHooks = buildHooks()
+  const newHooks = buildHooks(NOTIFY_SCRIPT)
   const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>
   const merged: Record<string, unknown[]> = { ...existingHooks }
 
@@ -54,6 +59,34 @@ export async function installHooks(
 
   if (!skipGitignore) {
     ensureGitignore(projectPath, '.claude/settings.local.json')
+  }
+}
+
+export async function installRemoteHooks(
+  execRemote: (argv: string[], opts?: { timeoutMs?: number }) => Promise<ExecResult>,
+  worktreePath: string,
+  notifyScriptPath: string
+): Promise<void> {
+  const hooksJson = ccPewpewHookJson(notifyScriptPath)
+  const script =
+    'set -e\n' +
+    'claude_dir="$1/.claude"\n' +
+    'settings="$claude_dir/settings.local.json"\n' +
+    'mkdir -p "$claude_dir"\n' +
+    'if [ -s "$settings" ]; then cat "$settings"; else printf "{}"; fi |\n' +
+    'jq --argjson newHooks "$2" \'\n' +
+    '  .hooks = (.hooks // {}) |\n' +
+    '  reduce ($newHooks | keys[]) as $k (.;\n' +
+    '    .hooks[$k] = (((.hooks[$k] // []) | map(select(((. | tostring) | contains("cc-pewpew")) | not))) + $newHooks[$k])\n' +
+    '  )\n' +
+    '\' > "$settings.tmp"\n' +
+    'mv "$settings.tmp" "$settings"\n'
+  const result = await execRemote(['sh', '-c', script, '_', worktreePath, hooksJson], {
+    timeoutMs: 15000,
+  })
+  if (result.timedOut || result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`
+    throw new Error(`Failed to install remote hooks: ${detail}`)
   }
 }
 

--- a/src/main/hook-server.test.ts
+++ b/src/main/hook-server.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createConnection } from 'net'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  configDir: '',
+  hookResult: true,
+  hookCalls: [] as {
+    method: string
+    params: Record<string, unknown>
+    originHostId: string | null
+  }[],
+  broadcasts: [] as { channel: string; payload: unknown }[],
+}))
+
+vi.mock('./config', () => ({
+  get CONFIG_DIR() {
+    return state.configDir
+  },
+}))
+
+vi.mock('./window-registry', () => ({
+  broadcastToAll: (channel: string, payload: unknown) => {
+    state.broadcasts.push({ channel, payload })
+  },
+}))
+
+vi.mock('./session-manager', () => ({
+  handleHookEvent: (
+    method: string,
+    params: Record<string, unknown>,
+    originHostId: string | null
+  ) => {
+    state.hookCalls.push({ method, params, originHostId })
+    return state.hookResult
+  },
+}))
+
+async function loadHookServer(): Promise<typeof import('./hook-server')> {
+  vi.resetModules()
+  hookServer = await import('./hook-server')
+  return hookServer
+}
+
+let hookServer: typeof import('./hook-server') | null = null
+
+function send(socketPath: string, payload: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(socketPath)
+    let response = ''
+    socket.on('connect', () => {
+      socket.write(JSON.stringify(payload) + '\n')
+    })
+    socket.on('data', (data) => {
+      response += data.toString()
+      if (response.includes('\n')) {
+        socket.end()
+        resolve(JSON.parse(response.trim()))
+      }
+    })
+    socket.on('error', reject)
+  })
+}
+
+describe('hook-server', () => {
+  beforeEach(() => {
+    state.configDir = mkdtempSync(join(tmpdir(), 'cc-pewpew-hook-'))
+    state.hookResult = true
+    state.hookCalls = []
+    state.broadcasts = []
+  })
+
+  afterEach(async () => {
+    hookServer?.stopHookServer()
+    hookServer = null
+    rmSync(state.configDir, { recursive: true, force: true })
+  })
+
+  it('listens on local and per-host sockets and tags originHostId', async () => {
+    const mod = await loadHookServer()
+    mod.startHookServer()
+    const hostSocket = mod.listenHookServerForHost('h1')
+
+    await send(join(state.configDir, 'ipc.sock'), {
+      jsonrpc: '2.0',
+      method: 'session.activity',
+      params: { cwd: '/local' },
+      id: 1,
+    })
+    await send(hostSocket, {
+      jsonrpc: '2.0',
+      method: 'session.activity',
+      params: { cwd: '/remote' },
+      id: 2,
+    })
+
+    expect(state.hookCalls.map((c) => c.originHostId)).toEqual([null, 'h1'])
+    expect(
+      state.broadcasts.map((b) => (b.payload as { originHostId: string | null }).originHostId)
+    ).toEqual([null, 'h1'])
+  })
+
+  it('does not broadcast events dropped by session-origin validation', async () => {
+    const mod = await loadHookServer()
+    mod.startHookServer()
+    const hostSocket = mod.listenHookServerForHost('h1')
+    state.hookResult = false
+
+    const response = await send(hostSocket, {
+      jsonrpc: '2.0',
+      method: 'session.stop',
+      params: { session_id: 's1' },
+      id: 3,
+    })
+
+    expect(response).toMatchObject({ jsonrpc: '2.0', result: 'ok', id: 3 })
+    expect(state.hookCalls).toHaveLength(1)
+    expect(state.hookCalls[0].originHostId).toBe('h1')
+    expect(state.broadcasts).toEqual([])
+  })
+})

--- a/src/main/hook-server.ts
+++ b/src/main/hook-server.ts
@@ -21,7 +21,10 @@ const METHODS = new Set([
 const servers = new Map<string, { server: Server; socketPath: string }>()
 
 function originKey(originHostId: string | null): string {
-  return originHostId ?? 'local'
+  // Namespace local vs host keys so a hand-edited config with
+  // hostId === "local" can't collide with the real local listener and tear
+  // down (or reuse) the wrong server.
+  return originHostId === null ? 'local' : `host:${originHostId}`
 }
 
 function socketPathForOrigin(originHostId: string | null): string {

--- a/src/main/hook-server.ts
+++ b/src/main/hook-server.ts
@@ -5,8 +5,8 @@ import { broadcastToAll } from './window-registry'
 import { CONFIG_DIR } from './config'
 import { handleHookEvent } from './session-manager'
 
-const SOCKET_PATH = join(CONFIG_DIR, 'ipc.sock')
-const SOCKET_BREADCRUMB = join(CONFIG_DIR, 'socket-path')
+const LOCAL_SOCKET_PATH = join(CONFIG_DIR, 'ipc.sock')
+const LOCAL_SOCKET_BREADCRUMB = join(CONFIG_DIR, 'socket-path')
 
 const METHODS = new Set([
   'ping',
@@ -17,10 +17,28 @@ const METHODS = new Set([
   'session.notification',
 ])
 
-let server: Server | null = null
+const servers = new Map<string, { server: Server; socketPath: string }>()
+
+function originKey(originHostId: string | null): string {
+  return originHostId ?? 'local'
+}
+
+function socketPathForOrigin(originHostId: string | null): string {
+  return originHostId ? join(CONFIG_DIR, `ipc-${originHostId}.sock`) : LOCAL_SOCKET_PATH
+}
+
+function unlinkIfPresent(path: string): void {
+  if (!existsSync(path)) return
+  try {
+    unlinkSync(path)
+  } catch {
+    // ignore stale socket cleanup failures; listen() will surface real errors
+  }
+}
 
 function handleRequest(
-  raw: string
+  raw: string,
+  originHostId: string | null
 ): { jsonrpc: string; result?: unknown; error?: unknown; id: unknown } | null {
   let req: { jsonrpc?: string; method?: string; params?: unknown; id?: unknown }
   try {
@@ -49,18 +67,24 @@ function handleRequest(
     return { jsonrpc: '2.0', result: 'pong', id: req.id ?? null }
   }
 
-  // Update session state in session manager
-  handleHookEvent(req.method, (req.params as Record<string, unknown>) ?? {})
+  const accepted = handleHookEvent(
+    req.method,
+    (req.params as Record<string, unknown>) ?? {},
+    originHostId
+  )
 
-  broadcastToAll('hook:event', {
-    method: req.method,
-    params: req.params,
-  })
+  if (accepted) {
+    broadcastToAll('hook:event', {
+      method: req.method,
+      params: req.params,
+      originHostId,
+    })
+  }
 
   return { jsonrpc: '2.0', result: 'ok', id: req.id ?? null }
 }
 
-function handleConnection(socket: Socket): void {
+function handleConnection(socket: Socket, originHostId: string | null): void {
   let buffer = ''
 
   socket.on('data', (data) => {
@@ -73,18 +97,16 @@ function handleConnection(socket: Socket): void {
 
       if (!line) continue
 
-      const response = handleRequest(line)
+      const response = handleRequest(line, originHostId)
       if (response) {
         socket.write(JSON.stringify(response) + '\n')
       }
     }
-
-    // Handle single message without trailing newline (connection close flushes)
   })
 
   socket.on('end', () => {
     if (buffer.trim()) {
-      const response = handleRequest(buffer.trim())
+      const response = handleRequest(buffer.trim(), originHostId)
       if (response) {
         socket.write(JSON.stringify(response) + '\n')
       }
@@ -96,40 +118,55 @@ function handleConnection(socket: Socket): void {
   })
 }
 
-export function startHookServer(): void {
-  // Clean up stale socket
-  if (existsSync(SOCKET_PATH)) {
-    try {
-      unlinkSync(SOCKET_PATH)
-    } catch {
-      // ignore
+function listenOrigin(originHostId: string | null): string {
+  const key = originKey(originHostId)
+  const existing = servers.get(key)
+  if (existing) return existing.socketPath
+
+  const socketPath = socketPathForOrigin(originHostId)
+  unlinkIfPresent(socketPath)
+
+  const server = createServer((socket) => handleConnection(socket, originHostId))
+  server.listen(socketPath, () => {
+    if (originHostId === null) {
+      writeFileSync(LOCAL_SOCKET_BREADCRUMB, socketPath)
     }
-  }
-
-  server = createServer(handleConnection)
-
-  server.listen(SOCKET_PATH, () => {
-    writeFileSync(SOCKET_BREADCRUMB, SOCKET_PATH)
   })
 
   server.on('error', (err) => {
     console.error('Hook server error:', err)
   })
+
+  servers.set(key, { server, socketPath })
+  return socketPath
+}
+
+export function startHookServer(): void {
+  listenOrigin(null)
+}
+
+export function listenHookServerForHost(hostId: string): string {
+  return listenOrigin(hostId)
+}
+
+export function stopHookServerForHost(hostId: string): void {
+  const key = originKey(hostId)
+  const entry = servers.get(key)
+  if (!entry) return
+  entry.server.close()
+  servers.delete(key)
+  unlinkIfPresent(entry.socketPath)
 }
 
 export function stopHookServer(): void {
-  if (server) {
-    server.close()
-    server = null
+  for (const [key, entry] of servers) {
+    entry.server.close()
+    servers.delete(key)
+    unlinkIfPresent(entry.socketPath)
   }
 
   try {
-    if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH)
-  } catch {
-    // ignore
-  }
-  try {
-    if (existsSync(SOCKET_BREADCRUMB)) unlinkSync(SOCKET_BREADCRUMB)
+    if (existsSync(LOCAL_SOCKET_BREADCRUMB)) unlinkSync(LOCAL_SOCKET_BREADCRUMB)
   } catch {
     // ignore
   }

--- a/src/main/hook-server.ts
+++ b/src/main/hook-server.ts
@@ -3,6 +3,7 @@ import { writeFileSync, unlinkSync, existsSync } from 'fs'
 import { join } from 'path'
 import { broadcastToAll } from './window-registry'
 import { CONFIG_DIR } from './config'
+import { sanitizeHostIdForPath } from './host-connection'
 import { handleHookEvent } from './session-manager'
 
 const LOCAL_SOCKET_PATH = join(CONFIG_DIR, 'ipc.sock')
@@ -24,7 +25,11 @@ function originKey(originHostId: string | null): string {
 }
 
 function socketPathForOrigin(originHostId: string | null): string {
-  return originHostId ? join(CONFIG_DIR, `ipc-${originHostId}.sock`) : LOCAL_SOCKET_PATH
+  // Sanitize hostId so a malformed/hand-edited value can't escape CONFIG_DIR
+  // through path traversal segments.
+  return originHostId
+    ? join(CONFIG_DIR, `ipc-${sanitizeHostIdForPath(originHostId)}.sock`)
+    : LOCAL_SOCKET_PATH
 }
 
 function unlinkIfPresent(path: string): void {

--- a/src/main/host-bootstrap.test.ts
+++ b/src/main/host-bootstrap.test.ts
@@ -18,7 +18,7 @@ function fakeConnection(calls: string[][], depsStdout = '\n'): HostBootstrapConn
       const script = argv[2]
       if (script.includes('command -v')) return ok(depsStdout)
       if (script === 'test -S "$1"') return ok()
-      if (script.includes('printf "%s" "$HOME"')) return ok('/home/dev')
+      if (script.includes('XDG_CONFIG_HOME')) return ok('/home/dev/.config')
       if (script.includes('notify-v')) return ok()
       return ok()
     },

--- a/src/main/host-bootstrap.test.ts
+++ b/src/main/host-bootstrap.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import {
+  bootstrapHost,
+  HostBootstrapError,
+  NOTIFY_SCRIPT_VERSION,
+  type HostBootstrapConnection,
+} from './host-bootstrap'
+import type { ExecResult } from './host-connection'
+
+function ok(stdout = ''): ExecResult {
+  return { stdout, stderr: '', code: 0, timedOut: false }
+}
+
+function fakeConnection(calls: string[][], depsStdout = '\n'): HostBootstrapConnection {
+  return {
+    exec: async (argv) => {
+      calls.push(argv)
+      const script = argv[2]
+      if (script.includes('command -v')) return ok(depsStdout)
+      if (script === 'test -S "$1"') return ok()
+      if (script.includes('printf "%s" "$HOME"')) return ok('/home/dev')
+      if (script.includes('notify-v')) return ok()
+      return ok()
+    },
+  }
+}
+
+describe('bootstrapHost', () => {
+  it('probes deps, checks the remote socket, and installs notify-v1.sh', async () => {
+    const calls: string[][] = []
+    const result = await bootstrapHost(
+      'host-bootstrap-all-present',
+      fakeConnection(calls),
+      '/tmp/ipc'
+    )
+
+    expect(result).toEqual({
+      notifyScriptPath: '/home/dev/.config/cc-pewpew/hooks/notify-v1.sh',
+      remoteSocketPath: '/tmp/ipc',
+    })
+    expect(calls.some((argv) => argv.includes('tmux') && argv.includes('claude'))).toBe(true)
+    expect(calls.some((argv) => argv.includes('/tmp/ipc'))).toBe(true)
+    expect(
+      calls.some((argv) => argv.includes('/home/dev/.config/cc-pewpew/hooks/notify-v1.sh'))
+    ).toBe(true)
+  })
+
+  it('returns a typed missing-deps error with the selective missing set', async () => {
+    const calls: string[][] = []
+    await expect(
+      bootstrapHost('host-bootstrap-missing', fakeConnection(calls, ' jq claude\n'), '/tmp/ipc')
+    ).rejects.toMatchObject({
+      kind: 'missing-deps',
+      missingDeps: ['jq', 'claude'],
+    } satisfies Partial<HostBootstrapError>)
+  })
+
+  it('installs through a version guard so already-installed notify scripts are kept', async () => {
+    const calls: string[][] = []
+    await bootstrapHost('host-bootstrap-version-guard', fakeConnection(calls), '/tmp/ipc')
+
+    const installCall = calls.find((argv) =>
+      argv.some((part) => part.includes(`notify-v${NOTIFY_SCRIPT_VERSION}.sh`))
+    )
+    expect(installCall).toBeDefined()
+    expect(installCall?.[2]).toContain('grep -q "CC_PEWPEW_NOTIFY_VERSION=$5"')
+    expect(installCall).toContain(String(NOTIFY_SCRIPT_VERSION))
+  })
+})

--- a/src/main/host-bootstrap.ts
+++ b/src/main/host-bootstrap.ts
@@ -1,0 +1,146 @@
+import { posix } from 'path'
+import type { ExecResult } from './host-connection'
+
+export const NOTIFY_SCRIPT_VERSION = 1
+
+const REQUIRED_DEPS = ['tmux', 'git', 'jq', 'socat', 'claude'] as const
+
+const notifyScript = `#!/usr/bin/env bash
+# cc-pewpew notify script v${NOTIFY_SCRIPT_VERSION}
+CC_PEWPEW_NOTIFY_VERSION=${NOTIFY_SCRIPT_VERSION}
+set -euo pipefail
+
+INPUT=$(cat)
+CC_PEWPEW_DIR="\${XDG_CONFIG_HOME:-$HOME/.config}/cc-pewpew"
+SOCKET=$(cat "$CC_PEWPEW_DIR/hooks/socket-path" 2>/dev/null || echo "")
+if [ -z "$SOCKET" ] || [ ! -S "$SOCKET" ]; then
+  exit 0
+fi
+
+EVENT_NAME=$(echo "$INPUT" | jq -r '.hook_event_name // empty')
+
+case "$EVENT_NAME" in
+  SessionStart)   METHOD="session.start" ;;
+  Stop)           METHOD="session.stop" ;;
+  PostToolUse)    METHOD="session.activity" ;;
+  SessionEnd)     METHOD="session.end" ;;
+  Notification)   METHOD="session.notification" ;;
+  *)              exit 0 ;;
+esac
+
+PAYLOAD=$(printf '%s' "$INPUT" | jq -c \\
+  --arg method "$METHOD" \\
+  '{jsonrpc:"2.0",method:$method,params:.,id:null}')
+
+echo "$PAYLOAD" | socat - UNIX-CONNECT:"$SOCKET" >/dev/null 2>/dev/null || true
+`
+
+export type HostBootstrapErrorKind = 'missing-deps' | 'stream-local-bind' | 'install-failed'
+
+export class HostBootstrapError extends Error {
+  kind: HostBootstrapErrorKind
+  missingDeps: string[]
+
+  constructor(kind: HostBootstrapErrorKind, message: string, missingDeps: string[] = []) {
+    super(message)
+    this.name = 'HostBootstrapError'
+    this.kind = kind
+    this.missingDeps = missingDeps
+  }
+}
+
+export interface HostBootstrapConnection {
+  exec(argv: string[], opts?: { timeoutMs?: number }): Promise<ExecResult>
+}
+
+export interface HostBootstrapResult {
+  notifyScriptPath: string
+  remoteSocketPath: string
+}
+
+const bootstrapped = new Map<string, HostBootstrapResult>()
+
+async function expectOk(
+  result: ExecResult,
+  kind: HostBootstrapErrorKind,
+  message: string
+): Promise<void> {
+  if (result.timedOut) throw new HostBootstrapError(kind, `${message}: timed out`)
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`
+    throw new HostBootstrapError(kind, `${message}: ${detail}`)
+  }
+}
+
+export async function bootstrapHost(
+  hostId: string,
+  connection: HostBootstrapConnection,
+  remoteSocketPath: string
+): Promise<HostBootstrapResult> {
+  const cached = bootstrapped.get(hostId)
+  if (cached && cached.remoteSocketPath === remoteSocketPath) return cached
+
+  const depProbe =
+    'missing=""; for dep in "$@"; do command -v "$dep" >/dev/null 2>&1 || missing="$missing $dep"; done; printf "%s\\n" "$missing"'
+  const deps = await connection.exec(['sh', '-c', depProbe, '_', ...REQUIRED_DEPS], {
+    timeoutMs: 15000,
+  })
+  await expectOk(deps, 'missing-deps', 'Dependency probe failed')
+  const missingDeps = deps.stdout.trim().split(/\s+/).filter(Boolean)
+  if (missingDeps.length > 0) {
+    throw new HostBootstrapError(
+      'missing-deps',
+      `Remote host is missing required tools: ${missingDeps.join(', ')}`,
+      missingDeps
+    )
+  }
+
+  const socketProbe = await connection.exec(['sh', '-c', 'test -S "$1"', '_', remoteSocketPath], {
+    timeoutMs: 5000,
+  })
+  if (socketProbe.code !== 0 || socketProbe.timedOut) {
+    throw new HostBootstrapError(
+      'stream-local-bind',
+      `Remote hook socket ${remoteSocketPath} is not available; check StreamLocalBindUnlink and reverse Unix-socket forwarding`
+    )
+  }
+
+  const home = await connection.exec(['sh', '-c', 'printf "%s" "$HOME"'], { timeoutMs: 5000 })
+  await expectOk(home, 'install-failed', 'Unable to resolve remote HOME')
+  const remoteHome = home.stdout.trim()
+  if (!remoteHome.startsWith('/')) {
+    throw new HostBootstrapError('install-failed', 'Remote HOME is not an absolute path')
+  }
+
+  const hooksDir = posix.join(remoteHome, '.config', 'cc-pewpew', 'hooks')
+  const notifyScriptPath = posix.join(hooksDir, `notify-v${NOTIFY_SCRIPT_VERSION}.sh`)
+  const breadcrumbPath = posix.join(hooksDir, 'socket-path')
+  const installScript =
+    'set -e\n' +
+    'mkdir -p "$1"\n' +
+    'if [ ! -f "$2" ] || ! grep -q "CC_PEWPEW_NOTIFY_VERSION=$5" "$2"; then\n' +
+    '  printf "%s" "$4" > "$2"\n' +
+    '  chmod 700 "$2"\n' +
+    'fi\n' +
+    'printf "%s\\n" "$3" > "$6"\n'
+  const install = await connection.exec(
+    [
+      'sh',
+      '-c',
+      installScript,
+      '_',
+      hooksDir,
+      notifyScriptPath,
+      remoteSocketPath,
+      notifyScript,
+      String(NOTIFY_SCRIPT_VERSION),
+      breadcrumbPath,
+    ],
+    { timeoutMs: 15000 }
+  )
+  await expectOk(install, 'install-failed', 'Unable to install remote notify hook')
+
+  const result = { notifyScriptPath, remoteSocketPath }
+  bootstrapped.set(hostId, result)
+  return result
+}

--- a/src/main/host-bootstrap.ts
+++ b/src/main/host-bootstrap.ts
@@ -112,14 +112,21 @@ export async function bootstrapHost(
     )
   }
 
-  const home = await connection.exec(['sh', '-c', 'printf "%s" "$HOME"'], { timeoutMs: 5000 })
-  await expectOk(home, 'install-failed', 'Unable to resolve remote HOME')
-  const remoteHome = home.stdout.trim()
-  if (!remoteHome.startsWith('/')) {
-    throw new HostBootstrapError('install-failed', 'Remote HOME is not an absolute path')
+  // Resolve the remote config root the same way notifyScript does
+  // (`${XDG_CONFIG_HOME:-$HOME/.config}`), so the breadcrumb we write here is
+  // the one the script reads at hook time. Hardcoding $HOME/.config would
+  // silently drop events on remotes with XDG_CONFIG_HOME set.
+  const configRootProbe = await connection.exec(
+    ['sh', '-c', 'printf "%s" "${XDG_CONFIG_HOME:-$HOME/.config}"'],
+    { timeoutMs: 5000 }
+  )
+  await expectOk(configRootProbe, 'install-failed', 'Unable to resolve remote config root')
+  const configRoot = configRootProbe.stdout.trim()
+  if (!configRoot.startsWith('/')) {
+    throw new HostBootstrapError('install-failed', 'Remote config root is not an absolute path')
   }
 
-  const hooksDir = posix.join(remoteHome, '.config', 'cc-pewpew', 'hooks')
+  const hooksDir = posix.join(configRoot, 'cc-pewpew', 'hooks')
   const notifyScriptPath = posix.join(hooksDir, `notify-v${NOTIFY_SCRIPT_VERSION}.sh`)
   const breadcrumbPath = posix.join(hooksDir, 'socket-path')
   const installScript =

--- a/src/main/host-bootstrap.ts
+++ b/src/main/host-bootstrap.ts
@@ -60,6 +60,13 @@ export interface HostBootstrapResult {
 
 const bootstrapped = new Map<string, HostBootstrapResult>()
 
+// Called when the SSH target for a host changes (alias edit). Drops the cached
+// bootstrap result so the next session re-probes dependencies and reinstalls
+// notify hooks on the new endpoint.
+export function invalidateBootstrap(hostId: string): void {
+  bootstrapped.delete(hostId)
+}
+
 async function expectOk(
   result: ExecResult,
   kind: HostBootstrapErrorKind,

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -47,8 +47,13 @@ function uidSegment(): string {
   }
 }
 
-export function remoteSocketPathForHost(_hostId: HostId): string {
-  return `/tmp/cc-pewpew-${uidSegment()}.sock`
+export function remoteSocketPathForHost(hostId: HostId): string {
+  // Include hostId so two configured hosts that resolve to the same remote
+  // account don't collide on the reverse-forwarded socket (StreamLocalBindUnlink
+  // would otherwise let the later connection steal the earlier one's socket).
+  // hostId is UUID-shaped but sanitize defensively against hand-edited configs.
+  const safeId = hostId.replace(/[^A-Za-z0-9_.-]/g, '_')
+  return `/tmp/cc-pewpew-${uidSegment()}-${safeId}.sock`
 }
 
 function controlPathForHost(hostId: HostId): string {

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -199,8 +199,25 @@ async function startRuntime(runtime: HostRuntime): Promise<void> {
     })
   })
 
+  // Attach before any await so spawn failures (ENOENT, EACCES) don't
+  // bubble up as unhandled EventEmitter errors and crash the main process.
+  const errorPromise = new Promise<never>((_, reject) => {
+    child.once('error', (err) => {
+      runtime.child = null
+      runtime.state = 'offline'
+      const errno = err as NodeJS.ErrnoException
+      reject(
+        new Error(
+          errno.code === 'ENOENT'
+            ? 'ssh: command not found'
+            : `ssh failed to spawn: ${errno.message || errno.code || 'unknown'}`
+        )
+      )
+    })
+  })
+
   try {
-    await Promise.race([waitForControl(runtime), exitPromise])
+    await Promise.race([waitForControl(runtime), exitPromise, errorPromise])
     runtime.state = 'live'
   } catch (err) {
     const exitCode = child.exitCode

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -5,16 +5,76 @@
 // `-` (e.g. from a hand-edited config.json) cannot be interpreted by ssh as an
 // option, even if upstream validation was bypassed.
 
-import { execFile } from 'child_process'
+import { execFile, spawn } from 'child_process'
+import { mkdirSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { homedir, userInfo } from 'os'
+import * as pty from 'node-pty'
+import type { IPty, IPtyForkOptions } from 'node-pty'
 import { shellQuote } from './shell-quote'
 import { classifySshExit } from './ssh-exit-parser'
-import type { TestConnectionResult, ValidateRemoteRepoResult } from '../shared/types'
+import { CONFIG_DIR } from './config'
+import type { Host, HostId, TestConnectionResult, ValidateRemoteRepoResult } from '../shared/types'
 
-interface ExecResult {
+export interface ExecResult {
   stdout: string
   stderr: string
   code: number
   timedOut: boolean
+}
+
+type HostConnectionState = 'offline' | 'connecting' | 'live' | 'auth-failed' | 'unreachable'
+
+interface HostRuntime {
+  host: Host
+  controlPath: string
+  localSocketPath: string
+  remoteSocketPath: string
+  child: ReturnType<typeof spawn> | null
+  state: HostConnectionState
+  refs: number
+  ready?: Promise<void>
+}
+
+const runtimes = new Map<HostId, HostRuntime>()
+
+function uidSegment(): string {
+  if (typeof process.getuid === 'function') return String(process.getuid())
+  try {
+    return String(userInfo().uid)
+  } catch {
+    return homedir().replace(/[^A-Za-z0-9_.-]/g, '_')
+  }
+}
+
+export function remoteSocketPathForHost(_hostId: HostId): string {
+  return `/tmp/cc-pewpew-${uidSegment()}.sock`
+}
+
+function controlPathForHost(hostId: HostId): string {
+  return join(CONFIG_DIR, `ssh-${hostId}.sock`)
+}
+
+function runtimeFor(host: Host, localSocketPath: string): HostRuntime {
+  const existing = runtimes.get(host.hostId)
+  if (existing) {
+    existing.host = host
+    existing.localSocketPath = localSocketPath
+    return existing
+  }
+
+  mkdirSync(CONFIG_DIR, { recursive: true })
+  const runtime: HostRuntime = {
+    host,
+    controlPath: controlPathForHost(host.hostId),
+    localSocketPath,
+    remoteSocketPath: remoteSocketPathForHost(host.hostId),
+    child: null,
+    state: 'offline',
+    refs: 0,
+  }
+  runtimes.set(host.hostId, runtime)
+  return runtime
 }
 
 function runSsh(argv: string[], timeoutMs: number): Promise<ExecResult> {
@@ -22,7 +82,7 @@ function runSsh(argv: string[], timeoutMs: number): Promise<ExecResult> {
     const child = execFile(
       'ssh',
       argv,
-      { timeout: timeoutMs, maxBuffer: 64 * 1024 },
+      { timeout: timeoutMs, maxBuffer: 256 * 1024 },
       (error, stdout, stderr) => {
         // execFile's `timeout` option kills the child with `killSignal` (default
         // SIGTERM) when it fires. Node sets `error.killed === true` in that
@@ -58,6 +118,174 @@ function runSsh(argv: string[], timeoutMs: number): Promise<ExecResult> {
   })
 }
 
+function controlArgs(runtime: HostRuntime): string[] {
+  return [
+    '-N',
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'ControlMaster=yes',
+    '-o',
+    `ControlPath=${runtime.controlPath}`,
+    '-o',
+    'ControlPersist=10m',
+    '-o',
+    'ExitOnForwardFailure=yes',
+    '-o',
+    'StreamLocalBindUnlink=yes',
+    '-o',
+    'ServerAliveInterval=15',
+    '-o',
+    'ServerAliveCountMax=3',
+    '-R',
+    `${runtime.remoteSocketPath}:${runtime.localSocketPath}`,
+    '--',
+    runtime.host.alias,
+  ]
+}
+
+async function controlCheck(runtime: HostRuntime): Promise<boolean> {
+  const result = await runSsh(
+    [
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      `ControlPath=${runtime.controlPath}`,
+      '-O',
+      'check',
+      '--',
+      runtime.host.alias,
+    ],
+    1000
+  )
+  return result.code === 0
+}
+
+async function waitForControl(runtime: HostRuntime): Promise<void> {
+  const deadline = Date.now() + 5000
+  while (Date.now() < deadline) {
+    if (!runtime.child || runtime.child.exitCode !== null) break
+    if (await controlCheck(runtime)) return
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error('ssh control connection did not become ready')
+}
+
+function classifyConnectionFailure(code: number | null, stderr: string): HostConnectionState {
+  const { reason } = classifySshExit({ exitCode: code, stderr })
+  if (reason === 'auth-failed') return 'auth-failed'
+  if (reason === 'network') return 'unreachable'
+  return 'offline'
+}
+
+async function startRuntime(runtime: HostRuntime): Promise<void> {
+  runtime.state = 'connecting'
+  let stderr = ''
+
+  const child = spawn('ssh', controlArgs(runtime), {
+    stdio: ['ignore', 'ignore', 'pipe'],
+  })
+  runtime.child = child
+
+  child.stderr?.on('data', (data) => {
+    stderr += data.toString()
+  })
+
+  const exitPromise = new Promise<never>((_, reject) => {
+    child.once('exit', (code) => {
+      runtime.child = null
+      runtime.state = classifyConnectionFailure(code, stderr)
+      reject(new Error(stderr.trim() || `ssh control connection exited: ${code ?? 'signal'}`))
+    })
+  })
+
+  try {
+    await Promise.race([waitForControl(runtime), exitPromise])
+    runtime.state = 'live'
+  } catch (err) {
+    const exitCode = child.exitCode
+    if (runtime.child) {
+      try {
+        runtime.child.kill()
+      } catch {
+        // Already gone.
+      }
+    }
+    runtime.child = null
+    runtime.state = classifyConnectionFailure(exitCode, stderr)
+    throw err
+  }
+}
+
+export async function ensureHostConnection(
+  host: Host,
+  localSocketPath: string
+): Promise<{ remoteSocketPath: string; controlPath: string }> {
+  const runtime = runtimeFor(host, localSocketPath)
+  if (runtime.state === 'live' && runtime.child) {
+    return { remoteSocketPath: runtime.remoteSocketPath, controlPath: runtime.controlPath }
+  }
+  if (!runtime.ready) {
+    runtime.ready = startRuntime(runtime).finally(() => {
+      runtime.ready = undefined
+    })
+  }
+  await runtime.ready
+  return { remoteSocketPath: runtime.remoteSocketPath, controlPath: runtime.controlPath }
+}
+
+export function retainHostConnection(hostId: HostId): void {
+  const runtime = runtimes.get(hostId)
+  if (runtime) runtime.refs++
+}
+
+export async function releaseHostConnection(hostId: HostId): Promise<void> {
+  const runtime = runtimes.get(hostId)
+  if (!runtime) return
+  runtime.refs = Math.max(0, runtime.refs - 1)
+  if (runtime.refs > 0) return
+  await stopHostConnection(hostId)
+}
+
+export async function stopHostConnection(hostId: HostId): Promise<void> {
+  const runtime = runtimes.get(hostId)
+  if (!runtime) return
+
+  if (runtime.child) {
+    await runSsh(
+      [
+        '-o',
+        'BatchMode=yes',
+        '-o',
+        `ControlPath=${runtime.controlPath}`,
+        '-O',
+        'exit',
+        '--',
+        runtime.host.alias,
+      ],
+      2000
+    ).catch(() => undefined)
+    try {
+      runtime.child.kill()
+    } catch {
+      // Already gone.
+    }
+  }
+
+  runtime.child = null
+  runtime.state = 'offline'
+  runtimes.delete(hostId)
+  try {
+    unlinkSync(runtime.controlPath)
+  } catch {
+    // Control socket may already be gone.
+  }
+}
+
+export async function stopAllHostConnections(): Promise<void> {
+  await Promise.all(Array.from(runtimes.keys()).map((hostId) => stopHostConnection(hostId)))
+}
+
 export async function testConnection(
   alias: string,
   opts: { timeoutMs?: number } = {}
@@ -76,18 +304,52 @@ export async function testConnection(
   return { ok: false, reason, message }
 }
 
-// Forward-looking helper for slices 2+. Slice 1 has no caller, but the
-// shell-quote invariant is tested and shipped so later code inherits a correct
-// foundation.
+function aliasOf(aliasOrHost: string | Host): string {
+  return typeof aliasOrHost === 'string' ? aliasOrHost : aliasOrHost.alias
+}
+
+function runtimeForHostIfLive(host: Host): HostRuntime | undefined {
+  const runtime = runtimes.get(host.hostId)
+  return runtime?.state === 'live' ? runtime : undefined
+}
+
+// Forward-looking helper for remote project/session operations.
 export async function exec(
-  alias: string,
+  aliasOrHost: string | Host,
   argv: string[],
   opts: { timeoutMs?: number } = {}
 ): Promise<ExecResult> {
   const timeoutMs = opts.timeoutMs ?? 30000
   const quoted = argv.map(shellQuote)
-  const sshArgv = ['-o', 'BatchMode=yes', '--', alias, ...quoted]
+  const liveRuntime =
+    typeof aliasOrHost === 'string' ? undefined : runtimeForHostIfLive(aliasOrHost)
+  const sshArgv = liveRuntime
+    ? [
+        '-o',
+        'BatchMode=yes',
+        '-o',
+        `ControlPath=${liveRuntime.controlPath}`,
+        '--',
+        aliasOf(aliasOrHost),
+        ...quoted,
+      ]
+    : ['-o', 'BatchMode=yes', '--', aliasOf(aliasOrHost), ...quoted]
   return runSsh(sshArgv, timeoutMs)
+}
+
+export function spawnAttach(host: Host, argv: string[], options: IPtyForkOptions): IPty {
+  const runtime = runtimeForHostIfLive(host)
+  const quoted = argv.map(shellQuote)
+  const sshArgv = [
+    '-tt',
+    '-o',
+    'BatchMode=yes',
+    ...(runtime ? ['-o', `ControlPath=${runtime.controlPath}`] : []),
+    '--',
+    host.alias,
+    ...quoted,
+  ]
+  return pty.spawn('ssh', sshArgv, options)
 }
 
 // Validates that a remote path is a git repository ROOT (not a subdirectory)

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -38,6 +38,15 @@ interface HostRuntime {
 
 const runtimes = new Map<HostId, HostRuntime>()
 
+// Fired after the SSH control connection is fully torn down. Lets higher-level
+// modules (index.ts wires hook-server here) release resources that were
+// allocated alongside the SSH runtime without host-connection taking on a
+// cross-module dependency.
+let onConnectionStopped: ((hostId: HostId) => void) | null = null
+export function setOnHostConnectionStopped(fn: ((hostId: HostId) => void) | null): void {
+  onConnectionStopped = fn
+}
+
 function uidSegment(): string {
   if (typeof process.getuid === 'function') return String(process.getuid())
   try {
@@ -311,6 +320,7 @@ export async function stopHostConnection(hostId: HostId): Promise<void> {
   } catch {
     // Control socket may already be gone.
   }
+  onConnectionStopped?.(hostId)
 }
 
 export async function stopAllHostConnections(): Promise<void> {

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -82,12 +82,21 @@ function runtimeFor(host: Host, localSocketPath: string): HostRuntime {
   return runtime
 }
 
-function runSsh(argv: string[], timeoutMs: number): Promise<ExecResult> {
+// 16 MiB lets `tmux capture-pane -S -5000` (up to 5000 lines with ANSI escapes)
+// fit even for wide terminals with heavy color output, which would otherwise
+// overflow execFile's default and return empty scrollback on reattach.
+const DEFAULT_MAX_BUFFER = 16 * 1024 * 1024
+
+function runSsh(
+  argv: string[],
+  timeoutMs: number,
+  maxBuffer = DEFAULT_MAX_BUFFER
+): Promise<ExecResult> {
   return new Promise((resolve) => {
     const child = execFile(
       'ssh',
       argv,
-      { timeout: timeoutMs, maxBuffer: 256 * 1024 },
+      { timeout: timeoutMs, maxBuffer },
       (error, stdout, stderr) => {
         // execFile's `timeout` option kills the child with `killSignal` (default
         // SIGTERM) when it fires. Node sets `error.killed === true` in that

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -56,17 +56,23 @@ function uidSegment(): string {
   }
 }
 
+// Strip any character that could let a hand-edited/corrupted hostId traverse
+// out of the intended directory when used in a filesystem path. UUIDs pass
+// through unchanged. Shared with hook-server.ts and any other module that
+// uses hostId as a path segment.
+export function sanitizeHostIdForPath(hostId: HostId): string {
+  return hostId.replace(/[^A-Za-z0-9_.-]/g, '_')
+}
+
 export function remoteSocketPathForHost(hostId: HostId): string {
   // Include hostId so two configured hosts that resolve to the same remote
   // account don't collide on the reverse-forwarded socket (StreamLocalBindUnlink
   // would otherwise let the later connection steal the earlier one's socket).
-  // hostId is UUID-shaped but sanitize defensively against hand-edited configs.
-  const safeId = hostId.replace(/[^A-Za-z0-9_.-]/g, '_')
-  return `/tmp/cc-pewpew-${uidSegment()}-${safeId}.sock`
+  return `/tmp/cc-pewpew-${uidSegment()}-${sanitizeHostIdForPath(hostId)}.sock`
 }
 
 function controlPathForHost(hostId: HostId): string {
-  return join(CONFIG_DIR, `ssh-${hostId}.sock`)
+  return join(CONFIG_DIR, `ssh-${sanitizeHostIdForPath(hostId)}.sock`)
 }
 
 function runtimeFor(host: Host, localSocketPath: string): HostRuntime {

--- a/src/main/host-registry.ts
+++ b/src/main/host-registry.ts
@@ -59,6 +59,20 @@ export function updateHost(hostId: HostId, input: { alias: string; label: string
   if (config.hosts.some((h) => h.hostId !== hostId && h.alias === alias)) {
     throw new Error('Alias already exists')
   }
+  // Refuse alias retargeting while sessions/projects are bound to this host.
+  // Lifecycle actions (kill/revive/remove) re-resolve the host by hostId at
+  // runtime, so pointing at a different SSH endpoint would dispatch commands
+  // to the new machine while the original tmux/Claude keeps running on the
+  // old one. Label-only edits are safe. Same rule deleteHost already enforces.
+  const previous = config.hosts[idx]
+  if (previous.alias !== alias) {
+    if (hasRemoteProjectsBoundTo(hostId)) {
+      throw new Error('Cannot retarget host: remote projects are registered on it')
+    }
+    if (hasSessionsBoundTo(hostId)) {
+      throw new Error('Cannot retarget host: sessions are still bound to it')
+    }
+  }
   const updated: Host = { hostId, alias, label }
   config.hosts = [...config.hosts.slice(0, idx), updated, ...config.hosts.slice(idx + 1)]
   saveConfig(config)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -41,7 +41,13 @@ import {
 } from './session-manager'
 import { parseDiff, synthesizeUntrackedFile } from './diff-parser'
 import { listHosts, addHost, updateHost, deleteHost, getHost } from './host-registry'
-import { testConnection, validateRemoteRepo, stopAllHostConnections } from './host-connection'
+import {
+  testConnection,
+  validateRemoteRepo,
+  stopAllHostConnections,
+  stopHostConnection,
+} from './host-connection'
+import { invalidateBootstrap } from './host-bootstrap'
 import {
   listRemoteProjects,
   addRemoteProject as persistRemoteProject,
@@ -466,9 +472,15 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('hosts:list', () => listHosts())
   ipcMain.handle('hosts:add', (_event, alias: string, label: string) => addHost({ alias, label }))
-  ipcMain.handle('hosts:update', (_event, hostId: string, alias: string, label: string) =>
-    updateHost(hostId, { alias, label })
-  )
+  ipcMain.handle('hosts:update', async (_event, hostId: string, alias: string, label: string) => {
+    const previous = getHost(hostId)
+    const updated = updateHost(hostId, { alias, label })
+    if (previous && previous.alias !== alias) {
+      invalidateBootstrap(hostId)
+      await stopHostConnection(hostId).catch(() => undefined)
+    }
+    return updated
+  })
   ipcMain.handle('hosts:delete', (_event, hostId: string) => deleteHost(hostId))
   ipcMain.handle('hosts:test-connection', async (_event, hostId: string) => {
     const host = getHost(hostId)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -264,11 +264,16 @@ app.whenReady().then(async () => {
     return getSessions()
   })
 
+  // Single-session handlers log and re-throw so the renderer can react (e.g.
+  // DetailPane.handleRevive clears its "Reviving..." state on rejection).
+  // Batch handlers below swallow per-session errors so one failure doesn't
+  // abort a multi-select operation.
   ipcMain.handle('sessions:kill', async (_event, id: string) => {
     try {
       await killSession(id)
     } catch (err) {
       console.error(`Failed to kill session ${id}:`, err)
+      throw err
     }
   })
 
@@ -277,6 +282,7 @@ app.whenReady().then(async () => {
       await reviveSession(id)
     } catch (err) {
       console.error(`Failed to revive session ${id}:`, err)
+      throw err
     }
   })
 
@@ -289,6 +295,7 @@ app.whenReady().then(async () => {
       await removeSession(id)
     } catch (err) {
       console.error(`Failed to remove session ${id}:`, err)
+      throw err
     }
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -265,11 +265,19 @@ app.whenReady().then(async () => {
   })
 
   ipcMain.handle('sessions:kill', async (_event, id: string) => {
-    await killSession(id)
+    try {
+      await killSession(id)
+    } catch (err) {
+      console.error(`Failed to kill session ${id}:`, err)
+    }
   })
 
   ipcMain.handle('sessions:revive', async (_event, id: string) => {
-    await reviveSession(id)
+    try {
+      await reviveSession(id)
+    } catch (err) {
+      console.error(`Failed to revive session ${id}:`, err)
+    }
   })
 
   ipcMain.handle('sessions:remove-worktree', async (_event, id: string) => {
@@ -277,7 +285,11 @@ app.whenReady().then(async () => {
   })
 
   ipcMain.handle('sessions:remove', async (_event, id: string) => {
-    await removeSession(id)
+    try {
+      await removeSession(id)
+    } catch (err) {
+      console.error(`Failed to remove session ${id}:`, err)
+    }
   })
 
   ipcMain.handle('sessions:kill-batch', async (_event, ids: string[]) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -511,11 +511,25 @@ app.whenReady().then(async () => {
     }
   })
 
-  app.on('before-quit', () => {
+  // before-quit fires synchronously; Electron won't wait for async work unless
+  // we preventDefault. Pattern: first fire → preventDefault, run teardown,
+  // app.quit() re-enters and we let it through.
+  let teardownStarted = false
+  app.on('before-quit', (event) => {
+    if (teardownStarted) return
+    teardownStarted = true
+    event.preventDefault()
     clearInterval(thumbInterval)
     stopPtyManager()
     stopHookServer()
-    void stopAllHostConnections()
+    void (async () => {
+      // Bound teardown so an unreachable host can't wedge shutdown.
+      await Promise.race([
+        stopAllHostConnections().catch(() => undefined),
+        new Promise((resolve) => setTimeout(resolve, 5000)),
+      ])
+      app.quit()
+    })()
   })
 })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -46,8 +46,10 @@ import {
   validateRemoteRepo,
   stopAllHostConnections,
   stopHostConnection,
+  setOnHostConnectionStopped,
 } from './host-connection'
 import { invalidateBootstrap } from './host-bootstrap'
+import { stopHookServerForHost } from './hook-server'
 import {
   listRemoteProjects,
   addRemoteProject as persistRemoteProject,
@@ -522,6 +524,10 @@ app.whenReady().then(async () => {
   const mainWindow = createWindow()
   registerWindow(mainWindow, true)
   startHookServer()
+  // Tear down the per-host hook listener whenever its SSH control connection
+  // goes away, so long-running apps that cycle through many hosts don't
+  // accumulate idle Unix-socket servers and ipc-<hostId>.sock files.
+  setOnHostConnectionStopped((hostId) => stopHookServerForHost(hostId))
   initSessionManager()
   createTray()
   initPtyManager()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -281,7 +281,13 @@ app.whenReady().then(async () => {
   })
 
   ipcMain.handle('sessions:kill-batch', async (_event, ids: string[]) => {
-    for (const id of ids) await killSession(id)
+    for (const id of ids) {
+      try {
+        await killSession(id)
+      } catch (err) {
+        console.error(`Failed to kill session ${id}:`, err)
+      }
+    }
   })
 
   ipcMain.handle('sessions:revive-batch', async (_event, ids: string[]) => {
@@ -295,7 +301,13 @@ app.whenReady().then(async () => {
   })
 
   ipcMain.handle('sessions:remove-batch', async (_event, ids: string[]) => {
-    for (const id of ids) await removeSession(id)
+    for (const id of ids) {
+      try {
+        await removeSession(id)
+      } catch (err) {
+        console.error(`Failed to remove session ${id}:`, err)
+      }
+    }
   })
 
   ipcMain.handle('pty:write', (_event, sessionId: string, data: string) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -41,7 +41,7 @@ import {
 } from './session-manager'
 import { parseDiff, synthesizeUntrackedFile } from './diff-parser'
 import { listHosts, addHost, updateHost, deleteHost, getHost } from './host-registry'
-import { testConnection, validateRemoteRepo } from './host-connection'
+import { testConnection, validateRemoteRepo, stopAllHostConnections } from './host-connection'
 import {
   listRemoteProjects,
   addRemoteProject as persistRemoteProject,
@@ -211,9 +211,12 @@ app.whenReady().then(async () => {
     await shell.openPath(path)
   })
 
-  ipcMain.handle('sessions:create', async (_event, projectPath: string, name?: string) => {
-    return createSession(projectPath, name)
-  })
+  ipcMain.handle(
+    'sessions:create',
+    async (_event, projectPath: string, name?: string, hostId?: string | null) => {
+      return createSession(projectPath, name, hostId ?? null)
+    }
+  )
 
   ipcMain.handle('sessions:create-pr', async (_event, projectPath: string, prNumber: number) => {
     return createPrSession(projectPath, prNumber)
@@ -255,12 +258,12 @@ app.whenReady().then(async () => {
     return getSessions()
   })
 
-  ipcMain.handle('sessions:kill', (_event, id: string) => {
-    killSession(id)
+  ipcMain.handle('sessions:kill', async (_event, id: string) => {
+    await killSession(id)
   })
 
-  ipcMain.handle('sessions:revive', (_event, id: string) => {
-    reviveSession(id)
+  ipcMain.handle('sessions:revive', async (_event, id: string) => {
+    await reviveSession(id)
   })
 
   ipcMain.handle('sessions:remove-worktree', async (_event, id: string) => {
@@ -271,14 +274,14 @@ app.whenReady().then(async () => {
     await removeSession(id)
   })
 
-  ipcMain.handle('sessions:kill-batch', (_event, ids: string[]) => {
-    for (const id of ids) killSession(id)
+  ipcMain.handle('sessions:kill-batch', async (_event, ids: string[]) => {
+    for (const id of ids) await killSession(id)
   })
 
-  ipcMain.handle('sessions:revive-batch', (_event, ids: string[]) => {
+  ipcMain.handle('sessions:revive-batch', async (_event, ids: string[]) => {
     for (const id of ids) {
       try {
-        reviveSession(id)
+        await reviveSession(id)
       } catch (err) {
         console.error(`Failed to revive session ${id}:`, err)
       }
@@ -500,6 +503,7 @@ app.whenReady().then(async () => {
     clearInterval(thumbInterval)
     stopPtyManager()
     stopHookServer()
+    void stopAllHostConnections()
   })
 })
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -243,10 +243,6 @@ export async function destroyRemotePty(sessionId: string, host: Host): Promise<v
   const entry = ptys.get(sessionId)
   const tmuxSession = entry?.tmuxSession ?? `cc-pewpew-${sessionId}`
 
-  if (entry) {
-    ptys.delete(sessionId)
-  }
-
   const result = await execRemote(host, ['tmux', 'kill-session', '-t', tmuxSession], {
     timeoutMs: 5000,
   })
@@ -254,6 +250,8 @@ export async function destroyRemotePty(sessionId: string, host: Host): Promise<v
   // remote process is already gone. But SSH-level failures (auth, network,
   // timeout) mean the kill never ran on the remote; surface so killSession
   // doesn't dishonestly flip the UI to 'dead' while the remote Claude lives on.
+  // Keep `entry` registered in `ptys` until we know the kill succeeded so
+  // input/output stay routable if the caller retries.
   if (result.timedOut) {
     throw new Error(`Remote tmux kill-session timed out on host ${host.alias}`)
   }
@@ -265,6 +263,7 @@ export async function destroyRemotePty(sessionId: string, host: Host): Promise<v
   }
 
   if (entry) {
+    ptys.delete(sessionId)
     try {
       entry.pty.kill()
     } catch {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -10,6 +10,7 @@ import {
   releaseHostConnection,
   spawnAttach,
 } from './host-connection'
+import { classifySshExit } from './ssh-exit-parser'
 import type { Host } from '../shared/types'
 
 interface PtyEntry {
@@ -246,10 +247,21 @@ export async function destroyRemotePty(sessionId: string, host: Host): Promise<v
     ptys.delete(sessionId)
   }
 
-  try {
-    await execRemote(host, ['tmux', 'kill-session', '-t', tmuxSession], { timeoutMs: 5000 })
-  } catch {
-    // Session may already be dead or host unreachable; caller updates session state.
+  const result = await execRemote(host, ['tmux', 'kill-session', '-t', tmuxSession], {
+    timeoutMs: 5000,
+  })
+  // tmux returns nonzero when the session doesn't exist — that's fine, the
+  // remote process is already gone. But SSH-level failures (auth, network,
+  // timeout) mean the kill never ran on the remote; surface so killSession
+  // doesn't dishonestly flip the UI to 'dead' while the remote Claude lives on.
+  if (result.timedOut) {
+    throw new Error(`Remote tmux kill-session timed out on host ${host.alias}`)
+  }
+  if (result.code !== 0) {
+    const { reason, message } = classifySshExit({ exitCode: result.code, stderr: result.stderr })
+    if (reason === 'auth-failed' || reason === 'network' || reason === 'dep-missing') {
+      throw new Error(`Remote tmux kill-session failed on host ${host.alias}: ${message}`)
+    }
   }
 
   if (entry) {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -4,11 +4,20 @@ import { execFileSync } from 'child_process'
 import { existsSync } from 'fs'
 import { dialog } from 'electron'
 import { broadcastToAll } from './window-registry'
+import {
+  exec as execRemote,
+  retainHostConnection,
+  releaseHostConnection,
+  spawnAttach,
+} from './host-connection'
+import type { Host } from '../shared/types'
 
 interface PtyEntry {
   pty: IPty
   tmuxSession: string
   buffer: string
+  host?: Host
+  released?: boolean
 }
 
 const ptys = new Map<string, PtyEntry>()
@@ -109,6 +118,72 @@ export function createPty(
   ptys.set(sessionId, entry)
 }
 
+function releaseRemoteEntry(entry: PtyEntry): void {
+  if (!entry.host || entry.released) return
+  entry.released = true
+  void releaseHostConnection(entry.host.hostId)
+}
+
+export async function createRemotePty(
+  sessionId: string,
+  cwd: string,
+  host: Host,
+  options?: { continueSession?: boolean }
+): Promise<void> {
+  const tmuxSession = `cc-pewpew-${sessionId}`
+
+  const claudeArgs = ['claude', '--dangerously-skip-permissions']
+  if (options?.continueSession) {
+    claudeArgs.push('--continue')
+  }
+
+  const create = await execRemote(host, [
+    'tmux',
+    'new-session',
+    '-d',
+    '-s',
+    tmuxSession,
+    '-c',
+    cwd,
+    '-x',
+    '120',
+    '-y',
+    '30',
+    ...claudeArgs,
+  ])
+  if (create.timedOut || create.code !== 0) {
+    const detail = create.stderr.trim() || create.stdout.trim() || `exit ${create.code}`
+    throw new Error(`Failed to create remote tmux session: ${detail}`)
+  }
+
+  const ptyProcess = spawnAttach(host, ['tmux', 'attach-session', '-t', tmuxSession], {
+    name: 'xterm-256color',
+    cols: 120,
+    rows: 30,
+    env: process.env as Record<string, string>,
+  })
+
+  retainHostConnection(host.hostId)
+
+  const entry: PtyEntry = {
+    pty: ptyProcess,
+    tmuxSession,
+    buffer: '',
+    host,
+  }
+
+  ptyProcess.onData((data) => {
+    entry.buffer += data
+  })
+
+  ptyProcess.onExit(() => {
+    ptys.delete(sessionId)
+    releaseRemoteEntry(entry)
+  })
+
+  ptys.set(sessionId, entry)
+}
+
 export function writePty(sessionId: string, data: string): void {
   const entry = ptys.get(sessionId)
   if (entry) {
@@ -129,6 +204,7 @@ export function detachPty(sessionId: string): void {
   if (!entry) return
 
   ptys.delete(sessionId)
+  releaseRemoteEntry(entry)
 
   try {
     entry.pty.kill()
@@ -144,6 +220,7 @@ export function destroyPty(sessionId: string): void {
 
   if (entry) {
     ptys.delete(sessionId)
+    releaseRemoteEntry(entry)
 
     try {
       entry.pty.kill()
@@ -158,6 +235,30 @@ export function destroyPty(sessionId: string): void {
     execFileSync('tmux', ['kill-session', '-t', tmuxSession])
   } catch {
     // Session may already be dead
+  }
+}
+
+export async function destroyRemotePty(sessionId: string, host: Host): Promise<void> {
+  const entry = ptys.get(sessionId)
+  const tmuxSession = entry?.tmuxSession ?? `cc-pewpew-${sessionId}`
+
+  if (entry) {
+    ptys.delete(sessionId)
+  }
+
+  try {
+    await execRemote(host, ['tmux', 'kill-session', '-t', tmuxSession], { timeoutMs: 5000 })
+  } catch {
+    // Session may already be dead or host unreachable; caller updates session state.
+  }
+
+  if (entry) {
+    try {
+      entry.pty.kill()
+    } catch {
+      // Pty may already be dead from ssh/tmux exit
+    }
+    releaseRemoteEntry(entry)
   }
 }
 
@@ -181,6 +282,8 @@ export function hasTmuxSession(sessionId: string): boolean {
 export function captureThumbnails(): Record<string, string> {
   const result: Record<string, string> = {}
   for (const [sessionId, entry] of ptys) {
+    // Remote thumbnail capture is slice #13; issue #11 only needs the live PTY stream.
+    if (entry.host) continue
     try {
       const text = execFileSync('tmux', ['capture-pane', '-t', entry.tmuxSession, '-p'], {
         encoding: 'utf-8',
@@ -194,7 +297,24 @@ export function captureThumbnails(): Record<string, string> {
   return result
 }
 
-export function getScrollback(sessionId: string): string {
+export async function hasRemoteTmuxSession(sessionId: string, host: Host): Promise<boolean> {
+  const result = await execRemote(host, ['tmux', 'has-session', '-t', `cc-pewpew-${sessionId}`], {
+    timeoutMs: 3000,
+  })
+  return result.code === 0 && !result.timedOut
+}
+
+export async function getScrollback(sessionId: string): Promise<string> {
+  const entry = ptys.get(sessionId)
+  if (entry?.host) {
+    const result = await execRemote(
+      entry.host,
+      ['tmux', 'capture-pane', '-t', entry.tmuxSession, '-p', '-e', '-S', '-5000'],
+      { timeoutMs: 5000 }
+    )
+    return result.code === 0 && !result.timedOut ? result.stdout : ''
+  }
+
   const tmuxSession = `cc-pewpew-${sessionId}`
   try {
     return execFileSync('tmux', ['capture-pane', '-t', tmuxSession, '-p', '-e', '-S', '-5000'], {
@@ -260,5 +380,41 @@ export function reattachPty(sessionId: string): void {
     }
   } catch {
     // Scrollback capture may fail — not critical
+  }
+}
+
+export async function reattachRemotePty(sessionId: string, host: Host): Promise<void> {
+  const tmuxSession = `cc-pewpew-${sessionId}`
+
+  const ptyProcess = spawnAttach(host, ['tmux', 'attach-session', '-t', tmuxSession], {
+    name: 'xterm-256color',
+    cols: 120,
+    rows: 30,
+    env: process.env as Record<string, string>,
+  })
+
+  retainHostConnection(host.hostId)
+
+  const entry: PtyEntry = {
+    pty: ptyProcess,
+    tmuxSession,
+    buffer: '',
+    host,
+  }
+
+  ptyProcess.onData((data) => {
+    entry.buffer += data
+  })
+
+  ptyProcess.onExit(() => {
+    ptys.delete(sessionId)
+    releaseRemoteEntry(entry)
+  })
+
+  ptys.set(sessionId, entry)
+
+  const scrollback = await getScrollback(sessionId)
+  if (scrollback) {
+    entry.buffer += scrollback
   }
 }

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -2,6 +2,7 @@ import { execFile, execFileSync } from 'child_process'
 import { promisify } from 'util'
 import { readFileSync, writeFileSync, existsSync, realpathSync } from 'fs'
 import { join, basename, sep } from 'path'
+import { posix } from 'path'
 import { randomUUID } from 'crypto'
 import { dialog, shell } from 'electron'
 import { broadcastToAll, getMainWindow } from './window-registry'
@@ -12,15 +13,24 @@ import {
   createPty,
   detachPty,
   destroyPty,
+  destroyRemotePty,
   hasPty,
   hasTmuxSession,
+  hasRemoteTmuxSession,
   isTmuxAvailable,
   discoverTmuxSessions,
   reattachPty,
+  reattachRemotePty,
+  createRemotePty,
 } from './pty-manager'
 import { getRepoFingerprint, gitWorktrees } from './project-scanner'
-import { installHooks } from './hook-installer'
-import type { Session, SessionStatus } from '../shared/types'
+import { installHooks, installRemoteHooks } from './hook-installer'
+import { getHost } from './host-registry'
+import { listRemoteProjects } from './remote-project-registry'
+import { listenHookServerForHost } from './hook-server'
+import { ensureHostConnection, exec as execRemote } from './host-connection'
+import { bootstrapHost } from './host-bootstrap'
+import type { Host, RemoteProject, Session, SessionStatus } from '../shared/types'
 
 const execFileAsync = promisify(execFile)
 const SESSIONS_PATH = join(CONFIG_DIR, 'sessions.json')
@@ -76,6 +86,40 @@ interface SessionEntry {
 
 const sessions = new Map<string, SessionEntry>()
 
+function getRemoteProject(hostId: string, projectPath: string): RemoteProject {
+  const project = listRemoteProjects().find((p) => p.hostId === hostId && p.path === projectPath)
+  if (!project) throw new Error('Remote project is not registered')
+  return project
+}
+
+function getRequiredHost(hostId: string): Host {
+  const host = getHost(hostId)
+  if (!host) throw new Error('Unknown host')
+  return host
+}
+
+async function prepareRemoteHost(host: Host): Promise<{ notifyScriptPath: string }> {
+  const localSocketPath = listenHookServerForHost(host.hostId)
+  const { remoteSocketPath } = await ensureHostConnection(host, localSocketPath)
+  const bootstrap = await bootstrapHost(
+    host.hostId,
+    {
+      exec: (argv, opts) => execRemote(host, argv, opts),
+    },
+    remoteSocketPath
+  )
+  return { notifyScriptPath: bootstrap.notifyScriptPath }
+}
+
+async function expectRemoteOk(host: Host, argv: string[], message: string): Promise<string> {
+  const result = await execRemote(host, argv)
+  if (result.timedOut || result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`
+    throw new Error(`${message}: ${detail}`)
+  }
+  return result.stdout
+}
+
 // Positive hits are cached forever; negative hits (no PR yet / gh transient
 // error) are retained only for NEGATIVE_CACHE_TTL_MS so a PR opened after the
 // session was created can be picked up without requiring an app restart.
@@ -130,6 +174,7 @@ async function lookupPrForBranch(projectPath: string, branch: string): Promise<n
 function resolvePrNumberAsync(sessionId: string): void {
   const entry = sessions.get(sessionId)
   if (!entry || entry.session.prNumber !== undefined) return
+  if (entry.session.hostId) return
   const { projectPath, branch } = entry.session
   if (!branch) return
   lookupPrForBranch(projectPath, branch).then((num) => {
@@ -264,6 +309,7 @@ async function adoptWorktree(
 
   const session: Session = {
     id,
+    hostId: null,
     projectPath,
     projectName,
     worktreeName,
@@ -319,7 +365,85 @@ export async function mirrorAllWorktrees(projectPath: string): Promise<MirrorAll
   return { mirrored, failed }
 }
 
-export async function createSession(projectPath: string, name?: string): Promise<Session> {
+async function createRemoteSession(
+  hostId: string,
+  projectPath: string,
+  name?: string
+): Promise<Session> {
+  const host = getRequiredHost(hostId)
+  const remoteProject = getRemoteProject(hostId, projectPath)
+  const worktreeName = name || `session-${randomUUID().slice(0, 8)}`
+  const worktreePath = posix.join(projectPath, '.claude', 'worktrees', worktreeName)
+  const id = randomUUID().slice(0, 8)
+  const tmuxSession = `cc-pewpew-${id}`
+  const branchName = `cc-pewpew/${worktreeName}`
+
+  const { notifyScriptPath } = await prepareRemoteHost(host)
+
+  const addWithBranch = await execRemote(host, [
+    'git',
+    '-C',
+    projectPath,
+    'worktree',
+    'add',
+    worktreePath,
+    '-b',
+    branchName,
+  ])
+  if (addWithBranch.timedOut || addWithBranch.code !== 0) {
+    await expectRemoteOk(
+      host,
+      ['git', '-C', projectPath, 'worktree', 'add', worktreePath],
+      'Failed to create remote worktree'
+    )
+  }
+
+  const branch =
+    (
+      await expectRemoteOk(
+        host,
+        ['git', '-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'],
+        'Failed to resolve remote branch'
+      )
+    ).trim() || branchName
+
+  await installRemoteHooks(
+    (argv, opts) => execRemote(host, argv, opts),
+    worktreePath,
+    notifyScriptPath
+  )
+  await createRemotePty(id, worktreePath, host)
+
+  const session: Session = {
+    id,
+    hostId,
+    projectPath,
+    projectName: remoteProject.name,
+    worktreeName,
+    worktreePath,
+    branch,
+    issueNumber: parseIssueNumber(worktreeName, branch),
+    pid: 0,
+    tmuxSession,
+    status: 'running',
+    connectionState: 'live',
+    lastActivity: Date.now(),
+    hookEvents: [],
+    ...(remoteProject.repoFingerprint ? { repoFingerprint: remoteProject.repoFingerprint } : {}),
+  }
+
+  sessions.set(id, { session })
+  onSessionsChanged()
+  return session
+}
+
+export async function createSession(
+  projectPath: string,
+  name?: string,
+  hostId: string | null = null
+): Promise<Session> {
+  if (hostId) return createRemoteSession(hostId, projectPath, name)
+
   const worktreeName = name || `session-${randomUUID().slice(0, 8)}`
   const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
 
@@ -341,11 +465,15 @@ export async function createSession(projectPath: string, name?: string): Promise
   return createSessionForWorktree(projectPath, worktreePath, worktreeName)
 }
 
-export function handleHookEvent(method: string, params: Record<string, unknown>): void {
+export function handleHookEvent(
+  method: string,
+  params: Record<string, unknown>,
+  originHostId: string | null = null
+): boolean {
   // Match hook event to our session. CC's session_id differs from our internal id,
   // so match by cwd (worktree path) which is unique per session.
   const cwd = params.cwd as string | undefined
-  const ccSessionId = params.session_id as string | undefined
+  const ccSessionId = (params.session_id ?? params.sessionId) as string | undefined
 
   let entry: SessionEntry | undefined
   for (const e of sessions.values()) {
@@ -360,50 +488,87 @@ export function handleHookEvent(method: string, params: Record<string, unknown>)
       break
     }
   }
-  if (!entry) return
+  if (!entry) return false
+
+  const expectedHostId = entry.session.hostId ?? null
+  if (expectedHostId !== originHostId) {
+    console.warn(
+      `Dropping hook event for host mismatch: session=${entry.session.id} expected=${expectedHostId ?? 'local'} origin=${originHostId ?? 'local'}`
+    )
+    return false
+  }
 
   switch (method) {
     case 'session.start':
       entry.session.status = 'running'
+      entry.session.connectionState = originHostId ? 'live' : entry.session.connectionState
       break
     case 'session.stop':
       entry.session.status = 'needs_input'
+      entry.session.connectionState = originHostId ? 'live' : entry.session.connectionState
       notifyNeedsInput(entry.session)
       break
     case 'session.activity':
       entry.session.status = 'running'
+      entry.session.connectionState = originHostId ? 'live' : entry.session.connectionState
       break
     case 'session.end':
       promptCleanup(entry.session.id)
-      return
+      return true
     case 'session.notification':
       entry.session.hookEvents.push({
         method,
         sessionId: ccSessionId || entry.session.id,
         timestamp: Date.now(),
+        originHostId,
         data: params,
       })
       break
     default:
-      return
+      return false
   }
 
   entry.session.lastActivity = Date.now()
   onSessionsChanged()
+  return true
 }
 
-export function killSession(id: string): void {
+export async function killSession(id: string): Promise<void> {
+  const entry = sessions.get(id)
+  if (!entry) return
+  if (entry.session.hostId) {
+    const host = getRequiredHost(entry.session.hostId)
+    await destroyRemotePty(id, host)
+    entry.session.connectionState = 'offline'
+    updateSession(id, 'dead')
+    return
+  }
   detachPty(id)
   updateSession(id, 'dead')
 }
 
-export function reviveSession(id: string): void {
+export async function reviveSession(id: string): Promise<void> {
   const entry = sessions.get(id)
   if (!entry) throw new Error(`Session ${id} not found`)
 
   const session = entry.session
   if (session.status !== 'dead')
     throw new Error(`Session ${id} is not dead (status: ${session.status})`)
+
+  if (session.hostId) {
+    const host = getRequiredHost(session.hostId)
+    session.connectionState = 'connecting'
+    onSessionsChanged()
+    await prepareRemoteHost(host)
+    if (await hasRemoteTmuxSession(id, host)) {
+      await reattachRemotePty(id, host)
+    } else {
+      await createRemotePty(id, session.worktreePath, host, { continueSession: true })
+    }
+    session.connectionState = 'live'
+    updateSession(id, 'idle')
+    return
+  }
 
   if (hasTmuxSession(id)) {
     reattachPty(id)
@@ -416,6 +581,24 @@ export function reviveSession(id: string): void {
 export async function removeWorktree(id: string): Promise<void> {
   const entry = sessions.get(id)
   if (!entry) return
+
+  if (entry.session.hostId) {
+    const host = getRequiredHost(entry.session.hostId)
+    try {
+      await execRemote(host, [
+        'git',
+        '-C',
+        entry.session.projectPath,
+        'worktree',
+        'remove',
+        entry.session.worktreePath,
+        '--force',
+      ])
+    } catch {
+      // Remote worktree may already be removed or host unavailable.
+    }
+    return
+  }
 
   try {
     await execFileAsync('git', [
@@ -432,7 +615,13 @@ export async function removeWorktree(id: string): Promise<void> {
 }
 
 export async function removeSession(id: string): Promise<void> {
-  destroyPty(id)
+  const entry = sessions.get(id)
+  if (entry?.session.hostId) {
+    const host = getRequiredHost(entry.session.hostId)
+    await destroyRemotePty(id, host)
+  } else {
+    destroyPty(id)
+  }
   await removeWorktree(id)
   sessions.delete(id)
   onSessionsChanged()
@@ -467,9 +656,7 @@ async function promptCleanup(id: string): Promise<void> {
     : await dialog.showMessageBox(options)
 
   if (response === 0) {
-    destroyPty(id)
-    await removeWorktree(id)
-    removeSession(id)
+    await removeSession(id)
   } else if (response === 1) {
     updateSession(id, 'completed')
   } else if (response === 2) {
@@ -563,7 +750,7 @@ export async function relocateProject(
 
   const toMigrate: SessionEntry[] = []
   for (const entry of sessions.values()) {
-    if (entry.session.projectPath === oldProjectPath) {
+    if (entry.session.hostId === null && entry.session.projectPath === oldProjectPath) {
       toMigrate.push(entry)
     }
   }
@@ -629,6 +816,26 @@ export function restoreSessions(): void {
     let skippedForNoTmux = 0
 
     for (const session of data) {
+      session.hostId = session.hostId ?? null
+      if (session.hostId) {
+        if (
+          session.status === 'running' ||
+          session.status === 'idle' ||
+          session.status === 'needs_input'
+        ) {
+          session.status = 'dead'
+        }
+        session.connectionState = 'offline'
+        if (!session.branch) {
+          session.branch = `cc-pewpew/${session.worktreeName}`
+        }
+        if (session.issueNumber === undefined) {
+          session.issueNumber = parseIssueNumber(session.worktreeName, session.branch)
+        }
+        sessions.set(session.id, { session })
+        continue
+      }
+
       if (
         session.status === 'running' ||
         session.status === 'idle' ||

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -585,8 +585,12 @@ export async function reviveSession(id: string): Promise<void> {
     onSessionsChanged()
     // prepareRemoteHost retains the SSH runtime on success; we release it at
     // the end/in catch. createRemotePty/reattachRemotePty take over on success.
-    await prepareRemoteHost(host)
+    // The prepareRemoteHost await is inside the try so a bootstrap failure
+    // also resets connectionState instead of leaving it pinned at connecting.
+    let retained = false
     try {
+      await prepareRemoteHost(host)
+      retained = true
       if (await hasRemoteTmuxSession(id, host)) {
         await reattachRemotePty(id, host)
       } else {
@@ -595,7 +599,9 @@ export async function reviveSession(id: string): Promise<void> {
     } catch (err) {
       session.connectionState = 'offline'
       onSessionsChanged()
-      await releaseHostConnection(hostId).catch(() => undefined)
+      if (retained) {
+        await releaseHostConnection(hostId).catch(() => undefined)
+      }
       throw err
     }
     await releaseHostConnection(hostId).catch(() => undefined)

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -559,11 +559,17 @@ export async function reviveSession(id: string): Promise<void> {
     const host = getRequiredHost(session.hostId)
     session.connectionState = 'connecting'
     onSessionsChanged()
-    await prepareRemoteHost(host)
-    if (await hasRemoteTmuxSession(id, host)) {
-      await reattachRemotePty(id, host)
-    } else {
-      await createRemotePty(id, session.worktreePath, host, { continueSession: true })
+    try {
+      await prepareRemoteHost(host)
+      if (await hasRemoteTmuxSession(id, host)) {
+        await reattachRemotePty(id, host)
+      } else {
+        await createRemotePty(id, session.worktreePath, host, { continueSession: true })
+      }
+    } catch (err) {
+      session.connectionState = 'offline'
+      onSessionsChanged()
+      throw err
     }
     session.connectionState = 'live'
     updateSession(id, 'idle')

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -523,7 +523,11 @@ export function handleHookEvent(
       entry.session.connectionState = originHostId ? 'live' : entry.session.connectionState
       break
     case 'session.end':
-      promptCleanup(entry.session.id)
+      // Fire-and-forget, but attach a catch so a remote removeSession failure
+      // doesn't become an unhandled rejection in the main process.
+      promptCleanup(entry.session.id).catch((err) => {
+        console.error(`promptCleanup(${entry.session.id}) failed:`, err)
+      })
       return true
     case 'session.notification':
       entry.session.hookEvents.push({
@@ -652,39 +656,37 @@ const cleanupInProgress = new Set<string>()
 async function promptCleanup(id: string): Promise<void> {
   if (cleanupInProgress.has(id)) return
   cleanupInProgress.add(id)
+  try {
+    const entry = sessions.get(id)
+    if (!entry) return
 
-  const entry = sessions.get(id)
-  if (!entry) {
+    const session = entry.session
+    const parentWindow = getMainWindow()
+
+    const options = {
+      type: 'question' as const,
+      title: 'Session ended',
+      message: `Session "${session.projectName}/${session.worktreeName}" ended.\nClean up worktree?`,
+      buttons: ['Delete worktree', 'Keep worktree', 'Keep and open in file manager'],
+      defaultId: 1,
+      cancelId: 1,
+    }
+
+    const { response } = parentWindow
+      ? await dialog.showMessageBox(parentWindow, options)
+      : await dialog.showMessageBox(options)
+
+    if (response === 0) {
+      await removeSession(id)
+    } else if (response === 1) {
+      updateSession(id, 'completed')
+    } else if (response === 2) {
+      updateSession(id, 'completed')
+      shell.openPath(session.worktreePath)
+    }
+  } finally {
     cleanupInProgress.delete(id)
-    return
   }
-
-  const session = entry.session
-  const parentWindow = getMainWindow()
-
-  const options = {
-    type: 'question' as const,
-    title: 'Session ended',
-    message: `Session "${session.projectName}/${session.worktreeName}" ended.\nClean up worktree?`,
-    buttons: ['Delete worktree', 'Keep worktree', 'Keep and open in file manager'],
-    defaultId: 1,
-    cancelId: 1,
-  }
-
-  const { response } = parentWindow
-    ? await dialog.showMessageBox(parentWindow, options)
-    : await dialog.showMessageBox(options)
-
-  if (response === 0) {
-    await removeSession(id)
-  } else if (response === 1) {
-    updateSession(id, 'completed')
-  } else if (response === 2) {
-    updateSession(id, 'completed')
-    shell.openPath(session.worktreePath)
-  }
-
-  cleanupInProgress.delete(id)
 }
 
 export async function createPrSession(

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -475,8 +475,11 @@ export function handleHookEvent(
   const cwd = params.cwd as string | undefined
   const ccSessionId = (params.session_id ?? params.sessionId) as string | undefined
 
+  // Filter by origin first so local and remote sessions with the same worktree
+  // path don't shadow each other — picking the wrong one would drop the event.
   let entry: SessionEntry | undefined
   for (const e of sessions.values()) {
+    if ((e.session.hostId ?? null) !== originHostId) continue
     // Primary match: cwd matches our worktreePath
     if (cwd && e.session.worktreePath && cwd.startsWith(e.session.worktreePath)) {
       entry = e
@@ -489,14 +492,6 @@ export function handleHookEvent(
     }
   }
   if (!entry) return false
-
-  const expectedHostId = entry.session.hostId ?? null
-  if (expectedHostId !== originHostId) {
-    console.warn(
-      `Dropping hook event for host mismatch: session=${entry.session.id} expected=${expectedHostId ?? 'local'} origin=${originHostId ?? 'local'}`
-    )
-    return false
-  }
 
   switch (method) {
     case 'session.start':

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -33,6 +33,7 @@ import {
   exec as execRemote,
   retainHostConnection,
   releaseHostConnection,
+  stopHostConnection,
 } from './host-connection'
 import { bootstrapHost } from './host-bootstrap'
 import type { Host, RemoteProject, Session, SessionStatus } from '../shared/types'
@@ -104,12 +105,23 @@ function getRequiredHost(hostId: string): Host {
 }
 
 // Contract: on success the caller owns an incremented refcount on the host
-// SSH runtime and must call releaseHostConnection eventually. Retaining here
-// (after ensureHostConnection puts the runtime in the map) also covers
-// bootstrap failures, which previously left a live runtime with refs=0.
+// SSH runtime and must call releaseHostConnection eventually. Retaining after
+// ensureHostConnection also covers bootstrap failures. An ensureHostConnection
+// failure still has to tear down the hook listener we started first (the
+// reverse-forward target); stopHostConnection triggers the
+// setOnHostConnectionStopped callback to do that.
 async function prepareRemoteHost(host: Host): Promise<{ notifyScriptPath: string }> {
   const localSocketPath = listenHookServerForHost(host.hostId)
-  const { remoteSocketPath } = await ensureHostConnection(host, localSocketPath)
+  let remoteSocketPath: string
+  try {
+    ;({ remoteSocketPath } = await ensureHostConnection(host, localSocketPath))
+  } catch (err) {
+    // SSH couldn't start. Tear down the host runtime (which runtimeFor already
+    // registered) so the hook-server teardown callback fires and we don't leak
+    // the per-host listener across repeated failed startups.
+    await stopHostConnection(host.hostId).catch(() => undefined)
+    throw err
+  }
   retainHostConnection(host.hostId)
   try {
     const bootstrap = await bootstrapHost(

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -103,17 +103,27 @@ function getRequiredHost(hostId: string): Host {
   return host
 }
 
+// Contract: on success the caller owns an incremented refcount on the host
+// SSH runtime and must call releaseHostConnection eventually. Retaining here
+// (after ensureHostConnection puts the runtime in the map) also covers
+// bootstrap failures, which previously left a live runtime with refs=0.
 async function prepareRemoteHost(host: Host): Promise<{ notifyScriptPath: string }> {
   const localSocketPath = listenHookServerForHost(host.hostId)
   const { remoteSocketPath } = await ensureHostConnection(host, localSocketPath)
-  const bootstrap = await bootstrapHost(
-    host.hostId,
-    {
-      exec: (argv, opts) => execRemote(host, argv, opts),
-    },
-    remoteSocketPath
-  )
-  return { notifyScriptPath: bootstrap.notifyScriptPath }
+  retainHostConnection(host.hostId)
+  try {
+    const bootstrap = await bootstrapHost(
+      host.hostId,
+      {
+        exec: (argv, opts) => execRemote(host, argv, opts),
+      },
+      remoteSocketPath
+    )
+    return { notifyScriptPath: bootstrap.notifyScriptPath }
+  } catch (err) {
+    await releaseHostConnection(host.hostId).catch(() => undefined)
+    throw err
+  }
 }
 
 async function expectRemoteOk(host: Host, argv: string[], message: string): Promise<string> {
@@ -383,11 +393,10 @@ async function createRemoteSession(
   const tmuxSession = `cc-pewpew-${id}`
   const branchName = `cc-pewpew/${worktreeName}`
 
+  // prepareRemoteHost retains the SSH runtime on success; we own the ref and
+  // release it at the end (or in catch). createRemotePty takes its own retain
+  // on success, which is what keeps the connection alive past this function.
   const { notifyScriptPath } = await prepareRemoteHost(host)
-  // Own the SSH runtime while we run the failure-prone setup. createRemotePty
-  // takes its own retain on success (paired with the PTY lifecycle); on
-  // failure our release drops the orphaned connection.
-  retainHostConnection(hostId)
   let branch: string
   try {
     const addWithBranch = await execRemote(host, [
@@ -574,8 +583,9 @@ export async function reviveSession(id: string): Promise<void> {
     const hostId = session.hostId
     session.connectionState = 'connecting'
     onSessionsChanged()
+    // prepareRemoteHost retains the SSH runtime on success; we release it at
+    // the end/in catch. createRemotePty/reattachRemotePty take over on success.
     await prepareRemoteHost(host)
-    retainHostConnection(hostId)
     try {
       if (await hasRemoteTmuxSession(id, host)) {
         await reattachRemotePty(id, host)

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -28,7 +28,12 @@ import { installHooks, installRemoteHooks } from './hook-installer'
 import { getHost } from './host-registry'
 import { listRemoteProjects } from './remote-project-registry'
 import { listenHookServerForHost } from './hook-server'
-import { ensureHostConnection, exec as execRemote } from './host-connection'
+import {
+  ensureHostConnection,
+  exec as execRemote,
+  retainHostConnection,
+  releaseHostConnection,
+} from './host-connection'
 import { bootstrapHost } from './host-bootstrap'
 import type { Host, RemoteProject, Session, SessionStatus } from '../shared/types'
 
@@ -379,40 +384,50 @@ async function createRemoteSession(
   const branchName = `cc-pewpew/${worktreeName}`
 
   const { notifyScriptPath } = await prepareRemoteHost(host)
-
-  const addWithBranch = await execRemote(host, [
-    'git',
-    '-C',
-    projectPath,
-    'worktree',
-    'add',
-    worktreePath,
-    '-b',
-    branchName,
-  ])
-  if (addWithBranch.timedOut || addWithBranch.code !== 0) {
-    await expectRemoteOk(
-      host,
-      ['git', '-C', projectPath, 'worktree', 'add', worktreePath],
-      'Failed to create remote worktree'
-    )
-  }
-
-  const branch =
-    (
+  // Own the SSH runtime while we run the failure-prone setup. createRemotePty
+  // takes its own retain on success (paired with the PTY lifecycle); on
+  // failure our release drops the orphaned connection.
+  retainHostConnection(hostId)
+  let branch: string
+  try {
+    const addWithBranch = await execRemote(host, [
+      'git',
+      '-C',
+      projectPath,
+      'worktree',
+      'add',
+      worktreePath,
+      '-b',
+      branchName,
+    ])
+    if (addWithBranch.timedOut || addWithBranch.code !== 0) {
       await expectRemoteOk(
         host,
-        ['git', '-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'],
-        'Failed to resolve remote branch'
+        ['git', '-C', projectPath, 'worktree', 'add', worktreePath],
+        'Failed to create remote worktree'
       )
-    ).trim() || branchName
+    }
 
-  await installRemoteHooks(
-    (argv, opts) => execRemote(host, argv, opts),
-    worktreePath,
-    notifyScriptPath
-  )
-  await createRemotePty(id, worktreePath, host)
+    branch =
+      (
+        await expectRemoteOk(
+          host,
+          ['git', '-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'],
+          'Failed to resolve remote branch'
+        )
+      ).trim() || branchName
+
+    await installRemoteHooks(
+      (argv, opts) => execRemote(host, argv, opts),
+      worktreePath,
+      notifyScriptPath
+    )
+    await createRemotePty(id, worktreePath, host)
+  } catch (err) {
+    await releaseHostConnection(hostId).catch(() => undefined)
+    throw err
+  }
+  await releaseHostConnection(hostId).catch(() => undefined)
 
   const session: Session = {
     id,
@@ -552,10 +567,12 @@ export async function reviveSession(id: string): Promise<void> {
 
   if (session.hostId) {
     const host = getRequiredHost(session.hostId)
+    const hostId = session.hostId
     session.connectionState = 'connecting'
     onSessionsChanged()
+    await prepareRemoteHost(host)
+    retainHostConnection(hostId)
     try {
-      await prepareRemoteHost(host)
       if (await hasRemoteTmuxSession(id, host)) {
         await reattachRemotePty(id, host)
       } else {
@@ -564,8 +581,10 @@ export async function reviveSession(id: string): Promise<void> {
     } catch (err) {
       session.connectionState = 'offline'
       onSessionsChanged()
+      await releaseHostConnection(hostId).catch(() => undefined)
       throw err
     }
+    await releaseHostConnection(hostId).catch(() => undefined)
     session.connectionState = 'live'
     updateSession(id, 'idle')
     return

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,8 +13,8 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.on('hook:event', handler)
     return () => ipcRenderer.removeListener('hook:event', handler)
   },
-  createSession: (projectPath: string, name?: string) =>
-    ipcRenderer.invoke('sessions:create', projectPath, name),
+  createSession: (projectPath: string, name?: string, hostId?: string | null) =>
+    ipcRenderer.invoke('sessions:create', projectPath, name, hostId ?? null),
   createPrSession: (projectPath: string, prNumber: number) =>
     ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber),
   mirrorWorktree: (projectPath: string, worktreePath: string) =>

--- a/src/renderer/SwimLanesApp.tsx
+++ b/src/renderer/SwimLanesApp.tsx
@@ -64,7 +64,12 @@ export default function SwimLanesApp() {
   }, [focusedLane, toggleReview])
 
   const handleRevive = async (id: string) => {
-    await window.api.reviveSession(id)
+    try {
+      await window.api.reviveSession(id)
+    } catch {
+      // Error already logged in main; the swim-lane UI has no toast yet,
+      // but we swallow the rejection here to avoid an unhandled promise.
+    }
   }
 
   return (

--- a/src/renderer/components/DetailPane.tsx
+++ b/src/renderer/components/DetailPane.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import Terminal from './Terminal'
 import ReviewOverlay from './ReviewOverlay'
 import { useSessionsStore } from '../stores/sessions'
+import { useHostsStore } from '../stores/hosts'
 
 interface Props {
   sessionId: string
@@ -11,6 +12,8 @@ interface Props {
 
 export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
   const session = useSessionsStore((s) => s.sessions.find((s) => s.id === sessionId))
+  const hosts = useHostsStore((s) => s.hosts)
+  const host = session?.hostId ? hosts.find((h) => h.hostId === session.hostId) : null
   const isDead = session?.status === 'dead'
   const [reviving, setReviving] = useState(false)
   // Monotonic flip count — each toggle increments by 1, rotating +180deg.
@@ -89,6 +92,11 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
           ←
         </button>
         <span className="detail-pane-title">{sessionName}</span>
+        {host && (
+          <span className="detail-pane-host">
+            {host.label} - {session?.connectionState ?? 'offline'}
+          </span>
+        )}
       </div>
       <div className="detail-pane-terminal">
         {isDead ? (

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -24,6 +24,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [menu, setMenu] = useState<MenuState | null>(null)
   const [pendingSessionPath, setPendingSessionPath] = useState<string | null>(null)
+  const [pendingSessionHostId, setPendingSessionHostId] = useState<string | null>(null)
   const [sessionNameInput, setSessionNameInput] = useState('')
   const [creating, setCreating] = useState(false)
   const [pendingPrPath, setPendingPrPath] = useState<string | null>(null)
@@ -69,6 +70,15 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
     if (menu.hostId !== null) {
       const hostId = menu.hostId
       items.push({
+        label: 'New session...',
+        onClick: () => {
+          setPendingSessionPath(menu.projectPath)
+          setPendingSessionHostId(hostId)
+          setSessionNameInput('')
+        },
+      })
+      items.push({ label: '', separator: true, onClick: () => {} })
+      items.push({
         label: 'Remove remote project',
         onClick: () => void removeRemoteProject(hostId, menu.projectPath),
       })
@@ -90,6 +100,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
         label: 'New session...',
         onClick: () => {
           setPendingSessionPath(menu.projectPath)
+          setPendingSessionHostId(null)
           setSessionNameInput('')
         },
       })
@@ -172,8 +183,9 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
     setCreating(true)
     try {
       const name = sessionNameInput.trim() || undefined
-      await window.api.createSession(pendingSessionPath, name)
+      await window.api.createSession(pendingSessionPath, name, pendingSessionHostId)
       setPendingSessionPath(null)
+      setPendingSessionHostId(null)
       setSessionNameInput('')
     } finally {
       setCreating(false)
@@ -215,7 +227,10 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
             onChange={(e) => setSessionNameInput(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleCreateSession()
-              if (e.key === 'Escape') setPendingSessionPath(null)
+              if (e.key === 'Escape') {
+                setPendingSessionPath(null)
+                setPendingSessionHostId(null)
+              }
             }}
             autoFocus
           />
@@ -223,7 +238,13 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
             <button className="create-btn" onClick={handleCreateSession} disabled={creating}>
               {creating ? 'Creating...' : 'Create'}
             </button>
-            <button className="create-btn cancel" onClick={() => setPendingSessionPath(null)}>
+            <button
+              className="create-btn cancel"
+              onClick={() => {
+                setPendingSessionPath(null)
+                setPendingSessionHostId(null)
+              }}
+            >
               Cancel
             </button>
           </div>

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -128,7 +128,13 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
       {
         label: 'Remove from canvas',
         onClick: async () => {
-          await window.api.removeSession(session.id)
+          try {
+            await window.api.removeSession(session.id)
+          } catch {
+            // Error already logged in main. Fall through to re-scan so the UI
+            // reflects whatever actually survived (e.g. a failed remote remove
+            // leaves the worktree, which scanProjects will still show).
+          }
           useProjectsStore.getState().scanProjects()
         },
       },

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -119,7 +119,11 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
       },
       {
         label: 'Kill session',
-        onClick: () => window.api.killSession(session.id),
+        onClick: () => {
+          // Don't let a rejected IPC (e.g. remote SSH failure) become an
+          // unhandled promise. The main-side error is already logged.
+          void window.api.killSession(session.id).catch(() => undefined)
+        },
       },
       {
         label: 'Remove from canvas',

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import type { Session } from '../../shared/types'
 import { useProjectsStore } from '../stores/projects'
 import { useSessionsStore } from '../stores/sessions'
+import { useHostsStore } from '../stores/hosts'
 import { STATUS_CONFIG } from '../utils/status-config'
 import ContextMenu, { type MenuItem } from './ContextMenu'
 
@@ -28,6 +29,7 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
 
   const selectedIds = useSessionsStore((s) => s.selectedIds)
   const clearSelection = useSessionsStore((s) => s.clearSelection)
+  const hosts = useHostsStore((s) => s.hosts)
   const isSelected = selectedIds.has(session.id)
   const selectedCount = selectedIds.size
 
@@ -36,6 +38,8 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
     return () => clearInterval(interval)
   }, [])
   const { className: statusClass, label } = STATUS_CONFIG[session.status]
+  const host = session.hostId ? hosts.find((h) => h.hostId === session.hostId) : null
+  const connectionState = session.connectionState ?? (host ? 'offline' : undefined)
 
   const sessionName = `${session.projectName}/${session.worktreeName}`
 
@@ -145,6 +149,12 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
     >
       <div className="session-card-thumb">
         {thumbnail ? <pre className="session-card-text-thumb">{thumbnail}</pre> : null}
+        {host && (
+          <div className="session-card-host-overlay" title={`${host.label}: ${connectionState}`}>
+            <span className="host-pill">{host.label}</span>
+            <span className={`connection-dot connection-${connectionState}`} />
+          </div>
+        )}
       </div>
       <div className="session-card-body">
         <div className="session-card-header">{sessionName}</div>
@@ -167,6 +177,7 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
         <div className="session-card-status">
           <span className={`status-dot ${statusClass}`} />
           <span>{label}</span>
+          {host && connectionState && <span className="connection-label">{connectionState}</span>}
         </div>
         <div className="session-card-time">{timeAgo(session.lastActivity)}</div>
       </div>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -18,7 +18,11 @@ declare global {
       createProject: (name: string) => Promise<void>
       openInFileManager: (path: string) => Promise<void>
       onHookEvent: (callback: (event: { method: string; params: unknown }) => void) => () => void
-      createSession: (projectPath: string, name?: string) => Promise<Session>
+      createSession: (
+        projectPath: string,
+        name?: string,
+        hostId?: string | null
+      ) => Promise<Session>
       createPrSession: (projectPath: string, prNumber: number) => Promise<Session | string>
       mirrorWorktree: (
         projectPath: string,

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -330,10 +330,21 @@ body,
 }
 
 .session-card-thumb {
+  position: relative;
   width: 100%;
   height: 150px;
   background: var(--bg-terminal);
   overflow: hidden;
+}
+
+.session-card-host-overlay {
+  position: absolute;
+  left: 8px;
+  bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: calc(100% - 16px);
 }
 
 .session-card-text-thumb {
@@ -449,6 +460,36 @@ body,
 
 .status-dot.status-dead {
   background: var(--accent-red);
+}
+
+.connection-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  border: 1px solid rgba(14, 14, 30, 0.85);
+  flex-shrink: 0;
+}
+
+.connection-live {
+  background: var(--accent-green);
+}
+
+.connection-connecting {
+  background: var(--accent-yellow);
+}
+
+.connection-auth-failed,
+.connection-unreachable {
+  background: var(--accent-red);
+}
+
+.connection-offline {
+  background: var(--text-secondary);
+}
+
+.connection-label {
+  color: var(--text-secondary);
+  font-size: 12px;
 }
 
 .session-card-time {
@@ -782,6 +823,14 @@ body,
   font-size: 14px;
   font-weight: 600;
   color: var(--text-primary);
+}
+
+.detail-pane-host {
+  font-size: 12px;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
 }
 
 .detail-pane-terminal {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,5 @@
 export type SessionStatus = 'running' | 'needs_input' | 'idle' | 'completed' | 'error' | 'dead'
+export type ConnectionState = 'connecting' | 'live' | 'offline' | 'auth-failed' | 'unreachable'
 
 export interface Project {
   name: string
@@ -18,6 +19,7 @@ export interface Worktree {
 
 export interface Session {
   id: string
+  hostId: string | null
   projectPath: string
   projectName: string
   worktreeName: string
@@ -28,6 +30,7 @@ export interface Session {
   pid: number
   tmuxSession: string
   status: SessionStatus
+  connectionState?: ConnectionState
   lastActivity: number
   hookEvents: HookEvent[]
   repoFingerprint?: string
@@ -37,6 +40,7 @@ export interface HookEvent {
   method: string
   sessionId: string
   timestamp: number
+  originHostId?: string | null
   data: Record<string, unknown>
 }
 


### PR DESCRIPTION
## What changed
- added a persistent per-host SSH control connection with reverse Unix-socket forwarding for remote sessions
- added remote host bootstrap to probe required tools, verify the forwarded hook socket, and install versioned remote notify hooks
- refactored hook IPC to support local plus per-host origin sockets and drop host-mismatched events
- taught session creation and PTY lifecycle to create remote worktrees, launch remote tmux-backed Claude sessions, and attach them into the existing xterm flow
- added minimal remote session UI affordances: remote project session creation, host pill overlay, connection dot, and detail-pane host/state label
- added focused tests for host bootstrap and multi-origin hook dispatch

## Why
Remote projects already existed, but they could not actually launch or observe Claude sessions end-to-end. The missing pieces were the long-lived SSH control connection, remote bootstrap/install flow, per-host hook ingress, and remote PTY/session orchestration.

## Scope notes
This PR stays intentionally scoped to issue #11.

Deferred to follow-up issues and not implemented here:
- #12 restart-time persistence and lazy reconnect states
- #13 remote thumbnail capture pipeline
- #14 host-delete cascade behavior
- #15 remote review-pane disablement / coming-soon UX
- #16 diagnostic toasts and per-host ring buffer logging

## User impact
Users can now create a session from a registered remote project and have Claude run on the remote machine, stream into the local UI, and send hook events back through the reverse-tunneled per-host socket.

## Validation
- `npx tsc --noEmit`
- `npx vitest run`
- `npx eslint .`
- `npm run build`

Closes #11
