### PR TITLE
feat: persist remote sessions + lazy reconnect across app restart

### DIFF
--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -23,7 +23,7 @@ export interface ExecResult {
   timedOut: boolean
 }
 
-type HostConnectionState = 'offline' | 'connecting' | 'live' | 'auth-failed' | 'unreachable'
+export type HostConnectionState = 'offline' | 'connecting' | 'live' | 'auth-failed' | 'unreachable'
 
 interface HostRuntime {
   host: Host
@@ -200,11 +200,18 @@ async function waitForControl(runtime: HostRuntime): Promise<void> {
   throw new Error('ssh control connection did not become ready')
 }
 
-function classifyConnectionFailure(code: number | null, stderr: string): HostConnectionState {
+export function classifyConnectionFailure(
+  code: number | null,
+  stderr: string
+): HostConnectionState {
   const { reason } = classifySshExit({ exitCode: code, stderr })
   if (reason === 'auth-failed') return 'auth-failed'
   if (reason === 'network') return 'unreachable'
   return 'offline'
+}
+
+export function runtimeStateFor(hostId: HostId): HostConnectionState | undefined {
+  return runtimes.get(hostId)?.state
 }
 
 async function startRuntime(runtime: HostRuntime): Promise<void> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,7 @@ import {
   destroyPty,
   getScrollback,
   captureThumbnails,
+  getLastSnapshot,
 } from './pty-manager'
 import {
   initSessionManager,
@@ -35,9 +36,11 @@ import {
   restoreSessions,
   killSession,
   reviveSession,
+  reconnectRemoteSession,
   removeWorktree,
   removeSession,
   relocateProject,
+  updateLastKnownState,
 } from './session-manager'
 import { parseDiff, synthesizeUntrackedFile } from './diff-parser'
 import { listHosts, addHost, updateHost, deleteHost, getHost } from './host-registry'
@@ -288,6 +291,15 @@ app.whenReady().then(async () => {
     }
   })
 
+  ipcMain.handle('sessions:reconnect', async (_event, id: string) => {
+    try {
+      await reconnectRemoteSession(id)
+    } catch (err) {
+      console.error(`Failed to reconnect session ${id}:`, err)
+      throw err
+    }
+  })
+
   ipcMain.handle('sessions:remove-worktree', async (_event, id: string) => {
     await removeWorktree(id)
   })
@@ -533,11 +545,19 @@ app.whenReady().then(async () => {
   initPtyManager()
   restoreSessions()
 
-  // Periodic text thumbnail capture from tmux
+  // Periodic text thumbnail capture from tmux.
+  // Also snapshots `lastKnownState` from every live PTY buffer (local + remote)
+  // so a remote session's cached preview survives the next app restart without
+  // any new SSH traffic (issue #12 AC #1 / #9). updateLastKnownState rate-limits
+  // internally so the 3s tick doesn't churn sessions.json.
   const thumbInterval = setInterval(() => {
     const thumbs = captureThumbnails()
     if (Object.keys(thumbs).length > 0) {
       broadcastToAll('thumbnails:text-updated', thumbs)
+    }
+    for (const session of getSessions()) {
+      const text = getLastSnapshot(session.id)
+      if (text) updateLastKnownState(session.id, text)
     }
   }, 3000)
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,7 +40,7 @@ import {
   removeWorktree,
   removeSession,
   relocateProject,
-  updateLastKnownState,
+  updateLastKnownStatesBatch,
 } from './session-manager'
 import { parseDiff, synthesizeUntrackedFile } from './diff-parser'
 import { listHosts, addHost, updateHost, deleteHost, getHost } from './host-registry'
@@ -548,17 +548,21 @@ app.whenReady().then(async () => {
   // Periodic text thumbnail capture from tmux.
   // Also snapshots `lastKnownState` from every live PTY buffer (local + remote)
   // so a remote session's cached preview survives the next app restart without
-  // any new SSH traffic (issue #12 AC #1 / #9). updateLastKnownState rate-limits
-  // internally so the 3s tick doesn't churn sessions.json.
+  // any new SSH traffic (issue #12 AC #1 / #9). The batch helper applies the
+  // 10s per-session rate limit and emits a single persist + broadcast per
+  // tick, avoiding an O(N) write storm when many sessions unlock the window
+  // simultaneously.
   const thumbInterval = setInterval(() => {
     const thumbs = captureThumbnails()
     if (Object.keys(thumbs).length > 0) {
       broadcastToAll('thumbnails:text-updated', thumbs)
     }
+    const updates: { id: string; text: string }[] = []
     for (const session of getSessions()) {
       const text = getLastSnapshot(session.id)
-      if (text) updateLastKnownState(session.id, text)
+      if (text) updates.push({ id: session.id, text })
     }
+    if (updates.length > 0) updateLastKnownStatesBatch(updates)
   }, 3000)
 
   app.on('activate', () => {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -331,6 +331,31 @@ export async function hasRemoteTmuxSession(sessionId: string, host: Host): Promi
   return result.code === 0 && !result.timedOut
 }
 
+// Discriminated probe: distinguishes "tmux session is absent on the remote"
+// from "we couldn't reach the remote to ask". The boolean `hasRemoteTmuxSession`
+// collapses both into `false`, which reconnect/batch-probe paths would otherwise
+// treat as a dead session and incorrectly downgrade a still-running remote
+// terminal.
+export type RemoteTmuxProbeResult = 'present' | 'absent' | 'unreachable'
+
+export async function probeRemoteTmuxSession(
+  sessionId: string,
+  host: Host
+): Promise<RemoteTmuxProbeResult> {
+  const result = await execRemote(host, ['tmux', 'has-session', '-t', `cc-pewpew-${sessionId}`], {
+    timeoutMs: 3000,
+  })
+  if (result.timedOut) return 'unreachable'
+  if (result.code === 0) return 'present'
+  const { reason } = classifySshExit({ exitCode: result.code, stderr: result.stderr })
+  if (reason === 'auth-failed' || reason === 'network' || reason === 'dep-missing') {
+    return 'unreachable'
+  }
+  // Non-zero exit with no SSH-level failure marker is tmux's own "can't find
+  // session" exit. The remote is reachable; the session is simply gone.
+  return 'absent'
+}
+
 export async function getScrollback(sessionId: string): Promise<string> {
   const entry = ptys.get(sessionId)
   if (entry?.host) {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -17,9 +17,15 @@ interface PtyEntry {
   pty: IPty
   tmuxSession: string
   buffer: string
+  // Trailing window of PTY output. Populated on every flush so issue #12's
+  // `lastKnownState` survives restart with the last-seen pane text. Capped to
+  // LAST_SNAPSHOT_MAX bytes so a 100-session `sessions.json` stays small.
+  lastSnapshot: string
   host?: Host
   released?: boolean
 }
+
+const LAST_SNAPSHOT_MAX = 3 * 1024
 
 const ptys = new Map<string, PtyEntry>()
 let flushInterval: ReturnType<typeof setInterval> | null = null
@@ -28,9 +34,17 @@ function flushBuffers(): void {
   for (const [sessionId, entry] of ptys) {
     if (entry.buffer.length > 0) {
       broadcastToAll('pty:data', { sessionId, data: entry.buffer })
+      const appended = entry.lastSnapshot + entry.buffer
+      entry.lastSnapshot =
+        appended.length > LAST_SNAPSHOT_MAX ? appended.slice(-LAST_SNAPSHOT_MAX) : appended
       entry.buffer = ''
     }
   }
+}
+
+export function getLastSnapshot(sessionId: string): string | undefined {
+  const entry = ptys.get(sessionId)
+  return entry?.lastSnapshot || undefined
 }
 
 export function isTmuxAvailable(): boolean {
@@ -106,6 +120,7 @@ export function createPty(
     pty: ptyProcess,
     tmuxSession,
     buffer: '',
+    lastSnapshot: '',
   }
 
   ptyProcess.onData((data) => {
@@ -170,6 +185,7 @@ export async function createRemotePty(
     pty: ptyProcess,
     tmuxSession,
     buffer: '',
+    lastSnapshot: '',
     host,
   }
 
@@ -367,6 +383,7 @@ export function reattachPty(sessionId: string): void {
     pty: ptyProcess,
     tmuxSession,
     buffer: '',
+    lastSnapshot: '',
   }
 
   ptyProcess.onData((data) => {
@@ -410,6 +427,7 @@ export async function reattachRemotePty(sessionId: string, host: Host): Promise<
     pty: ptyProcess,
     tmuxSession,
     buffer: '',
+    lastSnapshot: '',
     host,
   }
 

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1,0 +1,500 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Host, Session } from '../shared/types'
+
+// Hoisted state so vi.mock factories can reach mutable per-test values before
+// the SUT imports run.
+const state = vi.hoisted(() => ({
+  configDir: '',
+  liveTmuxIds: [] as string[],
+  tmuxAvailable: true,
+  repoFingerprint: undefined as string | undefined,
+  hosts: [] as Host[],
+  runtimeStates: new Map<string, string>(),
+  // Call logs for assertion.
+  ensureHostConnectionCalls: [] as string[],
+  createRemotePtyCalls: [] as { sessionId: string; cwd: string; hostId: string }[],
+  reattachRemotePtyCalls: [] as { sessionId: string; hostId: string }[],
+  createPtyCalls: [] as { sessionId: string; cwd: string }[],
+  reattachPtyCalls: [] as string[],
+  hasRemoteTmuxResult: new Map<string, boolean>(),
+  execRemoteCalls: [] as { hostId: string; argv: string[] }[],
+  // Toggle to simulate ensureHostConnection throwing.
+  ensureHostConnectionThrows: null as null | { message: string; runtimeStateAfter: string },
+  // When set, delays next ensureHostConnection resolution (used for idempotency
+  // and cascade tests).
+  ensureHostConnectionGate: null as null | Promise<void>,
+}))
+
+vi.mock('./config', () => ({
+  get CONFIG_DIR() {
+    return state.configDir
+  },
+  getConfig: () => ({
+    scanDirs: [],
+    pinnedPaths: [],
+    followSymlinks: true,
+    canvas: { zoom: 1, panX: 0, panY: 0 },
+    clusterPositions: {},
+    sidebarWidth: 250,
+    uiScale: 1,
+    hosts: state.hosts,
+    remoteProjects: [],
+  }),
+  saveConfig: vi.fn(),
+}))
+
+vi.mock('./window-registry', () => ({
+  broadcastToAll: vi.fn(),
+  getMainWindow: () => null,
+}))
+
+vi.mock('./tray', () => ({
+  updateTray: vi.fn(),
+  createTray: vi.fn(),
+}))
+
+vi.mock('./notifications', () => ({
+  notifyNeedsInput: vi.fn(),
+}))
+
+vi.mock('./project-scanner', () => ({
+  getRepoFingerprint: vi.fn(async () => state.repoFingerprint),
+  gitWorktrees: vi.fn(async () => []),
+}))
+
+vi.mock('./hook-installer', () => ({
+  installHooks: vi.fn(async () => undefined),
+  installRemoteHooks: vi.fn(async () => undefined),
+}))
+
+vi.mock('./host-registry', () => ({
+  getHost: (hostId: string) => state.hosts.find((h) => h.hostId === hostId),
+}))
+
+vi.mock('./remote-project-registry', () => ({
+  listRemoteProjects: () => [],
+}))
+
+vi.mock('./hook-server', () => ({
+  listenHookServerForHost: (hostId: string) => `/tmp/cc-pewpew-ipc-${hostId}.sock`,
+}))
+
+vi.mock('./host-bootstrap', () => ({
+  bootstrapHost: vi.fn(async () => ({ notifyScriptPath: '/tmp/notify-v1.sh' })),
+}))
+
+vi.mock('./pty-manager', () => ({
+  createPty: (sessionId: string, cwd: string) => {
+    state.createPtyCalls.push({ sessionId, cwd })
+  },
+  detachPty: vi.fn(),
+  destroyPty: vi.fn(),
+  destroyRemotePty: vi.fn(async () => undefined),
+  hasPty: vi.fn(() => false),
+  hasTmuxSession: vi.fn(() => false),
+  hasRemoteTmuxSession: vi.fn(async (sessionId: string) => {
+    return state.hasRemoteTmuxResult.get(sessionId) ?? false
+  }),
+  isTmuxAvailable: () => state.tmuxAvailable,
+  discoverTmuxSessions: () => [...state.liveTmuxIds],
+  reattachPty: (sessionId: string) => {
+    state.reattachPtyCalls.push(sessionId)
+  },
+  reattachRemotePty: async (sessionId: string, host: Host) => {
+    state.reattachRemotePtyCalls.push({ sessionId, hostId: host.hostId })
+  },
+  createRemotePty: async (sessionId: string, cwd: string, host: Host) => {
+    state.createRemotePtyCalls.push({ sessionId, cwd, hostId: host.hostId })
+  },
+}))
+
+vi.mock('./host-connection', () => ({
+  ensureHostConnection: async (host: Host) => {
+    state.ensureHostConnectionCalls.push(host.hostId)
+    if (state.ensureHostConnectionGate) await state.ensureHostConnectionGate
+    if (state.ensureHostConnectionThrows) {
+      const stateAfter = state.ensureHostConnectionThrows.runtimeStateAfter
+      state.runtimeStates.set(host.hostId, stateAfter)
+      throw new Error(state.ensureHostConnectionThrows.message)
+    }
+    state.runtimeStates.set(host.hostId, 'live')
+    return { remoteSocketPath: '/tmp/remote.sock', controlPath: '/tmp/cm.sock' }
+  },
+  exec: async (hostOrAlias: Host | string, argv: string[]) => {
+    const hostId = typeof hostOrAlias === 'string' ? hostOrAlias : hostOrAlias.hostId
+    state.execRemoteCalls.push({ hostId, argv })
+    return { stdout: '', stderr: '', code: 0, timedOut: false }
+  },
+  retainHostConnection: vi.fn(),
+  releaseHostConnection: vi.fn(async () => undefined),
+  stopHostConnection: vi.fn(async () => undefined),
+  runtimeStateFor: (hostId: string) => state.runtimeStates.get(hostId),
+  classifyConnectionFailure: (_code: number | null, _stderr: string) => 'offline',
+}))
+
+// Import SUT after all mocks are registered.
+async function loadSessionManager(): Promise<typeof import('./session-manager')> {
+  vi.resetModules()
+  return import('./session-manager')
+}
+
+function writeSessionsJson(sessions: Partial<Session>[]): void {
+  writeFileSync(join(state.configDir, 'sessions.json'), JSON.stringify(sessions))
+}
+
+function baseRemoteSession(overrides: Partial<Session>): Session {
+  return {
+    id: 'r1',
+    hostId: 'h1',
+    projectPath: '/remote/proj',
+    projectName: 'proj',
+    worktreeName: 'feat',
+    worktreePath: '/remote/proj/.claude/worktrees/feat',
+    branch: 'cc-pewpew/feat',
+    pid: 0,
+    tmuxSession: 'cc-pewpew-r1',
+    status: 'idle',
+    lastActivity: 1000,
+    hookEvents: [],
+    ...overrides,
+  }
+}
+
+function baseLocalSession(overrides: Partial<Session>): Session {
+  return {
+    id: 'l1',
+    hostId: null,
+    projectPath: '/local/proj',
+    projectName: 'proj',
+    worktreeName: 'local-feat',
+    worktreePath: join(state.configDir, 'local-wt'),
+    branch: 'cc-pewpew/local-feat',
+    pid: 0,
+    tmuxSession: 'cc-pewpew-l1',
+    status: 'idle',
+    lastActivity: 1000,
+    hookEvents: [],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  state.configDir = mkdtempSync(join(tmpdir(), 'sess-mgr-'))
+  state.liveTmuxIds = []
+  state.tmuxAvailable = true
+  state.repoFingerprint = undefined
+  state.hosts = [{ hostId: 'h1', alias: 'devbox', label: 'Dev' }]
+  state.runtimeStates = new Map()
+  state.ensureHostConnectionCalls = []
+  state.createRemotePtyCalls = []
+  state.reattachRemotePtyCalls = []
+  state.createPtyCalls = []
+  state.reattachPtyCalls = []
+  state.hasRemoteTmuxResult = new Map()
+  state.execRemoteCalls = []
+  state.ensureHostConnectionThrows = null
+  state.ensureHostConnectionGate = null
+})
+
+afterEach(() => {
+  rmSync(state.configDir, { recursive: true, force: true })
+})
+
+describe('restoreSessions — remote lazy materialization', () => {
+  it('materializes remote sessions in pending state and opens no SSH', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    const got = sm.getSessions()
+    expect(got).toHaveLength(1)
+    expect(got[0].connectionState).toBe('pending')
+    expect(got[0].status).toBe('idle')
+    expect(state.ensureHostConnectionCalls).toEqual([])
+    expect(state.createRemotePtyCalls).toEqual([])
+    expect(state.reattachRemotePtyCalls).toEqual([])
+  })
+
+  it('round-trips lastKnownState across restore', async () => {
+    writeSessionsJson([
+      baseRemoteSession({
+        id: 'r1',
+        lastKnownState: { text: 'cached preview', timestamp: 42 },
+      }),
+    ])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    const got = sm.getSessions()[0]
+    expect(got.lastKnownState).toEqual({ text: 'cached preview', timestamp: 42 })
+  })
+
+  it('normalizes remote running → idle (mid-session crash normalization)', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'running' })])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    expect(sm.getSessions()[0].status).toBe('idle')
+    expect(sm.getSessions()[0].connectionState).toBe('pending')
+  })
+
+  it('preserves dead status and skips connectionState for confirmed-dead remote', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'dead' })])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    expect(sm.getSessions()[0].status).toBe('dead')
+    expect(sm.getSessions()[0].connectionState).toBeUndefined()
+  })
+
+  it('preserves needs_input status on restore', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'needs_input' })])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    expect(sm.getSessions()[0].status).toBe('needs_input')
+    expect(sm.getSessions()[0].connectionState).toBe('pending')
+  })
+
+  it('tolerates missing lastKnownState (fresh post-deploy restart)', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1' })])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    expect(sm.getSessions()[0].lastKnownState).toBeUndefined()
+  })
+})
+
+describe('reconnectRemoteSession', () => {
+  it('tmux present → reattach and mark live', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.hasRemoteTmuxResult.set('r1', true)
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.reconnectRemoteSession('r1')
+
+    const got = sm.getSessions()[0]
+    expect(got.connectionState).toBe('live')
+    expect(got.status).toBe('idle')
+    expect(state.reattachRemotePtyCalls).toEqual([{ sessionId: 'r1', hostId: 'h1' }])
+    expect(state.createRemotePtyCalls).toEqual([])
+  })
+
+  it('tmux gone → mark session dead without creating new PTY', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.hasRemoteTmuxResult.set('r1', false)
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.reconnectRemoteSession('r1')
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('dead')
+    expect(got.connectionState).toBe('offline')
+    expect(state.createRemotePtyCalls).toEqual([])
+    expect(state.reattachRemotePtyCalls).toEqual([])
+  })
+
+  it('auth-failed classification via runtimeStateFor', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.ensureHostConnectionThrows = {
+      message: 'Permission denied (publickey)',
+      runtimeStateAfter: 'auth-failed',
+    }
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await expect(sm.reconnectRemoteSession('r1')).rejects.toThrow(/Permission denied/)
+
+    const got = sm.getSessions()[0]
+    expect(got.connectionState).toBe('auth-failed')
+    expect(got.status).toBe('idle')
+    expect(state.reattachRemotePtyCalls).toEqual([])
+  })
+
+  it('network failure classified as unreachable', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.ensureHostConnectionThrows = {
+      message: 'Connection refused',
+      runtimeStateAfter: 'unreachable',
+    }
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await expect(sm.reconnectRemoteSession('r1')).rejects.toThrow(/Connection refused/)
+
+    expect(sm.getSessions()[0].connectionState).toBe('unreachable')
+  })
+
+  it('orphaned hostId → unreachable without SSH attempt', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', hostId: 'missing-host' })])
+    state.hosts = [] // host registry empty
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await expect(sm.reconnectRemoteSession('r1')).rejects.toThrow(/was removed/)
+
+    expect(sm.getSessions()[0].connectionState).toBe('unreachable')
+    expect(state.ensureHostConnectionCalls).toEqual([])
+  })
+
+  it('idempotency: concurrent calls coalesce into a single SSH attempt', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.hasRemoteTmuxResult.set('r1', true)
+    let gateResolve!: () => void
+    state.ensureHostConnectionGate = new Promise<void>((res) => {
+      gateResolve = res
+    })
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    const a = sm.reconnectRemoteSession('r1')
+    const b = sm.reconnectRemoteSession('r1')
+    gateResolve()
+    await Promise.all([a, b])
+
+    expect(state.ensureHostConnectionCalls).toEqual(['h1'])
+    expect(state.reattachRemotePtyCalls).toHaveLength(1)
+  })
+
+  it('retry succeeds after an auth-failed attempt (no app restart needed)', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.ensureHostConnectionThrows = {
+      message: 'Permission denied',
+      runtimeStateAfter: 'auth-failed',
+    }
+    state.hasRemoteTmuxResult.set('r1', true)
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await expect(sm.reconnectRemoteSession('r1')).rejects.toThrow()
+    expect(sm.getSessions()[0].connectionState).toBe('auth-failed')
+
+    // User fixes SSH config → retry succeeds.
+    state.ensureHostConnectionThrows = null
+    await sm.reconnectRemoteSession('r1')
+
+    expect(sm.getSessions()[0].connectionState).toBe('live')
+    expect(state.ensureHostConnectionCalls).toEqual(['h1', 'h1'])
+  })
+})
+
+describe('probePendingSessionsOnHost', () => {
+  function threePendingOnH1(): Session[] {
+    return [
+      baseRemoteSession({ id: 'a', hostId: 'h1', status: 'idle' }),
+      baseRemoteSession({ id: 'b', hostId: 'h1', status: 'idle' }),
+      baseRemoteSession({ id: 'c', hostId: 'h1', status: 'idle' }),
+    ] as Session[]
+  }
+
+  it('probes all pending siblings over the live control connection', async () => {
+    writeSessionsJson(threePendingOnH1())
+    state.hasRemoteTmuxResult.set('a', true)
+    state.hasRemoteTmuxResult.set('b', true)
+    state.hasRemoteTmuxResult.set('c', true)
+    state.runtimeStates.set('h1', 'live')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.probePendingSessionsOnHost('h1')
+
+    expect(sm.getSessions().every((s) => s.connectionState === 'live')).toBe(true)
+    expect(state.ensureHostConnectionCalls).toEqual([])
+    expect(state.reattachRemotePtyCalls.map((c) => c.sessionId).sort()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('marks only the tmux-gone sibling dead', async () => {
+    writeSessionsJson(threePendingOnH1())
+    state.hasRemoteTmuxResult.set('a', true)
+    state.hasRemoteTmuxResult.set('b', false)
+    state.hasRemoteTmuxResult.set('c', true)
+    state.runtimeStates.set('h1', 'live')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.probePendingSessionsOnHost('h1')
+
+    const byId = Object.fromEntries(sm.getSessions().map((s) => [s.id, s]))
+    expect(byId['a'].connectionState).toBe('live')
+    expect(byId['b'].status).toBe('dead')
+    expect(byId['b'].connectionState).toBe('offline')
+    expect(byId['c'].connectionState).toBe('live')
+  })
+
+  it('short-circuits to auth-failed cascade with zero network', async () => {
+    writeSessionsJson(threePendingOnH1())
+    state.runtimeStates.set('h1', 'auth-failed')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.probePendingSessionsOnHost('h1')
+
+    expect(sm.getSessions().every((s) => s.connectionState === 'auth-failed')).toBe(true)
+    expect(state.execRemoteCalls).toEqual([])
+    expect(state.reattachRemotePtyCalls).toEqual([])
+  })
+
+  it('idempotency: concurrent batch probes coalesce', async () => {
+    writeSessionsJson(threePendingOnH1())
+    state.hasRemoteTmuxResult.set('a', true)
+    state.hasRemoteTmuxResult.set('b', true)
+    state.hasRemoteTmuxResult.set('c', true)
+    state.runtimeStates.set('h1', 'live')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await Promise.all([sm.probePendingSessionsOnHost('h1'), sm.probePendingSessionsOnHost('h1')])
+
+    expect(state.reattachRemotePtyCalls).toHaveLength(3)
+  })
+})
+
+describe('updateLastKnownState', () => {
+  it('persists text + timestamp; caps at 3 KiB; rate-limits to 10s per session', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    // First write goes through.
+    const big = 'x'.repeat(5 * 1024)
+    sm.updateLastKnownState('r1', big)
+    let got = sm.getSessions()[0]
+    expect(got.lastKnownState?.text.length).toBe(3 * 1024)
+    expect(got.lastKnownState?.timestamp).toBeGreaterThan(0)
+    const firstTs = got.lastKnownState!.timestamp
+
+    // Second write within the 10s window is dropped.
+    sm.updateLastKnownState('r1', 'newer')
+    got = sm.getSessions()[0]
+    expect(got.lastKnownState?.timestamp).toBe(firstTs)
+    expect(got.lastKnownState?.text).not.toBe('newer')
+  })
+})
+
+describe('restoreSessions — local path unchanged (AC #10 regression)', () => {
+  it('reattaches a local session with a live tmux', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    state.liveTmuxIds = ['l1']
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('idle')
+    expect(got.connectionState).toBeUndefined()
+    expect(state.reattachPtyCalls).toEqual(['l1'])
+    expect(state.ensureHostConnectionCalls).toEqual([])
+  })
+})

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -377,6 +377,32 @@ describe('reconnectRemoteSession', () => {
     expect(state.reattachRemotePtyCalls).toHaveLength(1)
   })
 
+  it('auth-failed reconnect cascades to sibling pending sessions without new SSH', async () => {
+    writeSessionsJson([
+      baseRemoteSession({ id: 'clicked', hostId: 'h1', status: 'idle' }),
+      baseRemoteSession({ id: 'sibling1', hostId: 'h1', status: 'idle' }),
+      baseRemoteSession({ id: 'sibling2', hostId: 'h1', status: 'idle' }),
+    ] as Session[])
+    state.ensureHostConnectionThrows = {
+      message: 'Permission denied',
+      runtimeStateAfter: 'auth-failed',
+    }
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await expect(sm.reconnectRemoteSession('clicked')).rejects.toThrow(/Permission denied/)
+    // Let the fire-and-forget batch probe complete.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    const byId = Object.fromEntries(sm.getSessions().map((s) => [s.id, s]))
+    expect(byId['clicked'].connectionState).toBe('auth-failed')
+    expect(byId['sibling1'].connectionState).toBe('auth-failed')
+    expect(byId['sibling2'].connectionState).toBe('auth-failed')
+    // Only one SSH attempt (the clicked one). No probe calls for siblings.
+    expect(state.ensureHostConnectionCalls).toEqual(['h1'])
+    expect(state.execRemoteCalls).toEqual([])
+  })
+
   it('SSH probe failure on reconnect → unreachable, NOT dead', async () => {
     writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
     state.probeRemoteTmuxResult.set('r1', 'unreachable')

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -20,6 +20,7 @@ const state = vi.hoisted(() => ({
   createPtyCalls: [] as { sessionId: string; cwd: string }[],
   reattachPtyCalls: [] as string[],
   hasRemoteTmuxResult: new Map<string, boolean>(),
+  probeRemoteTmuxResult: new Map<string, 'present' | 'absent' | 'unreachable'>(),
   execRemoteCalls: [] as { hostId: string; argv: string[] }[],
   // Toggle to simulate ensureHostConnection throwing.
   ensureHostConnectionThrows: null as null | { message: string; runtimeStateAfter: string },
@@ -97,6 +98,14 @@ vi.mock('./pty-manager', () => ({
   hasTmuxSession: vi.fn(() => false),
   hasRemoteTmuxSession: vi.fn(async (sessionId: string) => {
     return state.hasRemoteTmuxResult.get(sessionId) ?? false
+  }),
+  probeRemoteTmuxSession: vi.fn(async (sessionId: string) => {
+    const explicit = state.probeRemoteTmuxResult.get(sessionId)
+    if (explicit) return explicit
+    // Back-compat for tests written against hasRemoteTmuxResult: true →
+    // present, false → absent. Tests that need 'unreachable' set it via
+    // probeRemoteTmuxResult directly.
+    return state.hasRemoteTmuxResult.get(sessionId) ? 'present' : 'absent'
   }),
   isTmuxAvailable: () => state.tmuxAvailable,
   discoverTmuxSessions: () => [...state.liveTmuxIds],
@@ -194,6 +203,7 @@ beforeEach(() => {
   state.createPtyCalls = []
   state.reattachPtyCalls = []
   state.hasRemoteTmuxResult = new Map()
+  state.probeRemoteTmuxResult = new Map()
   state.execRemoteCalls = []
   state.ensureHostConnectionThrows = null
   state.ensureHostConnectionGate = null
@@ -367,6 +377,43 @@ describe('reconnectRemoteSession', () => {
     expect(state.reattachRemotePtyCalls).toHaveLength(1)
   })
 
+  it('SSH probe failure on reconnect → unreachable, NOT dead', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.probeRemoteTmuxResult.set('r1', 'unreachable')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.reconnectRemoteSession('r1')
+
+    const got = sm.getSessions()[0]
+    expect(got.connectionState).toBe('unreachable')
+    expect(got.status).toBe('idle')
+    expect(state.reattachRemotePtyCalls).toEqual([])
+  })
+
+  it('triggers sibling batch probe even when first session ends dead (host is live)', async () => {
+    writeSessionsJson([
+      baseRemoteSession({ id: 'first', hostId: 'h1', status: 'idle' }),
+      baseRemoteSession({ id: 'sibling', hostId: 'h1', status: 'idle' }),
+    ] as Session[])
+    // First session: tmux gone, but host is live → dead outcome
+    state.probeRemoteTmuxResult.set('first', 'absent')
+    // Sibling: tmux alive
+    state.probeRemoteTmuxResult.set('sibling', 'present')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.reconnectRemoteSession('first')
+    // Allow the fire-and-forget batch probe to complete.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    const byId = Object.fromEntries(sm.getSessions().map((s) => [s.id, s]))
+    expect(byId['first'].status).toBe('dead')
+    expect(byId['first'].connectionState).toBe('offline')
+    // Critical: sibling was probed via the now-live host connection
+    expect(byId['sibling'].connectionState).toBe('live')
+  })
+
   it('retry succeeds after an auth-failed attempt (no app restart needed)', async () => {
     writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
     state.ensureHostConnectionThrows = {
@@ -443,6 +490,24 @@ describe('probePendingSessionsOnHost', () => {
     expect(sm.getSessions().every((s) => s.connectionState === 'auth-failed')).toBe(true)
     expect(state.execRemoteCalls).toEqual([])
     expect(state.reattachRemotePtyCalls).toEqual([])
+  })
+
+  it('SSH probe failure on a sibling → mark it unreachable and bail, do NOT downgrade rest to dead', async () => {
+    writeSessionsJson(threePendingOnH1())
+    state.probeRemoteTmuxResult.set('a', 'present')
+    state.probeRemoteTmuxResult.set('b', 'unreachable')
+    state.probeRemoteTmuxResult.set('c', 'present')
+    state.runtimeStates.set('h1', 'live')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.probePendingSessionsOnHost('h1')
+
+    const byId = Object.fromEntries(sm.getSessions().map((s) => [s.id, s]))
+    expect(byId['a'].connectionState).toBe('live')
+    expect(byId['b'].connectionState).toBe('unreachable')
+    // c remains pending — we bail to avoid a flood of SSH calls on a bad host
+    expect(byId['c'].connectionState).toBe('pending')
   })
 
   it('idempotency: concurrent batch probes coalesce', async () => {

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -733,6 +733,33 @@ describe('updateLastKnownStatesBatch', () => {
 
     expect(state.sessionsUpdatedBroadcasts - afterFirst).toBe(0)
   })
+
+  it('skips write when text is unchanged across rate-limit windows', async () => {
+    // Idle sessions emit identical thumbnail text every 3s tick. Once the
+    // 10s rate-limit elapses, the gate would otherwise fire a write +
+    // broadcast every 10s indefinitely. The text-equality early-return
+    // turns this into a no-op for stable sessions.
+    writeSessionsJson([baseRemoteSession({ id: 'a' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    sm.updateLastKnownStatesBatch([{ id: 'a', text: 'idle prompt $' }])
+    const afterFirst = state.sessionsUpdatedBroadcasts
+
+    // Advance past the 10s rate-limit window.
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() + 11_000)
+    try {
+      sm.updateLastKnownStatesBatch([{ id: 'a', text: 'idle prompt $' }])
+      expect(state.sessionsUpdatedBroadcasts - afterFirst).toBe(0)
+
+      // A real text change still goes through.
+      sm.updateLastKnownStatesBatch([{ id: 'a', text: 'idle prompt $ ls' }])
+      expect(state.sessionsUpdatedBroadcasts - afterFirst).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('updateLastKnownState', () => {

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -444,12 +444,11 @@ describe('reconnectRemoteSession', () => {
     expect(state.reattachRemotePtyCalls).toEqual([])
   })
 
-  it('triggers sibling batch probe even when absent-outcome release tore down the runtime', async () => {
-    // Regression: on 'absent' path the PTY does not retain, so the final
-    // releaseHostConnection drops refcount to 0 → stopHostConnection deletes
-    // the runtime entry. A post-reconnect lookup via runtimeStateFor would
-    // therefore return undefined and skip the batch probe. We must capture
-    // the state BEFORE the release.
+  it('keeps host runtime alive through sibling batch probe on absent outcome', async () => {
+    // Regression guard for two issues in one: (a) sibling probe must still
+    // run when the clicked session's outcome is `absent` (no PTY retain), and
+    // (b) the ControlMaster must stay up through the batch so sibling probes
+    // reuse the existing ControlPath instead of spawning fresh SSH per card.
     writeSessionsJson([
       baseRemoteSession({ id: 'first', hostId: 'h1', status: 'idle' }),
       baseRemoteSession({ id: 'sibling', hostId: 'h1', status: 'idle' }),
@@ -462,12 +461,36 @@ describe('reconnectRemoteSession', () => {
     await sm.reconnectRemoteSession('first')
     await new Promise((resolve) => setTimeout(resolve, 20))
 
-    // Runtime should now be deleted (no PTY retained it on the absent path).
-    expect(state.runtimeStates.has('h1')).toBe(false)
-    // Sibling still got probed and transitioned to live.
     const byId = Object.fromEntries(sm.getSessions().map((s) => [s.id, s]))
     expect(byId['first'].status).toBe('dead')
     expect(byId['sibling'].connectionState).toBe('live')
+    // Only one ensureHostConnection call — siblings reused the ControlMaster
+    // from the clicked session's reconnect (one SSH handshake, not N).
+    expect(state.ensureHostConnectionCalls).toEqual(['h1'])
+    // Sibling's reattach kept the runtime alive (refs=1 from sibling PTY).
+    // The test would have failed if doReconnect released before the batch
+    // probed siblings, because execRemote would then fall off the ControlPath
+    // fast path and classifySshExit… actually, a more direct check: only one
+    // SSH connection was opened total.
+    expect(state.runtimeRefs.get('h1')).toBe(1)
+  })
+
+  it('releases retain when absent outcome has no sibling to retain the runtime', async () => {
+    // Only one session on the host; clicked reconnect ends `absent`. After
+    // the batch completes with no live siblings, the retain chain unwinds to
+    // zero and the runtime is torn down.
+    writeSessionsJson([
+      baseRemoteSession({ id: 'lonely', hostId: 'h1', status: 'idle' }),
+    ] as Session[])
+    state.probeRemoteTmuxResult.set('lonely', 'absent')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.reconnectRemoteSession('lonely')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(state.runtimeStates.has('h1')).toBe(false)
+    expect(state.runtimeRefs.has('h1')).toBe(false)
   })
 
   it('triggers sibling batch probe even when first session ends dead (host is live)', async () => {

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -543,6 +543,35 @@ describe('reconnectRemoteSession', () => {
     expect(sm.getSessions()[0].connectionState).toBe('live')
     expect(state.ensureHostConnectionCalls).toEqual(['h1', 'h1'])
   })
+
+  it('releases host retain when session is removed mid-reconnect', async () => {
+    // doReconnectRemoteSession returns retainedForBatch=true; the outer caller
+    // owns releasing it. If `sessions.get(id)` is read after the await without
+    // a fallback, a concurrent removeSession() would leave hostId undefined
+    // and neither the batch nor the direct release path would run — the
+    // ControlMaster would leak for the lifetime of the app.
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })] as Session[])
+    state.probeRemoteTmuxResult.set('r1', 'absent')
+    let gateResolve!: () => void
+    state.ensureHostConnectionGate = new Promise<void>((res) => {
+      gateResolve = res
+    })
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    const reconnectPromise = sm.reconnectRemoteSession('r1')
+    // Allow doReconnectRemoteSession's synchronous prelude to run and park at
+    // the gated `await ensureHostConnection`.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await sm.removeSession('r1')
+    gateResolve()
+    await reconnectPromise
+    // Allow the fire-and-forget batch + release to complete.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(state.runtimeRefs.has('h1')).toBe(false)
+    expect(state.runtimeStates.has('h1')).toBe(false)
+  })
 })
 
 describe('probePendingSessionsOnHost', () => {

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -139,7 +139,11 @@ vi.mock('./host-connection', () => ({
   },
   retainHostConnection: vi.fn(),
   releaseHostConnection: vi.fn(async () => undefined),
-  stopHostConnection: vi.fn(async () => undefined),
+  // Match production: stopHostConnection deletes the runtime entry, so any
+  // caller reading runtimeStateFor(hostId) AFTER stop sees `undefined`.
+  stopHostConnection: vi.fn(async (hostId: string) => {
+    state.runtimeStates.delete(hostId)
+  }),
   runtimeStateFor: (hostId: string) => state.runtimeStates.get(hostId),
   classifyConnectionFailure: (_code: number | null, _stderr: string) => 'offline',
 }))

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -21,6 +21,8 @@ const state = vi.hoisted(() => ({
   reattachPtyCalls: [] as string[],
   hasRemoteTmuxResult: new Map<string, boolean>(),
   probeRemoteTmuxResult: new Map<string, 'present' | 'absent' | 'unreachable'>(),
+  runtimeRefs: new Map<string, number>(),
+  sessionsUpdatedBroadcasts: 0,
   execRemoteCalls: [] as { hostId: string; argv: string[] }[],
   // Toggle to simulate ensureHostConnection throwing.
   ensureHostConnectionThrows: null as null | { message: string; runtimeStateAfter: string },
@@ -48,7 +50,9 @@ vi.mock('./config', () => ({
 }))
 
 vi.mock('./window-registry', () => ({
-  broadcastToAll: vi.fn(),
+  broadcastToAll: (channel: string) => {
+    if (channel === 'sessions:updated') state.sessionsUpdatedBroadcasts++
+  },
   getMainWindow: () => null,
 }))
 
@@ -114,9 +118,13 @@ vi.mock('./pty-manager', () => ({
   },
   reattachRemotePty: async (sessionId: string, host: Host) => {
     state.reattachRemotePtyCalls.push({ sessionId, hostId: host.hostId })
+    // Match production: reattachRemotePty retains the host runtime for the
+    // PTY's lifetime so the runtime survives the caller's release.
+    state.runtimeRefs.set(host.hostId, (state.runtimeRefs.get(host.hostId) ?? 0) + 1)
   },
   createRemotePty: async (sessionId: string, cwd: string, host: Host) => {
     state.createRemotePtyCalls.push({ sessionId, cwd, hostId: host.hostId })
+    state.runtimeRefs.set(host.hostId, (state.runtimeRefs.get(host.hostId) ?? 0) + 1)
   },
 }))
 
@@ -137,11 +145,24 @@ vi.mock('./host-connection', () => ({
     state.execRemoteCalls.push({ hostId, argv })
     return { stdout: '', stderr: '', code: 0, timedOut: false }
   },
-  retainHostConnection: vi.fn(),
-  releaseHostConnection: vi.fn(async () => undefined),
-  // Match production: stopHostConnection deletes the runtime entry, so any
-  // caller reading runtimeStateFor(hostId) AFTER stop sees `undefined`.
+  retainHostConnection: vi.fn((hostId: string) => {
+    state.runtimeRefs.set(hostId, (state.runtimeRefs.get(hostId) ?? 0) + 1)
+  }),
+  // Match production: releaseHostConnection decrements refcount; on zero it
+  // delegates to stopHostConnection which wipes the runtime entry. That delete
+  // is what makes the sibling-batch cascade dependent on a state hint
+  // captured BEFORE the release.
+  releaseHostConnection: vi.fn(async (hostId: string) => {
+    const refs = (state.runtimeRefs.get(hostId) ?? 0) - 1
+    if (refs <= 0) {
+      state.runtimeRefs.delete(hostId)
+      state.runtimeStates.delete(hostId)
+    } else {
+      state.runtimeRefs.set(hostId, refs)
+    }
+  }),
   stopHostConnection: vi.fn(async (hostId: string) => {
+    state.runtimeRefs.delete(hostId)
     state.runtimeStates.delete(hostId)
   }),
   runtimeStateFor: (hostId: string) => state.runtimeStates.get(hostId),
@@ -208,6 +229,8 @@ beforeEach(() => {
   state.reattachPtyCalls = []
   state.hasRemoteTmuxResult = new Map()
   state.probeRemoteTmuxResult = new Map()
+  state.runtimeRefs = new Map()
+  state.sessionsUpdatedBroadcasts = 0
   state.execRemoteCalls = []
   state.ensureHostConnectionThrows = null
   state.ensureHostConnectionGate = null
@@ -421,6 +444,32 @@ describe('reconnectRemoteSession', () => {
     expect(state.reattachRemotePtyCalls).toEqual([])
   })
 
+  it('triggers sibling batch probe even when absent-outcome release tore down the runtime', async () => {
+    // Regression: on 'absent' path the PTY does not retain, so the final
+    // releaseHostConnection drops refcount to 0 → stopHostConnection deletes
+    // the runtime entry. A post-reconnect lookup via runtimeStateFor would
+    // therefore return undefined and skip the batch probe. We must capture
+    // the state BEFORE the release.
+    writeSessionsJson([
+      baseRemoteSession({ id: 'first', hostId: 'h1', status: 'idle' }),
+      baseRemoteSession({ id: 'sibling', hostId: 'h1', status: 'idle' }),
+    ] as Session[])
+    state.probeRemoteTmuxResult.set('first', 'absent')
+    state.probeRemoteTmuxResult.set('sibling', 'present')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.reconnectRemoteSession('first')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    // Runtime should now be deleted (no PTY retained it on the absent path).
+    expect(state.runtimeStates.has('h1')).toBe(false)
+    // Sibling still got probed and transitioned to live.
+    const byId = Object.fromEntries(sm.getSessions().map((s) => [s.id, s]))
+    expect(byId['first'].status).toBe('dead')
+    expect(byId['sibling'].connectionState).toBe('live')
+  })
+
   it('triggers sibling batch probe even when first session ends dead (host is live)', async () => {
     writeSessionsJson([
       baseRemoteSession({ id: 'first', hostId: 'h1', status: 'idle' }),
@@ -552,6 +601,45 @@ describe('probePendingSessionsOnHost', () => {
     await Promise.all([sm.probePendingSessionsOnHost('h1'), sm.probePendingSessionsOnHost('h1')])
 
     expect(state.reattachRemotePtyCalls).toHaveLength(3)
+  })
+})
+
+describe('updateLastKnownStatesBatch', () => {
+  it('persists once per batch regardless of session count', async () => {
+    writeSessionsJson([
+      baseRemoteSession({ id: 'a', hostId: 'h1' }),
+      baseRemoteSession({ id: 'b', hostId: 'h1' }),
+      baseRemoteSession({ id: 'c', hostId: 'h1' }),
+    ] as Session[])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    const before = state.sessionsUpdatedBroadcasts
+
+    sm.updateLastKnownStatesBatch([
+      { id: 'a', text: 'aaa' },
+      { id: 'b', text: 'bbb' },
+      { id: 'c', text: 'ccc' },
+    ])
+
+    expect(state.sessionsUpdatedBroadcasts - before).toBe(1)
+    const byId = Object.fromEntries(sm.getSessions().map((s) => [s.id, s]))
+    expect(byId['a'].lastKnownState?.text).toBe('aaa')
+    expect(byId['b'].lastKnownState?.text).toBe('bbb')
+    expect(byId['c'].lastKnownState?.text).toBe('ccc')
+  })
+
+  it('does not persist when every update is rate-limited', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'a' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    sm.updateLastKnownStatesBatch([{ id: 'a', text: 'first' }])
+    const afterFirst = state.sessionsUpdatedBroadcasts
+
+    // Immediate second call: rate-limited, must not trigger another broadcast.
+    sm.updateLastKnownStatesBatch([{ id: 'a', text: 'second' }])
+
+    expect(state.sessionsUpdatedBroadcasts - afterFirst).toBe(0)
   })
 })
 

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -21,6 +21,10 @@ const state = vi.hoisted(() => ({
   reattachPtyCalls: [] as string[],
   hasRemoteTmuxResult: new Map<string, boolean>(),
   probeRemoteTmuxResult: new Map<string, 'present' | 'absent' | 'unreachable'>(),
+  // Per-session side effect fired before the probe resolves. Lets tests
+  // simulate a concurrent reconnect advancing another session's state while
+  // the batch is in flight.
+  probeSideEffect: new Map<string, () => void>(),
   runtimeRefs: new Map<string, number>(),
   sessionsUpdatedBroadcasts: 0,
   execRemoteCalls: [] as { hostId: string; argv: string[] }[],
@@ -104,6 +108,8 @@ vi.mock('./pty-manager', () => ({
     return state.hasRemoteTmuxResult.get(sessionId) ?? false
   }),
   probeRemoteTmuxSession: vi.fn(async (sessionId: string) => {
+    const effect = state.probeSideEffect.get(sessionId)
+    if (effect) effect()
     const explicit = state.probeRemoteTmuxResult.get(sessionId)
     if (explicit) return explicit
     // Back-compat for tests written against hasRemoteTmuxResult: true →
@@ -231,6 +237,7 @@ beforeEach(() => {
   state.probeRemoteTmuxResult = new Map()
   state.runtimeRefs = new Map()
   state.sessionsUpdatedBroadcasts = 0
+  state.probeSideEffect = new Map()
   state.execRemoteCalls = []
   state.ensureHostConnectionThrows = null
   state.ensureHostConnectionGate = null
@@ -610,6 +617,39 @@ describe('probePendingSessionsOnHost', () => {
     expect(byId['b'].connectionState).toBe('unreachable')
     // c remains pending — we bail to avoid a flood of SSH calls on a bad host
     expect(byId['c'].connectionState).toBe('pending')
+  })
+
+  it('skips a sibling whose state advanced out of pending during the batch', async () => {
+    // If a concurrent reconnect moves a sibling out of `pending` while the
+    // batch is iterating, the batch must not re-probe/reattach it (doing so
+    // would duplicate the remote attach and leak refs).
+    writeSessionsJson(threePendingOnH1())
+    state.probeRemoteTmuxResult.set('a', 'present')
+    state.probeRemoteTmuxResult.set('b', 'present')
+    state.probeRemoteTmuxResult.set('c', 'present')
+    state.runtimeStates.set('h1', 'live')
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    // When the batch probes 'a' (first sibling in the snapshot), flip 'b'
+    // out of pending — simulating a concurrent reconnect on 'b' completing
+    // mid-batch.
+    state.probeSideEffect.set('a', () => {
+      const bSession = sm.getSessions().find((s) => s.id === 'b')!
+      bSession.connectionState = 'live'
+      bSession.status = 'idle'
+    })
+
+    await sm.probePendingSessionsOnHost('h1')
+
+    // 'b' must not have been reattached by the batch (state ≠ pending).
+    const bReattaches = state.reattachRemotePtyCalls.filter((c) => c.sessionId === 'b').length
+    expect(bReattaches).toBe(0)
+    // 'a' and 'c' still got reattached.
+    const aReattaches = state.reattachRemotePtyCalls.filter((c) => c.sessionId === 'a').length
+    const cReattaches = state.reattachRemotePtyCalls.filter((c) => c.sessionId === 'c').length
+    expect(aReattaches).toBe(1)
+    expect(cReattaches).toBe(1)
   })
 
   it('idempotency: concurrent batch probes coalesce', async () => {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -19,6 +19,7 @@ import {
   hasRemoteTmuxSession,
   isTmuxAvailable,
   discoverTmuxSessions,
+  probeRemoteTmuxSession,
   reattachPty,
   reattachRemotePty,
   createRemotePty,
@@ -630,10 +631,16 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
   // Fire-and-forget the sibling batch probe — the caller should not block on
   // it. `probePendingSessionsOnHost` is idempotent so concurrent clicks on
   // multiple cards of the same host still collapse to a single batch.
+  //
+  // Trigger whenever the host control connection is live, not when the clicked
+  // session is live: if the first click landed on a session whose remote tmux
+  // was already gone (session ends `dead`), the host itself is reachable, so
+  // we still want to reconcile the other pending sessions on it.
   const entry = sessions.get(id)
-  if (entry?.session.hostId && entry.session.connectionState === 'live') {
-    probePendingSessionsOnHost(entry.session.hostId).catch((err) => {
-      console.error(`probePendingSessionsOnHost(${entry.session.hostId}) failed:`, err)
+  const hostId = entry?.session.hostId
+  if (hostId && runtimeStateFor(hostId) === 'live') {
+    probePendingSessionsOnHost(hostId).catch((err) => {
+      console.error(`probePendingSessionsOnHost(${hostId}) failed:`, err)
     })
   }
 }
@@ -659,18 +666,25 @@ async function doReconnectRemoteSession(id: string): Promise<void> {
   try {
     await prepareRemoteHost(host)
     retained = true
-    if (await hasRemoteTmuxSession(id, host)) {
+    const probe = await probeRemoteTmuxSession(id, host)
+    if (probe === 'present') {
       await reattachRemotePty(id, host)
       session.connectionState = 'live'
       if (session.status === 'running') session.status = 'idle'
       session.lastActivity = Date.now()
       onSessionsChanged()
-    } else {
-      // Remote tmux session is gone — session is dead. The user can invoke
-      // "Restart terminal" (reviveSession) to spawn a fresh remote session.
+    } else if (probe === 'absent') {
+      // Remote confirmed the tmux session is gone — mark dead. The user can
+      // invoke "Restart terminal" (reviveSession) to spawn a fresh one.
       session.connectionState = 'offline'
       session.status = 'dead'
       session.lastActivity = Date.now()
+      onSessionsChanged()
+    } else {
+      // SSH-level failure probing an otherwise-live control connection. Treat
+      // as unreachable and let the user retry; do NOT mark dead because the
+      // remote Claude may still be running.
+      session.connectionState = 'unreachable'
       onSessionsChanged()
     }
   } catch (err) {
@@ -688,9 +702,10 @@ async function doReconnectRemoteSession(id: string): Promise<void> {
     }
     throw err
   }
-  if (retained) {
-    await releaseHostConnection(hostId).catch(() => undefined)
-  }
+  // `retained` is unconditionally true at this point — the only path that
+  // leaves it false throws inside prepareRemoteHost and goes through the
+  // catch block's `throw err`.
+  await releaseHostConnection(hostId).catch(() => undefined)
 }
 
 // Eager batch probe for remaining `pending` sessions on a host that just
@@ -737,16 +752,22 @@ async function doProbePendingSessionsOnHost(hostId: string): Promise<void> {
   for (const s of pending) {
     if (bailed) break
     try {
-      const alive = await hasRemoteTmuxSession(s.id, host)
-      if (alive) {
+      const probe = await probeRemoteTmuxSession(s.id, host)
+      if (probe === 'present') {
         await reattachRemotePty(s.id, host)
         s.connectionState = 'live'
         if (s.status === 'running') s.status = 'idle'
         s.lastActivity = Date.now()
-      } else {
+      } else if (probe === 'absent') {
         s.connectionState = 'offline'
         s.status = 'dead'
         s.lastActivity = Date.now()
+      } else {
+        // SSH probe failed (timeout / auth / network) — the remote may still be
+        // running. Mark unreachable and bail so we don't mis-classify the rest
+        // of the batch as dead on a transient failure.
+        s.connectionState = 'unreachable'
+        bailed = true
       }
     } catch (err) {
       // A mid-batch SSH failure means the host dropped. Mark this sibling

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -257,17 +257,44 @@ const LAST_KNOWN_STATE_MIN_INTERVAL_MS = 10_000
 const LAST_KNOWN_STATE_MAX_BYTES = 3 * 1024
 const lastKnownStateWrites = new Map<string, number>()
 
-export function updateLastKnownState(id: string, text: string): void {
+// Mutate a single session's `lastKnownState` in memory, respecting the 10s
+// per-session rate limit and 3 KiB cap. Returns `true` when the entry was
+// actually mutated so the caller can decide whether to flush; callers that
+// update many sessions in one tick should prefer `updateLastKnownStatesBatch`
+// to collapse the disk write + broadcast into one call (avoids an O(N) write
+// storm from a tight timer loop).
+function applyLastKnownState(id: string, text: string, now: number): boolean {
   const entry = sessions.get(id)
-  if (!entry) return
-  const now = Date.now()
+  if (!entry) return false
   const last = lastKnownStateWrites.get(id) ?? 0
-  if (now - last < LAST_KNOWN_STATE_MIN_INTERVAL_MS) return
+  if (now - last < LAST_KNOWN_STATE_MIN_INTERVAL_MS) return false
   const trimmed =
     text.length > LAST_KNOWN_STATE_MAX_BYTES ? text.slice(-LAST_KNOWN_STATE_MAX_BYTES) : text
   entry.session.lastKnownState = { text: trimmed, timestamp: now }
   lastKnownStateWrites.set(id, now)
-  onSessionsChanged()
+  return true
+}
+
+export function updateLastKnownState(id: string, text: string): void {
+  const now = Date.now()
+  if (applyLastKnownState(id, text, now)) {
+    onSessionsChanged()
+  }
+}
+
+// Batch variant for the periodic thumbnail tick: collects all (id, text)
+// pairs for one tick and emits a single persist + broadcast when at least
+// one session was updated. Prevents an O(N) burst of JSON writes when many
+// session snapshots unlock the 10s window simultaneously.
+export function updateLastKnownStatesBatch(
+  updates: ReadonlyArray<{ id: string; text: string }>
+): void {
+  const now = Date.now()
+  let any = false
+  for (const { id, text } of updates) {
+    if (applyLastKnownState(id, text, now)) any = true
+  }
+  if (any) onSessionsChanged()
 }
 
 // Re-probe PR numbers for sessions that don't have one yet, so a PR opened
@@ -617,8 +644,12 @@ export async function killSession(id: string): Promise<void> {
 
 // In-flight reconnect promises keyed by session id. Two concurrent clicks on
 // the same pending card (fast double-click, or a click that races the
-// auto-fired batch probe) coalesce into one SSH attempt.
-const inflightReconnects = new Map<string, Promise<void>>()
+// auto-fired batch probe) coalesce into one SSH attempt. The resolved value
+// is the host's runtime state at the moment the reconnect finished (before
+// any refcount drop that might tear the runtime down) — the outer caller
+// uses it as a `stateHint` for `probePendingSessionsOnHost` so the sibling
+// cascade still works after the runtime entry has been released.
+const inflightReconnects = new Map<string, Promise<HostConnectionState | undefined>>()
 
 // Probe-only reconnect for a remote session. If the remote tmux session is
 // present we reattach and mark `live`; if it is gone we mark the session
@@ -631,13 +662,17 @@ const inflightReconnects = new Map<string, Promise<void>>()
 // network-unreachable get distinct UI states without re-parsing stderr.
 export async function reconnectRemoteSession(id: string): Promise<void> {
   const existing = inflightReconnects.get(id)
-  if (existing) return existing
+  if (existing) {
+    await existing
+    return
+  }
 
   const promise = doReconnectRemoteSession(id)
   inflightReconnects.set(id, promise)
   let reconnectError: unknown = undefined
+  let successState: HostConnectionState | undefined
   try {
-    await promise
+    successState = await promise
   } catch (err) {
     reconnectError = err
   } finally {
@@ -648,22 +683,26 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
   // multiple cards of the same host still collapse to a single batch.
   //
   // Always attempt the batch probe, even when the clicked reconnect rejected:
-  // - on success (runtime `live`), we reconcile siblings over the now-live
-  //   ControlMaster
+  // - on success (runtime was `live`), we reconcile siblings over the
+  //   now-live ControlMaster
   // - on auth-failed / unreachable, the batch's short-circuit cascades that
   //   state to every pending sibling without any new SSH I/O (spec AC #8)
+  //
   // Skip only when there's no host at all (orphaned hostId / missing registry
-  // entry): there is nothing to probe.
+  // entry) or we couldn't determine any state — there's nothing to probe.
   const entry = sessions.get(id)
   const hostId = entry?.session.hostId
   if (hostId) {
-    // Prefer the state tagged onto the error by prepareRemoteHost — the
-    // runtime may have been deleted by stopHostConnection, so a direct
-    // runtimeStateFor lookup here would be `undefined` for the very cases
-    // (auth-failed / unreachable) the batch's short-circuit needs to catch.
+    // Prefer the state captured inside doReconnectRemoteSession BEFORE the
+    // final `releaseHostConnection` ran. For `absent` / `unreachable`
+    // outcomes the PTY doesn't retain the runtime, so release drops refcount
+    // to zero and stopHostConnection deletes the runtime entry — a fresh
+    // runtimeStateFor lookup here would therefore return `undefined`.
+    // Similarly, prepareRemoteHost stashes the pre-teardown state on the
+    // error so the catch-path cascade still works.
     const tagged = (reconnectError as { hostConnectionState?: HostConnectionState } | null)
       ?.hostConnectionState
-    const stateHint = tagged ?? runtimeStateFor(hostId)
+    const stateHint = successState ?? tagged ?? runtimeStateFor(hostId)
     if (stateHint) {
       probePendingSessionsOnHost(hostId, stateHint).catch((err) => {
         console.error(`probePendingSessionsOnHost(${hostId}) failed:`, err)
@@ -673,7 +712,7 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
   if (reconnectError !== undefined) throw reconnectError
 }
 
-async function doReconnectRemoteSession(id: string): Promise<void> {
+async function doReconnectRemoteSession(id: string): Promise<HostConnectionState | undefined> {
   const entry = sessions.get(id)
   if (!entry) throw new Error(`Session ${id} not found`)
   const session = entry.session
@@ -739,7 +778,15 @@ async function doReconnectRemoteSession(id: string): Promise<void> {
   // `retained` is unconditionally true at this point — the only path that
   // leaves it false throws inside prepareRemoteHost and goes through the
   // catch block's `throw err`.
+  //
+  // Snapshot the runtime state BEFORE the release: on `absent` or
+  // `unreachable` outcomes the PTY did not take a retain, so this release
+  // drops the refcount to zero and stopHostConnection deletes the entry. The
+  // outer reconnectRemoteSession uses the returned state as the sibling
+  // batch probe's stateHint.
+  const finalState = runtimeStateFor(hostId)
   await releaseHostConnection(hostId).catch(() => undefined)
+  return finalState
 }
 
 // Eager batch probe for remaining `pending` sessions on a host that just

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -860,6 +860,11 @@ async function doProbePendingSessionsOnHost(
   let bailed = false
   for (const s of pending) {
     if (bailed) break
+    // The snapshot was taken once at batch entry; by the time we get here
+    // another concurrent reconnect (e.g. user clicking a sibling card) may
+    // have already advanced this session out of `pending`. Skip — otherwise
+    // we'd duplicate the remote reattach and leak the earlier runtime retain.
+    if (s.connectionState !== 'pending') continue
     try {
       const probe = await probeRemoteTmuxSession(s.id, host)
       if (probe === 'present') {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -642,14 +642,21 @@ export async function killSession(id: string): Promise<void> {
   updateSession(id, 'dead')
 }
 
+interface ReconnectOutcome {
+  state: HostConnectionState | undefined
+  // True when the caller inherits an outstanding retain on the host runtime —
+  // the sibling batch probe consumes it and releases at the end. This keeps
+  // the ControlMaster alive across the doReconnect → batch boundary so each
+  // sibling probe reuses the existing ControlPath instead of spawning a
+  // fresh SSH handshake (which would also fail independently on a flaky
+  // host).
+  retainedForBatch: boolean
+}
+
 // In-flight reconnect promises keyed by session id. Two concurrent clicks on
 // the same pending card (fast double-click, or a click that races the
-// auto-fired batch probe) coalesce into one SSH attempt. The resolved value
-// is the host's runtime state at the moment the reconnect finished (before
-// any refcount drop that might tear the runtime down) — the outer caller
-// uses it as a `stateHint` for `probePendingSessionsOnHost` so the sibling
-// cascade still works after the runtime entry has been released.
-const inflightReconnects = new Map<string, Promise<HostConnectionState | undefined>>()
+// auto-fired batch probe) coalesce into one SSH attempt.
+const inflightReconnects = new Map<string, Promise<ReconnectOutcome>>()
 
 // Probe-only reconnect for a remote session. If the remote tmux session is
 // present we reattach and mark `live`; if it is gone we mark the session
@@ -670,14 +677,16 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
   const promise = doReconnectRemoteSession(id)
   inflightReconnects.set(id, promise)
   let reconnectError: unknown = undefined
-  let successState: HostConnectionState | undefined
+  let outcome: ReconnectOutcome | undefined
   try {
-    successState = await promise
+    outcome = await promise
   } catch (err) {
     reconnectError = err
   } finally {
     inflightReconnects.delete(id)
   }
+  const successState = outcome?.state
+  const retainedForBatch = outcome?.retainedForBatch ?? false
   // Fire-and-forget the sibling batch probe — the caller should not block on
   // it. `probePendingSessionsOnHost` is idempotent so concurrent clicks on
   // multiple cards of the same host still collapse to a single batch.
@@ -692,27 +701,35 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
   // entry) or we couldn't determine any state — there's nothing to probe.
   const entry = sessions.get(id)
   const hostId = entry?.session.hostId
-  if (hostId) {
-    // Prefer the state captured inside doReconnectRemoteSession BEFORE the
-    // final `releaseHostConnection` ran. For `absent` / `unreachable`
-    // outcomes the PTY doesn't retain the runtime, so release drops refcount
-    // to zero and stopHostConnection deletes the runtime entry — a fresh
-    // runtimeStateFor lookup here would therefore return `undefined`.
-    // Similarly, prepareRemoteHost stashes the pre-teardown state on the
-    // error so the catch-path cascade still works.
-    const tagged = (reconnectError as { hostConnectionState?: HostConnectionState } | null)
-      ?.hostConnectionState
-    const stateHint = successState ?? tagged ?? runtimeStateFor(hostId)
-    if (stateHint) {
-      probePendingSessionsOnHost(hostId, stateHint).catch((err) => {
+  const tagged = (reconnectError as { hostConnectionState?: HostConnectionState } | null)
+    ?.hostConnectionState
+  const stateHint = successState ?? tagged ?? (hostId ? runtimeStateFor(hostId) : undefined)
+  if (hostId && stateHint) {
+    // Fire-and-forget: user's first click should not wait for sibling
+    // reconciliation. When doReconnect left us an outstanding retain, the
+    // batch consumes it and releases at the end — that keeps the
+    // ControlMaster alive across the probe so siblings reuse one SSH
+    // handshake instead of spawning one per card.
+    ;(async () => {
+      try {
+        await probePendingSessionsOnHost(hostId, stateHint)
+      } catch (err) {
         console.error(`probePendingSessionsOnHost(${hostId}) failed:`, err)
-      })
-    }
+      } finally {
+        if (retainedForBatch) {
+          await releaseHostConnection(hostId).catch(() => undefined)
+        }
+      }
+    })()
+  } else if (hostId && retainedForBatch) {
+    // No batch to run but doReconnect handed us an outstanding retain — must
+    // release or we leak the runtime.
+    await releaseHostConnection(hostId).catch(() => undefined)
   }
   if (reconnectError !== undefined) throw reconnectError
 }
 
-async function doReconnectRemoteSession(id: string): Promise<HostConnectionState | undefined> {
+async function doReconnectRemoteSession(id: string): Promise<ReconnectOutcome> {
   const entry = sessions.get(id)
   if (!entry) throw new Error(`Session ${id} not found`)
   const session = entry.session
@@ -779,14 +796,15 @@ async function doReconnectRemoteSession(id: string): Promise<HostConnectionState
   // leaves it false throws inside prepareRemoteHost and goes through the
   // catch block's `throw err`.
   //
-  // Snapshot the runtime state BEFORE the release: on `absent` or
-  // `unreachable` outcomes the PTY did not take a retain, so this release
-  // drops the refcount to zero and stopHostConnection deletes the entry. The
-  // outer reconnectRemoteSession uses the returned state as the sibling
-  // batch probe's stateHint.
+  // Do NOT release here: the caller (reconnectRemoteSession) owns the retain
+  // and transfers it to the sibling batch probe, which releases at the end.
+  // This keeps the ControlMaster alive across the boundary so per-sibling
+  // `tmux has-session` calls reuse the existing ControlPath instead of
+  // spawning fresh SSH handshakes (which would also fail independently on a
+  // flaky host). The snapshot of runtime state captured here is still
+  // accurate — the release hasn't happened yet.
   const finalState = runtimeStateFor(hostId)
-  await releaseHostConnection(hostId).catch(() => undefined)
-  return finalState
+  return { state: finalState, retainedForBatch: true }
 }
 
 // Eager batch probe for remaining `pending` sessions on a host that just

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -270,6 +270,10 @@ function applyLastKnownState(id: string, text: string, now: number): boolean {
   if (now - last < LAST_KNOWN_STATE_MIN_INTERVAL_MS) return false
   const trimmed =
     text.length > LAST_KNOWN_STATE_MAX_BYTES ? text.slice(-LAST_KNOWN_STATE_MAX_BYTES) : text
+  // Idle sessions emit identical thumbnail text every tick; without this
+  // no-op the 10s window would still trigger a sessions.json write +
+  // broadcast for every live session indefinitely.
+  if (entry.session.lastKnownState?.text === trimmed) return false
   entry.session.lastKnownState = { text: trimmed, timestamp: now }
   lastKnownStateWrites.set(id, now)
   return true

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -36,6 +36,7 @@ import {
   releaseHostConnection,
   stopHostConnection,
   runtimeStateFor,
+  type HostConnectionState,
 } from './host-connection'
 import { bootstrapHost } from './host-bootstrap'
 import type { Host, RemoteProject, Session, SessionStatus } from '../shared/types'
@@ -118,10 +119,21 @@ async function prepareRemoteHost(host: Host): Promise<{ notifyScriptPath: string
   try {
     ;({ remoteSocketPath } = await ensureHostConnection(host, localSocketPath))
   } catch (err) {
-    // SSH couldn't start. Tear down the host runtime (which runtimeFor already
-    // registered) so the hook-server teardown callback fires and we don't leak
-    // the per-host listener across repeated failed startups.
+    // SSH couldn't start. Capture the runtime state BEFORE the teardown wipes
+    // the entry so callers can still classify auth-failed / unreachable —
+    // stopHostConnection does `runtimes.delete(hostId)` and a later
+    // `runtimeStateFor` would otherwise return `undefined`.
+    const capturedState = runtimeStateFor(host.hostId)
+    // Tear down the host runtime (which runtimeFor already registered) so the
+    // hook-server teardown callback fires and we don't leak the per-host
+    // listener across repeated failed startups.
     await stopHostConnection(host.hostId).catch(() => undefined)
+    if (capturedState === 'auth-failed' || capturedState === 'unreachable') {
+      const wrapped = err instanceof Error ? err : new Error(String(err))
+      ;(wrapped as Error & { hostConnectionState?: HostConnectionState }).hostConnectionState =
+        capturedState
+      throw wrapped
+    }
     throw err
   }
   retainHostConnection(host.hostId)
@@ -644,11 +656,19 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
   // entry): there is nothing to probe.
   const entry = sessions.get(id)
   const hostId = entry?.session.hostId
-  const runtimeState = hostId ? runtimeStateFor(hostId) : undefined
-  if (hostId && runtimeState) {
-    probePendingSessionsOnHost(hostId).catch((err) => {
-      console.error(`probePendingSessionsOnHost(${hostId}) failed:`, err)
-    })
+  if (hostId) {
+    // Prefer the state tagged onto the error by prepareRemoteHost — the
+    // runtime may have been deleted by stopHostConnection, so a direct
+    // runtimeStateFor lookup here would be `undefined` for the very cases
+    // (auth-failed / unreachable) the batch's short-circuit needs to catch.
+    const tagged = (reconnectError as { hostConnectionState?: HostConnectionState } | null)
+      ?.hostConnectionState
+    const stateHint = tagged ?? runtimeStateFor(hostId)
+    if (stateHint) {
+      probePendingSessionsOnHost(hostId, stateHint).catch((err) => {
+        console.error(`probePendingSessionsOnHost(${hostId}) failed:`, err)
+      })
+    }
   }
   if (reconnectError !== undefined) throw reconnectError
 }
@@ -696,7 +716,13 @@ async function doReconnectRemoteSession(id: string): Promise<void> {
       onSessionsChanged()
     }
   } catch (err) {
-    const runtimeState = runtimeStateFor(hostId)
+    // Prefer the state captured by prepareRemoteHost (attached to the error
+    // before stopHostConnection wipes the runtime entry). Fall back to the
+    // live runtime when the failure happened after prepareRemoteHost returned
+    // (e.g. bootstrap / PTY attach step).
+    const tagged = (err as { hostConnectionState?: HostConnectionState } | null)
+      ?.hostConnectionState
+    const runtimeState = tagged ?? runtimeStateFor(hostId)
     if (runtimeState === 'auth-failed') {
       session.connectionState = 'auth-failed'
     } else if (runtimeState === 'unreachable') {
@@ -724,10 +750,13 @@ async function doReconnectRemoteSession(id: string): Promise<void> {
 // host-auth-failed with no further attempts".
 const inflightBatchProbes = new Map<string, Promise<void>>()
 
-export async function probePendingSessionsOnHost(hostId: string): Promise<void> {
+export async function probePendingSessionsOnHost(
+  hostId: string,
+  stateHint?: HostConnectionState
+): Promise<void> {
   const existing = inflightBatchProbes.get(hostId)
   if (existing) return existing
-  const promise = doProbePendingSessionsOnHost(hostId)
+  const promise = doProbePendingSessionsOnHost(hostId, stateHint)
   inflightBatchProbes.set(hostId, promise)
   try {
     await promise
@@ -736,7 +765,10 @@ export async function probePendingSessionsOnHost(hostId: string): Promise<void> 
   }
 }
 
-async function doProbePendingSessionsOnHost(hostId: string): Promise<void> {
+async function doProbePendingSessionsOnHost(
+  hostId: string,
+  stateHint?: HostConnectionState
+): Promise<void> {
   const host = getHost(hostId)
   if (!host) return
 
@@ -748,8 +780,12 @@ async function doProbePendingSessionsOnHost(hostId: string): Promise<void> {
   }
   if (pending.length === 0) return
 
-  // Short-circuit the cascade if the runtime is known-failed.
-  const runtime = runtimeStateFor(hostId)
+  // Short-circuit the cascade if the runtime is known-failed. Prefer
+  // stateHint: on an ensureHostConnection failure the runtime entry has been
+  // deleted by stopHostConnection, so runtimeStateFor would return undefined
+  // and we'd fall through to the probe loop — defeating the "no further
+  // attempts" contract on auth-failed cascades.
+  const runtime = stateHint ?? runtimeStateFor(hostId)
   if (runtime === 'auth-failed' || runtime === 'unreachable') {
     for (const s of pending) s.connectionState = runtime
     onSessionsChanged()

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -623,8 +623,11 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
 
   const promise = doReconnectRemoteSession(id)
   inflightReconnects.set(id, promise)
+  let reconnectError: unknown = undefined
   try {
     await promise
+  } catch (err) {
+    reconnectError = err
   } finally {
     inflightReconnects.delete(id)
   }
@@ -632,17 +635,22 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
   // it. `probePendingSessionsOnHost` is idempotent so concurrent clicks on
   // multiple cards of the same host still collapse to a single batch.
   //
-  // Trigger whenever the host control connection is live, not when the clicked
-  // session is live: if the first click landed on a session whose remote tmux
-  // was already gone (session ends `dead`), the host itself is reachable, so
-  // we still want to reconcile the other pending sessions on it.
+  // Always attempt the batch probe, even when the clicked reconnect rejected:
+  // - on success (runtime `live`), we reconcile siblings over the now-live
+  //   ControlMaster
+  // - on auth-failed / unreachable, the batch's short-circuit cascades that
+  //   state to every pending sibling without any new SSH I/O (spec AC #8)
+  // Skip only when there's no host at all (orphaned hostId / missing registry
+  // entry): there is nothing to probe.
   const entry = sessions.get(id)
   const hostId = entry?.session.hostId
-  if (hostId && runtimeStateFor(hostId) === 'live') {
+  const runtimeState = hostId ? runtimeStateFor(hostId) : undefined
+  if (hostId && runtimeState) {
     probePendingSessionsOnHost(hostId).catch((err) => {
       console.error(`probePendingSessionsOnHost(${hostId}) failed:`, err)
     })
   }
+  if (reconnectError !== undefined) throw reconnectError
 }
 
 async function doReconnectRemoteSession(id: string): Promise<void> {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -674,6 +674,12 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
     return
   }
 
+  // Capture hostId BEFORE the await: if `removeSession(id)` runs while this
+  // reconnect is in flight, `sessions.get(id)` would return undefined after
+  // the await and we'd neither release the host retain nor run the sibling
+  // batch — leaking the ControlMaster for the lifetime of the app.
+  const initialHostId = sessions.get(id)?.session.hostId ?? null
+
   const promise = doReconnectRemoteSession(id)
   inflightReconnects.set(id, promise)
   let reconnectError: unknown = undefined
@@ -699,8 +705,7 @@ export async function reconnectRemoteSession(id: string): Promise<void> {
   //
   // Skip only when there's no host at all (orphaned hostId / missing registry
   // entry) or we couldn't determine any state — there's nothing to probe.
-  const entry = sessions.get(id)
-  const hostId = entry?.session.hostId
+  const hostId = sessions.get(id)?.session.hostId ?? initialHostId
   const tagged = (reconnectError as { hostConnectionState?: HostConnectionState } | null)
     ?.hostConnectionState
   const stateHint = successState ?? tagged ?? (hostId ? runtimeStateFor(hostId) : undefined)

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -34,6 +34,7 @@ import {
   retainHostConnection,
   releaseHostConnection,
   stopHostConnection,
+  runtimeStateFor,
 } from './host-connection'
 import { bootstrapHost } from './host-bootstrap'
 import type { Host, RemoteProject, Session, SessionStatus } from '../shared/types'
@@ -234,6 +235,25 @@ function updateSession(id: string, status: SessionStatus): void {
   if (!entry) return
   entry.session.status = status
   entry.session.lastActivity = Date.now()
+  onSessionsChanged()
+}
+
+// Rate-limit `lastKnownState` writes per session to once every 10s so the
+// 3s thumbnail tick doesn't churn `sessions.json` on disk.
+const LAST_KNOWN_STATE_MIN_INTERVAL_MS = 10_000
+const LAST_KNOWN_STATE_MAX_BYTES = 3 * 1024
+const lastKnownStateWrites = new Map<string, number>()
+
+export function updateLastKnownState(id: string, text: string): void {
+  const entry = sessions.get(id)
+  if (!entry) return
+  const now = Date.now()
+  const last = lastKnownStateWrites.get(id) ?? 0
+  if (now - last < LAST_KNOWN_STATE_MIN_INTERVAL_MS) return
+  const trimmed =
+    text.length > LAST_KNOWN_STATE_MAX_BYTES ? text.slice(-LAST_KNOWN_STATE_MAX_BYTES) : text
+  entry.session.lastKnownState = { text: trimmed, timestamp: now }
+  lastKnownStateWrites.set(id, now)
   onSessionsChanged()
 }
 
@@ -582,6 +602,164 @@ export async function killSession(id: string): Promise<void> {
   updateSession(id, 'dead')
 }
 
+// In-flight reconnect promises keyed by session id. Two concurrent clicks on
+// the same pending card (fast double-click, or a click that races the
+// auto-fired batch probe) coalesce into one SSH attempt.
+const inflightReconnects = new Map<string, Promise<void>>()
+
+// Probe-only reconnect for a remote session. If the remote tmux session is
+// present we reattach and mark `live`; if it is gone we mark the session
+// `dead` (matches issue #12 AC #4: "either reattach the PTY or marks the
+// session dead"). Creating a fresh remote tmux session is `reviveSession`'s
+// job — that requires explicit user intent ("Restart terminal" on dead).
+//
+// On SSH failure we classify via `runtimeStateFor` (set by host-connection's
+// `startRuntime` before ensureHostConnection rejects), so auth-failed vs.
+// network-unreachable get distinct UI states without re-parsing stderr.
+export async function reconnectRemoteSession(id: string): Promise<void> {
+  const existing = inflightReconnects.get(id)
+  if (existing) return existing
+
+  const promise = doReconnectRemoteSession(id)
+  inflightReconnects.set(id, promise)
+  try {
+    await promise
+  } finally {
+    inflightReconnects.delete(id)
+  }
+  // Fire-and-forget the sibling batch probe — the caller should not block on
+  // it. `probePendingSessionsOnHost` is idempotent so concurrent clicks on
+  // multiple cards of the same host still collapse to a single batch.
+  const entry = sessions.get(id)
+  if (entry?.session.hostId && entry.session.connectionState === 'live') {
+    probePendingSessionsOnHost(entry.session.hostId).catch((err) => {
+      console.error(`probePendingSessionsOnHost(${entry.session.hostId}) failed:`, err)
+    })
+  }
+}
+
+async function doReconnectRemoteSession(id: string): Promise<void> {
+  const entry = sessions.get(id)
+  if (!entry) throw new Error(`Session ${id} not found`)
+  const session = entry.session
+  if (!session.hostId) {
+    throw new Error(`Session ${id} is not a remote session`)
+  }
+  const hostId = session.hostId
+  const host = getHost(hostId)
+  if (!host) {
+    session.connectionState = 'unreachable'
+    onSessionsChanged()
+    throw new Error(`Host configuration for "${hostId}" was removed`)
+  }
+  session.connectionState = 'connecting'
+  onSessionsChanged()
+
+  let retained = false
+  try {
+    await prepareRemoteHost(host)
+    retained = true
+    if (await hasRemoteTmuxSession(id, host)) {
+      await reattachRemotePty(id, host)
+      session.connectionState = 'live'
+      if (session.status === 'running') session.status = 'idle'
+      session.lastActivity = Date.now()
+      onSessionsChanged()
+    } else {
+      // Remote tmux session is gone — session is dead. The user can invoke
+      // "Restart terminal" (reviveSession) to spawn a fresh remote session.
+      session.connectionState = 'offline'
+      session.status = 'dead'
+      session.lastActivity = Date.now()
+      onSessionsChanged()
+    }
+  } catch (err) {
+    const runtimeState = runtimeStateFor(hostId)
+    if (runtimeState === 'auth-failed') {
+      session.connectionState = 'auth-failed'
+    } else if (runtimeState === 'unreachable') {
+      session.connectionState = 'unreachable'
+    } else {
+      session.connectionState = 'offline'
+    }
+    onSessionsChanged()
+    if (retained) {
+      await releaseHostConnection(hostId).catch(() => undefined)
+    }
+    throw err
+  }
+  if (retained) {
+    await releaseHostConnection(hostId).catch(() => undefined)
+  }
+}
+
+// Eager batch probe for remaining `pending` sessions on a host that just
+// became live. Runs `tmux has-session` per sibling over the live ControlMaster
+// (no new SSH handshakes). If the runtime state is `auth-failed` /
+// `unreachable` we short-circuit: all siblings inherit that state without any
+// network I/O, satisfying spec AC #8 "auth failures transition directly to
+// host-auth-failed with no further attempts".
+const inflightBatchProbes = new Map<string, Promise<void>>()
+
+export async function probePendingSessionsOnHost(hostId: string): Promise<void> {
+  const existing = inflightBatchProbes.get(hostId)
+  if (existing) return existing
+  const promise = doProbePendingSessionsOnHost(hostId)
+  inflightBatchProbes.set(hostId, promise)
+  try {
+    await promise
+  } finally {
+    inflightBatchProbes.delete(hostId)
+  }
+}
+
+async function doProbePendingSessionsOnHost(hostId: string): Promise<void> {
+  const host = getHost(hostId)
+  if (!host) return
+
+  const pending: Session[] = []
+  for (const entry of sessions.values()) {
+    if (entry.session.hostId === hostId && entry.session.connectionState === 'pending') {
+      pending.push(entry.session)
+    }
+  }
+  if (pending.length === 0) return
+
+  // Short-circuit the cascade if the runtime is known-failed.
+  const runtime = runtimeStateFor(hostId)
+  if (runtime === 'auth-failed' || runtime === 'unreachable') {
+    for (const s of pending) s.connectionState = runtime
+    onSessionsChanged()
+    return
+  }
+
+  let bailed = false
+  for (const s of pending) {
+    if (bailed) break
+    try {
+      const alive = await hasRemoteTmuxSession(s.id, host)
+      if (alive) {
+        await reattachRemotePty(s.id, host)
+        s.connectionState = 'live'
+        if (s.status === 'running') s.status = 'idle'
+        s.lastActivity = Date.now()
+      } else {
+        s.connectionState = 'offline'
+        s.status = 'dead'
+        s.lastActivity = Date.now()
+      }
+    } catch (err) {
+      // A mid-batch SSH failure means the host dropped. Mark this sibling
+      // unreachable and stop — remaining siblings stay `pending` for a
+      // later manual reconnect, avoiding a flood of follow-up SSH attempts.
+      console.error(`probePendingSessionsOnHost(${hostId}) aborted on ${s.id}:`, err)
+      s.connectionState = 'unreachable'
+      bailed = true
+    }
+  }
+  onSessionsChanged()
+}
+
 export async function reviveSession(id: string): Promise<void> {
   const entry = sessions.get(id)
   if (!entry) throw new Error(`Session ${id} not found`)
@@ -853,6 +1031,26 @@ export async function relocateProject(
   return { migratedCount: toMigrate.length }
 }
 
+// Backfill / reconcile fields added in later versions. For local sessions
+// (worktreePath exists on this machine) the live git branch trumps whatever
+// was persisted — an earlier version stored a wrong default that we self-heal
+// here. Remote sessions can't access git without SSH, so they keep the
+// persisted branch and only fall back when it's missing.
+function backfillDerivedFields(session: Session): void {
+  if (!session.hostId && existsSync(session.worktreePath)) {
+    session.branch = resolveBranchFromWorktree(session.worktreePath, session.worktreeName)
+  } else if (!session.branch) {
+    session.branch = `cc-pewpew/${session.worktreeName}`
+  }
+  if (session.issueNumber === undefined) {
+    session.issueNumber = parseIssueNumber(session.worktreeName, session.branch)
+  }
+  if (session.prNumber === undefined) {
+    const m = session.worktreeName.match(/^pr-(\d+)$/)
+    if (m) session.prNumber = parseInt(m[1], 10)
+  }
+}
+
 export function restoreSessions(): void {
   if (!existsSync(SESSIONS_PATH)) return
 
@@ -868,20 +1066,19 @@ export function restoreSessions(): void {
     for (const session of data) {
       session.hostId = session.hostId ?? null
       if (session.hostId) {
-        if (
-          session.status === 'running' ||
-          session.status === 'idle' ||
-          session.status === 'needs_input'
-        ) {
-          session.status = 'dead'
+        // Lazy restore: a remote session materializes in `pending` until the
+        // user's first click (or reconnectRemoteSession) opens the host's SSH
+        // control connection and probes tmux. No network I/O here.
+        // `running` → `idle` matches the local "resumedStatus" mapping; a
+        // persisted status of `dead` means the remote tmux is confirmed gone
+        // and there is nothing to reconnect to, so leave connectionState unset.
+        if (session.status === 'running') {
+          session.status = 'idle'
         }
-        session.connectionState = 'offline'
-        if (!session.branch) {
-          session.branch = `cc-pewpew/${session.worktreeName}`
+        if (session.status !== 'dead') {
+          session.connectionState = 'pending'
         }
-        if (session.issueNumber === undefined) {
-          session.issueNumber = parseIssueNumber(session.worktreeName, session.branch)
-        }
+        backfillDerivedFields(session)
         sessions.set(session.id, { session })
         continue
       }
@@ -925,22 +1122,7 @@ export function restoreSessions(): void {
       }
       // Migrate legacy symlink-form paths to canonical so renderer matches work.
       session.worktreePath = canonicalPath(session.worktreePath)
-      // Backfill / reconcile fields added in later versions. Read the real
-      // branch from git when the worktree exists — an earlier version of this
-      // code persisted an incorrect default that we self-heal. If the worktree
-      // is gone, keep whatever was persisted (or the default fallback).
-      if (existsSync(session.worktreePath)) {
-        session.branch = resolveBranchFromWorktree(session.worktreePath, session.worktreeName)
-      } else if (!session.branch) {
-        session.branch = `cc-pewpew/${session.worktreeName}`
-      }
-      if (session.issueNumber === undefined) {
-        session.issueNumber = parseIssueNumber(session.worktreeName, session.branch)
-      }
-      if (session.prNumber === undefined) {
-        const m = session.worktreeName.match(/^pr-(\d+)$/)
-        if (m) session.prNumber = parseInt(m[1], 10)
-      }
+      backfillDerivedFields(session)
       if (session.status !== 'dead') {
         session.lastActivity = Date.now()
       }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -24,6 +24,7 @@ contextBridge.exposeInMainWorld('api', {
   getSessions: () => ipcRenderer.invoke('sessions:list'),
   killSession: (id: string) => ipcRenderer.invoke('sessions:kill', id),
   reviveSession: (id: string) => ipcRenderer.invoke('sessions:revive', id),
+  reconnectSession: (id: string) => ipcRenderer.invoke('sessions:reconnect', id),
   removeWorktree: (id: string) => ipcRenderer.invoke('sessions:remove-worktree', id),
   removeSession: (id: string) => ipcRenderer.invoke('sessions:remove', id),
   killSessionBatch: (ids: string[]) => ipcRenderer.invoke('sessions:kill-batch', ids),

--- a/src/renderer/components/DetailPane.tsx
+++ b/src/renderer/components/DetailPane.tsx
@@ -15,7 +15,15 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
   const hosts = useHostsStore((s) => s.hosts)
   const host = session?.hostId ? hosts.find((h) => h.hostId === session.hostId) : null
   const isDead = session?.status === 'dead'
+  const connectionState = session?.connectionState
+  const isRemote = !!session?.hostId
+  const isPending = isRemote && connectionState === 'pending'
+  const isConnecting = isRemote && connectionState === 'connecting'
+  const isAuthFailed = isRemote && connectionState === 'auth-failed'
+  const isUnreachable = isRemote && connectionState === 'unreachable'
+  const showReconnectOverlay = !isDead && (isPending || isAuthFailed || isUnreachable)
   const [reviving, setReviving] = useState(false)
+  const [reconnecting, setReconnecting] = useState(false)
   // Monotonic flip count — each toggle increments by 1, rotating +180deg.
   // Using a counter (instead of a boolean) keeps the rotation going in the
   // same direction on return instead of reversing.
@@ -80,6 +88,18 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
     }
   }
 
+  const handleReconnect = async () => {
+    setReconnecting(true)
+    try {
+      await window.api.reconnectSession(sessionId)
+    } catch {
+      // Error surfaces via the session's connectionState update; swallow so we
+      // can re-enable the button.
+    } finally {
+      setReconnecting(false)
+    }
+  }
+
   return (
     <div className="detail-pane">
       <div className="detail-pane-header">
@@ -111,6 +131,51 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
               <button className="dead-session-restart" onClick={handleRevive} disabled={reviving}>
                 {reviving ? 'Restarting...' : 'Restart terminal'}
               </button>
+            </div>
+          </div>
+        ) : showReconnectOverlay ? (
+          <div
+            className={`dead-session-overlay connection-overlay connection-overlay--${connectionState}`}
+          >
+            <div className="dead-session-content">
+              {isPending && (
+                <>
+                  <h3>Connecting to {host?.label ?? 'host'}</h3>
+                  <p>Probing the remote tmux session.</p>
+                </>
+              )}
+              {isAuthFailed && (
+                <>
+                  <h3>Authentication failed</h3>
+                  <p>
+                    SSH authentication to {host?.label ?? 'the host'} was rejected. Fix your
+                    credentials and click Retry.
+                  </p>
+                </>
+              )}
+              {isUnreachable && (
+                <>
+                  <h3>Host unreachable</h3>
+                  <p>
+                    {host?.label ?? 'The host'} did not respond. Check your network or VPN, then
+                    click Retry.
+                  </p>
+                </>
+              )}
+              <button
+                className="dead-session-restart"
+                onClick={handleReconnect}
+                disabled={reconnecting || isConnecting}
+              >
+                {reconnecting || isConnecting ? 'Connecting...' : isPending ? 'Connect' : 'Retry'}
+              </button>
+            </div>
+          </div>
+        ) : isConnecting ? (
+          <div className="dead-session-overlay connection-overlay connection-overlay--connecting">
+            <div className="dead-session-content">
+              <h3>Reconnecting…</h3>
+              <p>Re-attaching the terminal.</p>
             </div>
           </div>
         ) : (

--- a/src/renderer/components/DetailPane.tsx
+++ b/src/renderer/components/DetailPane.tsx
@@ -21,7 +21,11 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
   const isConnecting = isRemote && connectionState === 'connecting'
   const isAuthFailed = isRemote && connectionState === 'auth-failed'
   const isUnreachable = isRemote && connectionState === 'unreachable'
-  const showReconnectOverlay = !isDead && (isPending || isAuthFailed || isUnreachable)
+  // 'offline' covers post-prepareRemoteHost reconnect failures (probe /
+  // reattach / bootstrap errors) that aren't auth- or network-classified.
+  // Without this branch the user sees an inert Terminal pane with no Retry.
+  const isOffline = isRemote && connectionState === 'offline'
+  const showReconnectOverlay = !isDead && (isPending || isAuthFailed || isUnreachable || isOffline)
   const [reviving, setReviving] = useState(false)
   const [reconnecting, setReconnecting] = useState(false)
   // Monotonic flip count — each toggle increments by 1, rotating +180deg.
@@ -159,6 +163,15 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
                   <p>
                     {host?.label ?? 'The host'} did not respond. Check your network or VPN, then
                     click Retry.
+                  </p>
+                </>
+              )}
+              {isOffline && (
+                <>
+                  <h3>Reconnect failed</h3>
+                  <p>
+                    The session could not be reattached on {host?.label ?? 'the host'}. Click Retry
+                    to try again.
                   </p>
                 </>
               )}

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -51,6 +51,12 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
     if (selectedCount > 0) {
       clearSelection()
     }
+    // First click on a pending remote session opens the host's control
+    // connection and probes tmux. DetailPane renders the cached preview +
+    // spinner overlay while connectionState transitions to 'live' (or dead).
+    if (session.hostId && connectionState === 'pending') {
+      void window.api.reconnectSession(session.id).catch(() => undefined)
+    }
     if (onOpenSession && session.status !== 'dead' && session.status !== 'error') {
       onOpenSession(session.id, sessionName)
     }
@@ -112,11 +118,23 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
         },
       ]
     }
+    const isRemoteNonLive =
+      !!session.hostId && connectionState !== undefined && connectionState !== 'live'
     return [
       {
         label: session.status === 'dead' ? 'Restart terminal' : 'Open terminal',
         onClick: () => onOpenSession?.(session.id, sessionName),
       },
+      ...(isRemoteNonLive && session.status !== 'dead'
+        ? [
+            {
+              label: 'Reconnect',
+              onClick: () => {
+                void window.api.reconnectSession(session.id).catch(() => undefined)
+              },
+            },
+          ]
+        : []),
       {
         label: 'Kill session',
         onClick: () => {
@@ -158,7 +176,12 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
       style={style}
     >
       <div className="session-card-thumb">
-        {thumbnail ? <pre className="session-card-text-thumb">{thumbnail}</pre> : null}
+        {(() => {
+          const preview = thumbnail ?? session.lastKnownState?.text
+          if (!preview) return null
+          const stale = !thumbnail && connectionState !== 'live'
+          return <pre className={`session-card-text-thumb${stale ? ' stale' : ''}`}>{preview}</pre>
+        })()}
         {host && (
           <div className="session-card-host-overlay" title={`${host.label}: ${connectionState}`}>
             <span className="host-pill">{host.label}</span>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -35,6 +35,7 @@ declare global {
       getSessions: () => Promise<Session[]>
       killSession: (id: string) => Promise<void>
       reviveSession: (id: string) => Promise<void>
+      reconnectSession: (id: string) => Promise<void>
       removeWorktree: (id: string) => Promise<void>
       removeSession: (id: string) => Promise<void>
       killSessionBatch: (ids: string[]) => Promise<void>

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -478,18 +478,44 @@ body,
   background: var(--accent-yellow);
 }
 
-.connection-auth-failed,
-.connection-unreachable {
+.connection-auth-failed {
   background: var(--accent-red);
+}
+
+.connection-unreachable {
+  background: var(--accent-yellow);
 }
 
 .connection-offline {
   background: var(--text-secondary);
 }
 
+.connection-pending {
+  background: var(--text-secondary);
+  opacity: 0.6;
+}
+
 .connection-label {
   color: var(--text-secondary);
   font-size: 12px;
+}
+
+.session-card-text-thumb.stale {
+  opacity: 0.55;
+  filter: saturate(0.6);
+}
+
+.connection-overlay--pending,
+.connection-overlay--connecting {
+  background: rgba(14, 14, 30, 0.82);
+}
+
+.connection-overlay--auth-failed {
+  background: rgba(64, 18, 24, 0.85);
+}
+
+.connection-overlay--unreachable {
+  background: rgba(64, 56, 18, 0.85);
 }
 
 .session-card-time {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,16 @@
 export type SessionStatus = 'running' | 'needs_input' | 'idle' | 'completed' | 'error' | 'dead'
-export type ConnectionState = 'connecting' | 'live' | 'offline' | 'auth-failed' | 'unreachable'
+export type ConnectionState =
+  | 'connecting'
+  | 'live'
+  | 'offline'
+  | 'pending'
+  | 'auth-failed'
+  | 'unreachable'
+
+export interface LastKnownState {
+  text: string
+  timestamp: number
+}
 
 export interface Project {
   name: string
@@ -34,6 +45,7 @@ export interface Session {
   lastActivity: number
   hookEvents: HookEvent[]
   repoFingerprint?: string
+  lastKnownState?: LastKnownState
 }
 
 export interface HookEvent {


### PR DESCRIPTION
## Summary

- Remote sessions materialize in a new `pending` connection state at restart with a cached pane-text preview, without opening any SSH connections
- First click on a pending card opens the host's control connection, runs `tmux has-session`, and either reattaches the PTY (→ `live`) or marks the session dead
- After first connect, remaining pending siblings on the same host are probed in a single batch over the live ControlMaster — no new SSH handshakes
- New states `host-auth-failed` (red) and `host-unreachable` (amber) with distinct CSS + DetailPane overlays; manual Reconnect on any non-live remote session; no auto-retry in v1
- `sessions.json` gains `lastKnownState` (≤3 KiB, rate-limited to 10s) so the cached preview survives restarts
- Local session restore behavior unchanged

Closes #12

## Design notes

- `reconnectRemoteSession(id)` is probe-only — reattaches on tmux-present, marks dead on tmux-absent. `reviveSession` keeps its create-if-missing semantics for the truly-dead case.
- Auth vs. network is read from `runtimeStateFor(hostId)` (exported from `host-connection`), which is set by `startRuntime` before `ensureHostConnection` rejects — no re-parsing stderr.
- Idempotency: module-level in-flight Maps for both `reconnectRemoteSession(id)` (per session) and `probePendingSessionsOnHost(hostId)` (per host). Concurrent clicks coalesce.
- Auth-failed cascade: `probePendingSessionsOnHost` short-circuits when the runtime is already `auth-failed` or `unreachable`, marking all siblings without any network I/O.
- Orphaned `hostId` (host deleted from registry): `reconnectRemoteSession` sets `connectionState='unreachable'` and skips SSH.
- `lastKnownState` is captured from the local `PtyEntry.buffer` we already accumulate — no new remote I/O. Remote thumbnail capture remains deferred to issue #13.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] `npx prettier --check .` — clean
- [x] `npx vitest run` — 177 pass (19 new in `session-manager.test.ts` covering: pending materialization, preserved prior status, running→idle normalization, dead preserved, lastKnownState round-trip, local-restore regression, reconnectRemoteSession (tmux-present, tmux-gone, auth-failed, unreachable, orphaned host, idempotency, retry-after-auth-failed), batch probe (parallel, tmux-gone-sibling, auth-failed cascade, idempotency), lastKnownState rate-limit + 3 KiB cap)
- [x] `npm run build` — clean
- [ ] Manual CDP walkthrough per PRD #8 reconnection flow (host unreachable, reconnect button, auth-failed retry)