### PR TITLE
feat: scan subdirectories with configurable scanDepth

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -21,6 +21,7 @@ export interface AppConfig {
   scanDirs: string[]
   pinnedPaths: string[]
   followSymlinks: boolean
+  scanDepth: number
   canvas: CanvasState
   clusterPositions: Record<string, { x: number; y: number }>
   windowState?: WindowState
@@ -41,6 +42,7 @@ const DEFAULT_CONFIG: AppConfig = {
   scanDirs: ['~/dev'],
   pinnedPaths: [],
   followSymlinks: true,
+  scanDepth: 3,
   canvas: { zoom: 0.7, panX: 0, panY: 0 },
   clusterPositions: {},
   sidebarWidth: 250,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -139,7 +139,7 @@ app.whenReady().then(async () => {
     const config = getConfig()
     const dirs = config.scanDirs.map(resolvePath)
     const pinned = (config.pinnedPaths || []).map(resolvePath)
-    const local = await scanProjects(dirs, pinned, config.followSymlinks)
+    const local = await scanProjects(dirs, pinned, config.followSymlinks, config.scanDepth)
     const remote = listRemoteProjects().map(remoteToProject)
     return [...local, ...remote].sort((a, b) => a.name.localeCompare(b.name))
   })

--- a/src/main/project-scanner.test.ts
+++ b/src/main/project-scanner.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest'
-import { parseWorktreeList } from './project-scanner'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, symlinkSync, rmSync, chmodSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { discoverRepos, parseWorktreeList } from './project-scanner'
 
 describe('parseWorktreeList', () => {
   it('returns empty array for empty input', () => {
@@ -62,5 +65,173 @@ describe('parseWorktreeList', () => {
     const result = parseWorktreeList(stdout)
     expect(result).toHaveLength(1)
     expect(result[0].isMain).toBe(true)
+  })
+})
+
+describe('discoverRepos', () => {
+  let root: string
+
+  function makeRepo(path: string): void {
+    mkdirSync(join(path, '.git'), { recursive: true })
+  }
+
+  function makeDir(path: string): void {
+    mkdirSync(path, { recursive: true })
+  }
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'discoverRepos-'))
+  })
+
+  afterEach(() => {
+    try {
+      chmodSync(root, 0o755)
+    } catch {
+      // ignore
+    }
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('depth=1 matches current behavior (direct children only)', () => {
+    makeRepo(join(root, 'alpha'))
+    makeRepo(join(root, 'beta', 'sub'))
+    makeDir(join(root, 'gamma'))
+
+    const result = discoverRepos([root], [], true, 1)
+
+    expect(result.map((r) => r.name)).toEqual(['alpha'])
+  })
+
+  it('depth=1 still includes a dotdir child with .git (regression guard)', () => {
+    makeRepo(join(root, '.config-repo'))
+
+    const result = discoverRepos([root], [], true, 1)
+
+    expect(result.map((r) => r.name)).toEqual(['.config-repo'])
+  })
+
+  it('depth=2 discovers nested repos', () => {
+    makeRepo(join(root, 'alpha'))
+    makeRepo(join(root, 'beta', 'sub'))
+
+    const result = discoverRepos([root], [], true, 2)
+
+    expect(result.map((r) => r.name).sort()).toEqual(['alpha', 'sub'])
+  })
+
+  it('stops descending once a .git is found', () => {
+    makeRepo(join(root, 'alpha'))
+    makeRepo(join(root, 'alpha', '.claude', 'worktrees', 'wt'))
+
+    const result = discoverRepos([root], [], true, 5)
+
+    expect(result.map((r) => r.name)).toEqual(['alpha'])
+  })
+
+  it('skips node_modules during recursion', () => {
+    makeRepo(join(root, 'pkg'))
+    makeRepo(join(root, 'pkg-consumer', 'node_modules', 'nested'))
+
+    const result = discoverRepos([root], [], true, 5)
+
+    expect(result.map((r) => r.name)).toEqual(['pkg'])
+  })
+
+  it('skips dotdirs during recursion (past depth 1)', () => {
+    makeRepo(join(root, 'container', '.hidden', 'repo'))
+
+    const result = discoverRepos([root], [], true, 5)
+
+    expect(result).toEqual([])
+  })
+
+  it('dedupes across scanDirs via symlink', () => {
+    makeRepo(join(root, 'real', 'alpha'))
+    symlinkSync(join(root, 'real'), join(root, 'mirror'))
+
+    const result = discoverRepos([join(root, 'real'), join(root, 'mirror')], [], true, 2)
+
+    expect(result.map((r) => r.name)).toEqual(['alpha'])
+  })
+
+  it('terminates on symlink cycles', () => {
+    makeDir(join(root, 'a'))
+    symlinkSync(root, join(root, 'a', 'loop'))
+    makeRepo(join(root, 'a', 'real-repo'))
+
+    const result = discoverRepos([root], [], true, 6)
+
+    expect(result.map((r) => r.name)).toEqual(['real-repo'])
+  })
+
+  it('skips broken symlinks silently', () => {
+    symlinkSync(join(root, 'does-not-exist'), join(root, 'dangling'))
+    makeRepo(join(root, 'alpha'))
+
+    const result = discoverRepos([root], [], true, 3)
+
+    expect(result.map((r) => r.name)).toEqual(['alpha'])
+  })
+
+  it('includes and dedupes pinned paths', () => {
+    makeRepo(join(root, 'alpha'))
+    const pinned = join(root, 'pinned', 'repo')
+    makeRepo(pinned)
+
+    const result = discoverRepos([root], [pinned], true, 1)
+
+    // root yields alpha (pinned not reached at depth 1); pinned adds 'repo'.
+    expect(result.map((r) => r.name).sort()).toEqual(['alpha', 'repo'])
+  })
+
+  it('dedupes pinned path against scanDir discovery', () => {
+    const repoPath = join(root, 'alpha')
+    makeRepo(repoPath)
+
+    const result = discoverRepos([root], [repoPath], true, 1)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].path).toBe(repoPath)
+  })
+
+  it('silently skips non-existent scanDir', () => {
+    makeRepo(join(root, 'alpha'))
+
+    const result = discoverRepos([join(root, 'missing'), root], [], true, 1)
+
+    expect(result.map((r) => r.name)).toEqual(['alpha'])
+  })
+
+  it('does not abort the walk when a subdir is unreadable', () => {
+    makeRepo(join(root, 'alpha'))
+    const locked = join(root, 'locked')
+    makeDir(locked)
+    makeRepo(join(root, 'beta'))
+    chmodSync(locked, 0o000)
+    try {
+      const result = discoverRepos([root], [], true, 3)
+      expect(result.map((r) => r.name).sort()).toEqual(['alpha', 'beta'])
+    } finally {
+      chmodSync(locked, 0o755)
+    }
+  })
+
+  it('clamps maxDepth=0 up to 1', () => {
+    makeRepo(join(root, 'alpha'))
+    makeRepo(join(root, 'beta', 'sub'))
+
+    const result = discoverRepos([root], [], true, 0)
+
+    expect(result.map((r) => r.name)).toEqual(['alpha'])
+  })
+
+  it('clamps large maxDepth down to 6', () => {
+    // Build a chain 7 levels deep: root/a/b/c/d/e/f/repo/.git
+    makeRepo(join(root, 'a', 'b', 'c', 'd', 'e', 'f', 'repo'))
+
+    const result = discoverRepos([root], [], true, 99)
+
+    // Depth 6 means the walk visits depth 1..6; 'repo' at level 7 is out of reach.
+    expect(result).toEqual([])
   })
 })

--- a/src/main/project-scanner.ts
+++ b/src/main/project-scanner.ts
@@ -76,42 +76,68 @@ function detectSetupState(repoPath: string): 'ready' | 'unsetup' {
   }
 }
 
-function discoverRepos(
+const EXCLUDED_DIR_NAMES = new Set(['node_modules'])
+
+function safeRealpath(p: string): string | null {
+  try {
+    return realpathSync(p)
+  } catch {
+    return null
+  }
+}
+
+export function discoverRepos(
   scanDirs: string[],
   pinnedPaths: string[],
-  followSymlinks: boolean
+  followSymlinks: boolean,
+  maxDepth: number
 ): { name: string; path: string }[] {
+  const depth = Math.max(1, Math.min(6, maxDepth))
   const repos: { name: string; path: string }[] = []
   const seen = new Set<string>()
 
-  for (const dir of scanDirs) {
-    if (!existsSync(dir)) continue
-
+  function walk(dir: string, currentDepth: number): void {
     let entries: string[]
     try {
       entries = readdirSync(dir)
     } catch {
-      continue
+      return
     }
 
     for (const entry of entries) {
       const entryPath = join(dir, entry)
+
       try {
         if (!followSymlinks && lstatSync(entryPath).isSymbolicLink()) continue
         if (!statSync(entryPath).isDirectory()) continue
       } catch {
         continue
       }
-      if (!existsSync(join(entryPath, '.git'))) continue
-      const realPath = followSymlinks ? realpathSync(entryPath) : entryPath
+
+      const realPath = followSymlinks ? safeRealpath(entryPath) : entryPath
+      if (realPath === null) continue
       if (seen.has(realPath)) continue
-      repos.push({ name: entry, path: entryPath })
       seen.add(realPath)
+
+      if (existsSync(join(entryPath, '.git'))) {
+        repos.push({ name: entry, path: entryPath })
+        continue
+      }
+
+      if (currentDepth < depth && !entry.startsWith('.') && !EXCLUDED_DIR_NAMES.has(entry)) {
+        walk(entryPath, currentDepth + 1)
+      }
     }
   }
 
+  for (const dir of scanDirs) {
+    if (!existsSync(dir)) continue
+    walk(dir, 1)
+  }
+
   for (const pinned of pinnedPaths) {
-    const realPinned = followSymlinks ? realpathSync(pinned) : pinned
+    const realPinned = followSymlinks ? safeRealpath(pinned) : pinned
+    if (realPinned === null) continue
     if (seen.has(realPinned)) continue
     try {
       if (!followSymlinks && lstatSync(pinned).isSymbolicLink()) continue
@@ -159,9 +185,10 @@ export async function getRepoFingerprint(repoPath: string): Promise<string | und
 export async function scanProjects(
   scanDirs: string[],
   pinnedPaths?: string[],
-  followSymlinks?: boolean
+  followSymlinks?: boolean,
+  scanDepth?: number
 ): Promise<Project[]> {
-  const repos = discoverRepos(scanDirs, pinnedPaths || [], followSymlinks ?? true)
+  const repos = discoverRepos(scanDirs, pinnedPaths || [], followSymlinks ?? true, scanDepth ?? 3)
   const projects: Project[] = []
 
   // Process in batches to avoid spawning hundreds of git processes


### PR DESCRIPTION
## Summary

- Project scanner recurses through each `scanDir` up to a new `scanDepth` config field (default `3`, clamped to `[1, 6]`), so nested repos like `~/dev/saas/petovita` and `~/dev/vow-lang/vow` are discovered without manual pinning.
- `scanDepth: 1` reproduces current behavior exactly (direct children only). Existing configs gain the default automatically via `getConfig()`'s spread merge — no manual edit needed.
- Stop-on-repo: once `.git` is found, the dir is included and not descended into, so submodules and `.claude/worktrees/*` don't appear as separate projects.
- Dotdirs and `node_modules` are skipped only from the recursion decision, never from `.git` inclusion — a direct child named `.config-repo` with `.git` is still listed.
- Hardened: every `realpathSync`, `readdirSync`, `lstatSync`, `statSync` is wrapped in try/catch at every recursion level; a shared `seen` set (keyed on realpath) guards against symlink cycles and dedupes across scanDirs + pinned paths.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `npx vitest run` — 153/153 pass, including 19 new `discoverRepos` cases (depth parity, dotdir-child regression guard, stop-on-repo, node_modules/dotdir exclusion, symlink dedup & cycle termination, broken symlinks, pinned-path dedup, missing scanDir, permission-denied mid-walk, clamp 0→1 and 99→6)
- [x] Real-world smoke: `scanProjects(['/home/pmatos/dev'], [], true, 3)` now surfaces `saas/petovita`, `saas/rightkey.app`, `vow-lang/vow`, `vow-lang/vow-website`, `igalia/wpe-tools`, `lean-learn/test`, `tri-foo/www` — previously invisible