### PR TITLE
Remote SSH [5/8]: naive remote thumbnails over ControlMaster

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -552,17 +552,29 @@ app.whenReady().then(async () => {
   // 10s per-session rate limit and emits a single persist + broadcast per
   // tick, avoiding an O(N) write storm when many sessions unlock the window
   // simultaneously.
+  let thumbCaptureInFlight = false
   const thumbInterval = setInterval(() => {
-    const thumbs = captureThumbnails()
-    if (Object.keys(thumbs).length > 0) {
-      broadcastToAll('thumbnails:text-updated', thumbs)
-    }
-    const updates: { id: string; text: string }[] = []
-    for (const session of getSessions()) {
-      const text = getLastSnapshot(session.id)
-      if (text) updates.push({ id: session.id, text })
-    }
-    if (updates.length > 0) updateLastKnownStatesBatch(updates)
+    // Skip if the previous tick is still running. Remote captures await ssh
+    // round-trips, so a slow host could otherwise stack overlapping passes and
+    // race on the lastSnapshot writes.
+    if (thumbCaptureInFlight) return
+    thumbCaptureInFlight = true
+    void (async () => {
+      try {
+        const thumbs = await captureThumbnails()
+        if (Object.keys(thumbs).length > 0) {
+          broadcastToAll('thumbnails:text-updated', thumbs)
+        }
+        const updates: { id: string; text: string }[] = []
+        for (const session of getSessions()) {
+          const text = getLastSnapshot(session.id)
+          if (text) updates.push({ id: session.id, text })
+        }
+        if (updates.length > 0) updateLastKnownStatesBatch(updates)
+      } finally {
+        thumbCaptureInFlight = false
+      }
+    })()
   }, 3000)
 
   app.on('activate', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -556,15 +556,20 @@ app.whenReady().then(async () => {
   const thumbInterval = setInterval(() => {
     // Skip if the previous tick is still running. Remote captures await ssh
     // round-trips, so a slow host could otherwise stack overlapping passes and
-    // race on the lastSnapshot writes.
+    // race on the lastSnapshot writes. Per-session results still surface as
+    // they settle via the onCapture callback below — the in-flight guard only
+    // gates the next batch start, not the broadcast cadence within a batch.
     if (thumbCaptureInFlight) return
     thumbCaptureInFlight = true
     void (async () => {
       try {
-        const thumbs = await captureThumbnails()
-        if (Object.keys(thumbs).length > 0) {
-          broadcastToAll('thumbnails:text-updated', thumbs)
-        }
+        await captureThumbnails({
+          // Broadcast each thumbnail the instant its capture lands so a wedged
+          // remote session timing out at the 3 s cap can't delay healthy
+          // siblings' updates.
+          onCapture: (sessionId, text) =>
+            broadcastToAll('thumbnails:text-updated', { [sessionId]: text }),
+        })
         const updates: { id: string; text: string }[] = []
         for (const session of getSessions()) {
           const text = getLastSnapshot(session.id)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,7 +23,6 @@ import {
   destroyPty,
   getScrollback,
   captureThumbnails,
-  getLastSnapshot,
 } from './pty-manager'
 import {
   initSessionManager,
@@ -555,26 +554,27 @@ app.whenReady().then(async () => {
   let thumbCaptureInFlight = false
   const thumbInterval = setInterval(() => {
     // Skip if the previous tick is still running. Remote captures await ssh
-    // round-trips, so a slow host could otherwise stack overlapping passes and
-    // race on the lastSnapshot writes. Per-session results still surface as
-    // they settle via the onCapture callback below — the in-flight guard only
-    // gates the next batch start, not the broadcast cadence within a batch.
+    // round-trips, so a slow host could otherwise stack overlapping ssh
+    // fan-outs across ticks. Per-session results still surface as they settle
+    // via the onCapture callback below — the in-flight guard only gates the
+    // next batch start, not the broadcast cadence within a batch.
     if (thumbCaptureInFlight) return
     thumbCaptureInFlight = true
     void (async () => {
       try {
-        await captureThumbnails({
+        const captured = await captureThumbnails({
           // Broadcast each thumbnail the instant its capture lands so a wedged
           // remote session timing out at the 3 s cap can't delay healthy
           // siblings' updates.
           onCapture: (sessionId, text) =>
             broadcastToAll('thumbnails:text-updated', { [sessionId]: text }),
         })
-        const updates: { id: string; text: string }[] = []
-        for (const session of getSessions()) {
-          const text = getLastSnapshot(session.id)
-          if (text) updates.push({ id: session.id, text })
-        }
+        // Persist directly from the captured Record. The Record is a snapshot
+        // of capture-pane text at capture time, so it can't race the live PTY
+        // stream that flows through the next 3 s tick — which would otherwise
+        // pollute a fast session's clean capture text with raw streaming-tail
+        // bytes while waiting for a slow sibling's exec to settle.
+        const updates = Object.entries(captured).map(([id, text]) => ({ id, text }))
         if (updates.length > 0) updateLastKnownStatesBatch(updates)
       } finally {
         thumbCaptureInFlight = false

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -551,35 +551,32 @@ app.whenReady().then(async () => {
   // 10s per-session rate limit and emits a single persist + broadcast per
   // tick, avoiding an O(N) write storm when many sessions unlock the window
   // simultaneously.
-  let thumbCaptureInFlight = false
+  // Ticks run independently — no in-flight guard. Per-call timeoutMs in
+  // captureRemotePaneTexts caps each tick at ~3 s, so at most two ticks
+  // overlap at the 3 s/3 s boundary (the slow ssh from the previous tick is
+  // still waiting on its timeout while the next tick fans out fresh
+  // captures). updateLastKnownStatesBatch is sync with a 10 s per-session
+  // rate limit + identical-text dedup, so two concurrent persists are safe.
+  // Gating the next tick on the slowest exec would have re-introduced the
+  // 6 s update cadence that the per-session onCapture broadcast was meant
+  // to fix.
   const thumbInterval = setInterval(() => {
-    // Skip if the previous tick is still running. Remote captures await ssh
-    // round-trips, so a slow host could otherwise stack overlapping ssh
-    // fan-outs across ticks. Per-session results still surface as they settle
-    // via the onCapture callback below — the in-flight guard only gates the
-    // next batch start, not the broadcast cadence within a batch.
-    if (thumbCaptureInFlight) return
-    thumbCaptureInFlight = true
     void (async () => {
-      try {
-        const captured = await captureThumbnails({
-          // Broadcast each thumbnail the instant its capture lands so a wedged
-          // remote session timing out at the 3 s cap can't delay healthy
-          // siblings' updates.
-          onCapture: (sessionId, text) =>
-            broadcastToAll('thumbnails:text-updated', { [sessionId]: text }),
-        })
-        // Persist directly from the captured Record. The Record is a snapshot
-        // of capture-pane text at capture time, so it can't race the live PTY
-        // stream that flows through the next 3 s tick — which would otherwise
-        // pollute a fast session's clean capture text with raw streaming-tail
-        // bytes while waiting for a slow sibling's exec to settle.
-        const updates = Object.entries(captured).map(([id, text]) => ({ id, text }))
-        if (updates.length > 0) updateLastKnownStatesBatch(updates)
-      } finally {
-        thumbCaptureInFlight = false
-      }
-    })()
+      const captured = await captureThumbnails({
+        // Broadcast each thumbnail the instant its capture lands so a wedged
+        // remote session timing out at the 3 s cap can't delay healthy
+        // siblings' updates.
+        onCapture: (sessionId, text) =>
+          broadcastToAll('thumbnails:text-updated', { [sessionId]: text }),
+      })
+      // Persist directly from the captured Record. The Record is a snapshot
+      // of capture-pane text at capture time, so it can't race the live PTY
+      // stream.
+      const updates = Object.entries(captured).map(([id, text]) => ({ id, text }))
+      if (updates.length > 0) updateLastKnownStatesBatch(updates)
+    })().catch((err) => {
+      console.error('thumbnail tick failed:', err)
+    })
   }, 3000)
 
   app.on('activate', () => {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -11,6 +11,7 @@ import {
   spawnAttach,
 } from './host-connection'
 import { classifySshExit } from './ssh-exit-parser'
+import { captureRemotePaneTexts, type RemoteSessionEntry } from './remote-thumbnail'
 import type { Host } from '../shared/types'
 
 interface PtyEntry {
@@ -306,11 +307,14 @@ export function hasTmuxSession(sessionId: string): boolean {
   }
 }
 
-export function captureThumbnails(): Record<string, string> {
+export async function captureThumbnails(): Promise<Record<string, string>> {
   const result: Record<string, string> = {}
+  const remoteEntries: RemoteSessionEntry[] = []
   for (const [sessionId, entry] of ptys) {
-    // Remote thumbnail capture is slice #13; issue #11 only needs the live PTY stream.
-    if (entry.host) continue
+    if (entry.host) {
+      remoteEntries.push({ sessionId, host: entry.host, tmuxSession: entry.tmuxSession })
+      continue
+    }
     try {
       const text = execFileSync('tmux', ['capture-pane', '-t', entry.tmuxSession, '-p'], {
         encoding: 'utf-8',
@@ -319,6 +323,23 @@ export function captureThumbnails(): Record<string, string> {
       result[sessionId] = text
     } catch {
       // Session may be dead
+    }
+  }
+  if (remoteEntries.length > 0) {
+    // Multiplexed through the per-host ControlMaster: every exec call shares the
+    // existing live SSH connection, so this is N tmux invocations but zero new
+    // SSH handshakes. Each per-session call is isolated by Promise.allSettled
+    // inside the helper so a single dead/unreachable session can't poison the
+    // batch or the underlying control connection.
+    const remote = await captureRemotePaneTexts(remoteEntries, { exec: execRemote })
+    for (const [sessionId, text] of Object.entries(remote)) {
+      result[sessionId] = text
+      // Captured pane text is a coherent screen snapshot — overwrite the
+      // streaming-buffer lastSnapshot so the lastKnownState cache persisted by
+      // session-manager reflects the most recent capture instead of the raw
+      // ANSI byte tail.
+      const entry = ptys.get(sessionId)
+      if (entry) entry.lastSnapshot = text
     }
   }
   return result

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -307,7 +307,13 @@ export function hasTmuxSession(sessionId: string): boolean {
   }
 }
 
-export async function captureThumbnails(): Promise<Record<string, string>> {
+export async function captureThumbnails(opts?: {
+  // Fired per session as soon as its capture lands. For remote sessions this
+  // happens inside the per-entry async path of `captureRemotePaneTexts`, so a
+  // healthy session's thumbnail surfaces without waiting for a wedged sibling
+  // to hit the per-call timeout.
+  onCapture?: (sessionId: string, text: string) => void
+}): Promise<Record<string, string>> {
   const result: Record<string, string> = {}
   const remoteEntries: RemoteSessionEntry[] = []
   for (const [sessionId, entry] of ptys) {
@@ -321,6 +327,7 @@ export async function captureThumbnails(): Promise<Record<string, string>> {
         timeout: 3000,
       })
       result[sessionId] = text
+      opts?.onCapture?.(sessionId, text)
     } catch {
       // Session may be dead
     }
@@ -328,18 +335,23 @@ export async function captureThumbnails(): Promise<Record<string, string>> {
   if (remoteEntries.length > 0) {
     // Multiplexed through the per-host ControlMaster: every exec call shares the
     // existing live SSH connection, so this is N tmux invocations but zero new
-    // SSH handshakes. Each per-session call is isolated by Promise.allSettled
-    // inside the helper so a single dead/unreachable session can't poison the
-    // batch or the underlying control connection.
-    const remote = await captureRemotePaneTexts(remoteEntries, { exec: execRemote })
+    // SSH handshakes. Each per-session call is isolated inside the helper so a
+    // single dead/unreachable session can't poison the batch or the underlying
+    // control connection.
+    const remote = await captureRemotePaneTexts(remoteEntries, {
+      exec: execRemote,
+      onCapture: (sessionId, text) => {
+        // Captured pane text is a coherent screen snapshot — overwrite the
+        // streaming-buffer lastSnapshot so the lastKnownState cache persisted
+        // by session-manager reflects the most recent capture instead of the
+        // raw ANSI byte tail.
+        const entry = ptys.get(sessionId)
+        if (entry) entry.lastSnapshot = text
+        opts?.onCapture?.(sessionId, text)
+      },
+    })
     for (const [sessionId, text] of Object.entries(remote)) {
       result[sessionId] = text
-      // Captured pane text is a coherent screen snapshot — overwrite the
-      // streaming-buffer lastSnapshot so the lastKnownState cache persisted by
-      // session-manager reflects the most recent capture instead of the raw
-      // ANSI byte tail.
-      const entry = ptys.get(sessionId)
-      if (entry) entry.lastSnapshot = text
     }
   }
   return result

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -18,15 +18,9 @@ interface PtyEntry {
   pty: IPty
   tmuxSession: string
   buffer: string
-  // Trailing window of PTY output. Populated on every flush so issue #12's
-  // `lastKnownState` survives restart with the last-seen pane text. Capped to
-  // LAST_SNAPSHOT_MAX bytes so a 100-session `sessions.json` stays small.
-  lastSnapshot: string
   host?: Host
   released?: boolean
 }
-
-const LAST_SNAPSHOT_MAX = 3 * 1024
 
 const ptys = new Map<string, PtyEntry>()
 let flushInterval: ReturnType<typeof setInterval> | null = null
@@ -35,17 +29,9 @@ function flushBuffers(): void {
   for (const [sessionId, entry] of ptys) {
     if (entry.buffer.length > 0) {
       broadcastToAll('pty:data', { sessionId, data: entry.buffer })
-      const appended = entry.lastSnapshot + entry.buffer
-      entry.lastSnapshot =
-        appended.length > LAST_SNAPSHOT_MAX ? appended.slice(-LAST_SNAPSHOT_MAX) : appended
       entry.buffer = ''
     }
   }
-}
-
-export function getLastSnapshot(sessionId: string): string | undefined {
-  const entry = ptys.get(sessionId)
-  return entry?.lastSnapshot || undefined
 }
 
 export function isTmuxAvailable(): boolean {
@@ -121,7 +107,6 @@ export function createPty(
     pty: ptyProcess,
     tmuxSession,
     buffer: '',
-    lastSnapshot: '',
   }
 
   ptyProcess.onData((data) => {
@@ -186,7 +171,6 @@ export async function createRemotePty(
     pty: ptyProcess,
     tmuxSession,
     buffer: '',
-    lastSnapshot: '',
     host,
   }
 
@@ -340,15 +324,7 @@ export async function captureThumbnails(opts?: {
     // control connection.
     const remote = await captureRemotePaneTexts(remoteEntries, {
       exec: execRemote,
-      onCapture: (sessionId, text) => {
-        // Captured pane text is a coherent screen snapshot — overwrite the
-        // streaming-buffer lastSnapshot so the lastKnownState cache persisted
-        // by session-manager reflects the most recent capture instead of the
-        // raw ANSI byte tail.
-        const entry = ptys.get(sessionId)
-        if (entry) entry.lastSnapshot = text
-        opts?.onCapture?.(sessionId, text)
-      },
+      onCapture: opts?.onCapture,
     })
     for (const [sessionId, text] of Object.entries(remote)) {
       result[sessionId] = text
@@ -441,7 +417,6 @@ export function reattachPty(sessionId: string): void {
     pty: ptyProcess,
     tmuxSession,
     buffer: '',
-    lastSnapshot: '',
   }
 
   ptyProcess.onData((data) => {
@@ -485,7 +460,6 @@ export async function reattachRemotePty(sessionId: string, host: Host): Promise<
     pty: ptyProcess,
     tmuxSession,
     buffer: '',
-    lastSnapshot: '',
     host,
   }
 

--- a/src/main/remote-thumbnail.test.ts
+++ b/src/main/remote-thumbnail.test.ts
@@ -131,4 +131,53 @@ describe('captureRemotePaneTexts', () => {
     // interval.
     expect(seenTimeouts[0]!).toBeLessThanOrEqual(3000)
   })
+
+  it('invokes onCapture for a fast session before a slow sibling settles', async () => {
+    let slowSettled = false
+    const fastEmitsObservedSlowState: boolean[] = []
+
+    const exec = async (_h: Host, argv: string[]): Promise<ExecResult> => {
+      if (argv.includes('cc-pewpew-slow')) {
+        await new Promise((r) => setTimeout(r, 60))
+        slowSettled = true
+        return ok('slow\n')
+      }
+      return ok('fast\n')
+    }
+
+    await captureRemotePaneTexts(
+      [
+        { sessionId: 'fast', host, tmuxSession: 'cc-pewpew-fast' },
+        { sessionId: 'slow', host, tmuxSession: 'cc-pewpew-slow' },
+      ],
+      {
+        exec,
+        onCapture: (sid) => {
+          if (sid === 'fast') fastEmitsObservedSlowState.push(slowSettled)
+        },
+      }
+    )
+
+    expect(fastEmitsObservedSlowState).toEqual([false])
+  })
+
+  it('passes the capped per-session text to onCapture and the aggregate return', async () => {
+    const calls: { sid: string; text: string }[] = []
+    const exec = async (_h: Host, argv: string[]) =>
+      ok(argv.includes('cc-pewpew-s1') ? 's1-text\n' : 's2-text\n')
+
+    const result = await captureRemotePaneTexts(
+      [
+        { sessionId: 's1', host, tmuxSession: 'cc-pewpew-s1' },
+        { sessionId: 's2', host, tmuxSession: 'cc-pewpew-s2' },
+      ],
+      { exec, onCapture: (sid, text) => calls.push({ sid, text }) }
+    )
+
+    expect(calls).toEqual([
+      { sid: 's1', text: 's1-text\n' },
+      { sid: 's2', text: 's2-text\n' },
+    ])
+    expect(result).toEqual({ s1: 's1-text\n', s2: 's2-text\n' })
+  })
 })

--- a/src/main/remote-thumbnail.test.ts
+++ b/src/main/remote-thumbnail.test.ts
@@ -19,6 +19,17 @@ describe('capLines', () => {
     const text = ['only', 'two'].join('\n')
     expect(capLines(text, 24)).toBe(text)
   })
+
+  it('preserves the trailing newline without dropping a real row', () => {
+    // 5 real rows + trailing newline, cap=5 — must keep all 5 rows.
+    const text = ['r1', 'r2', 'r3', 'r4', 'r5'].join('\n') + '\n'
+    expect(capLines(text, 5)).toBe(text)
+  })
+
+  it('caps to last N real rows when input has trailing newline and exceeds cap', () => {
+    const text = Array.from({ length: 6 }, (_, i) => `r${i + 1}`).join('\n') + '\n'
+    expect(capLines(text, 5)).toBe(['r2', 'r3', 'r4', 'r5', 'r6'].join('\n') + '\n')
+  })
 })
 
 describe('captureRemotePaneTexts', () => {
@@ -98,5 +109,26 @@ describe('captureRemotePaneTexts', () => {
     )
 
     expect(result).toEqual({ alive: 'alive\n' })
+  })
+
+  it('passes a per-call timeoutMs to exec so a hung session cannot stall the batch', async () => {
+    const seenTimeouts: (number | undefined)[] = []
+    const exec = async (
+      _h: Host,
+      _argv: string[],
+      opts?: { timeoutMs?: number }
+    ): Promise<ExecResult> => {
+      seenTimeouts.push(opts?.timeoutMs)
+      return ok('hi\n')
+    }
+
+    await captureRemotePaneTexts([{ sessionId: 's1', host, tmuxSession: 'cc-pewpew-s1' }], { exec })
+
+    expect(seenTimeouts).toHaveLength(1)
+    expect(seenTimeouts[0]).toBeDefined()
+    // The local thumbnail capture path uses 3000ms; remote must match so a
+    // single hung session can't push the whole tick past the 3s thumbnail
+    // interval.
+    expect(seenTimeouts[0]!).toBeLessThanOrEqual(3000)
   })
 })

--- a/src/main/remote-thumbnail.test.ts
+++ b/src/main/remote-thumbnail.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { capLines, captureRemotePaneTexts } from './remote-thumbnail'
+import type { ExecResult } from './host-connection'
+import type { Host } from '../shared/types'
+
+function ok(stdout = ''): ExecResult {
+  return { stdout, stderr: '', code: 0, timedOut: false }
+}
+
+const host: Host = { hostId: 'h1', alias: 'devbox', label: 'devbox' }
+
+describe('capLines', () => {
+  it('keeps only the last N lines when input exceeds N rows', () => {
+    const text = ['l1', 'l2', 'l3', 'l4', 'l5'].join('\n')
+    expect(capLines(text, 3)).toBe(['l3', 'l4', 'l5'].join('\n'))
+  })
+
+  it('returns input unchanged when it has fewer than N lines', () => {
+    const text = ['only', 'two'].join('\n')
+    expect(capLines(text, 24)).toBe(text)
+  })
+})
+
+describe('captureRemotePaneTexts', () => {
+  it('issues tmux capture-pane through the injected exec for each remote session', async () => {
+    const calls: { host: Host; argv: string[] }[] = []
+    const exec = async (h: Host, argv: string[]) => {
+      calls.push({ host: h, argv })
+      return ok('hi\n')
+    }
+
+    const result = await captureRemotePaneTexts(
+      [
+        { sessionId: 's1', host, tmuxSession: 'cc-pewpew-s1' },
+        { sessionId: 's2', host, tmuxSession: 'cc-pewpew-s2' },
+      ],
+      { exec }
+    )
+
+    expect(result).toEqual({ s1: 'hi\n', s2: 'hi\n' })
+    expect(calls).toHaveLength(2)
+    expect(calls[0]).toEqual({
+      host,
+      argv: ['tmux', 'capture-pane', '-t', 'cc-pewpew-s1', '-p'],
+    })
+    expect(calls[1].argv).toEqual(['tmux', 'capture-pane', '-t', 'cc-pewpew-s2', '-p'])
+  })
+
+  it('caps captured output to the configured row limit', async () => {
+    const big = Array.from({ length: 50 }, (_, i) => `row${i + 1}`).join('\n')
+    const exec = async () => ok(big)
+
+    const result = await captureRemotePaneTexts(
+      [{ sessionId: 's1', host, tmuxSession: 'cc-pewpew-s1' }],
+      { exec, maxRows: 24 }
+    )
+
+    expect(result.s1.split('\n')).toHaveLength(24)
+    expect(result.s1.split('\n')[0]).toBe('row27')
+    expect(result.s1.split('\n').at(-1)).toBe('row50')
+  })
+
+  it('skips a session whose exec rejects but still returns the others', async () => {
+    const exec = async (_h: Host, argv: string[]) => {
+      if (argv.includes('cc-pewpew-broken')) throw new Error('boom')
+      return ok('ok-out\n')
+    }
+
+    const result = await captureRemotePaneTexts(
+      [
+        { sessionId: 'broken', host, tmuxSession: 'cc-pewpew-broken' },
+        { sessionId: 'good', host, tmuxSession: 'cc-pewpew-good' },
+      ],
+      { exec }
+    )
+
+    expect(result).toEqual({ good: 'ok-out\n' })
+  })
+
+  it('skips a session whose capture times out or fails non-zero', async () => {
+    const exec = async (_h: Host, argv: string[]): Promise<ExecResult> => {
+      if (argv.includes('cc-pewpew-timeout')) {
+        return { stdout: '', stderr: 'timed out', code: 1, timedOut: true }
+      }
+      if (argv.includes('cc-pewpew-noexit')) {
+        return { stdout: '', stderr: "can't find session", code: 1, timedOut: false }
+      }
+      return ok('alive\n')
+    }
+
+    const result = await captureRemotePaneTexts(
+      [
+        { sessionId: 'timeout', host, tmuxSession: 'cc-pewpew-timeout' },
+        { sessionId: 'noexit', host, tmuxSession: 'cc-pewpew-noexit' },
+        { sessionId: 'alive', host, tmuxSession: 'cc-pewpew-alive' },
+      ],
+      { exec }
+    )
+
+    expect(result).toEqual({ alive: 'alive\n' })
+  })
+})

--- a/src/main/remote-thumbnail.ts
+++ b/src/main/remote-thumbnail.ts
@@ -1,0 +1,47 @@
+import type { ExecResult } from './host-connection'
+import type { Host } from '../shared/types'
+
+export interface RemoteSessionEntry {
+  sessionId: string
+  host: Host
+  tmuxSession: string
+}
+
+export interface CaptureOptions {
+  exec: (host: Host, argv: string[], opts?: { timeoutMs?: number }) => Promise<ExecResult>
+  maxRows?: number
+}
+
+export const DEFAULT_REMOTE_THUMBNAIL_ROWS = 24
+
+export function capLines(text: string, maxRows: number): string {
+  const lines = text.split('\n')
+  return lines.slice(-maxRows).join('\n')
+}
+
+export async function captureRemotePaneTexts(
+  entries: ReadonlyArray<RemoteSessionEntry>,
+  options: CaptureOptions
+): Promise<Record<string, string>> {
+  const maxRows = options.maxRows ?? DEFAULT_REMOTE_THUMBNAIL_ROWS
+  const settled = await Promise.allSettled(
+    entries.map(async (entry) => {
+      const result = await options.exec(entry.host, [
+        'tmux',
+        'capture-pane',
+        '-t',
+        entry.tmuxSession,
+        '-p',
+      ])
+      return { entry, result }
+    })
+  )
+  const out: Record<string, string> = {}
+  for (const item of settled) {
+    if (item.status !== 'fulfilled') continue
+    const { entry, result } = item.value
+    if (result.timedOut || result.code !== 0) continue
+    out[entry.sessionId] = capLines(result.stdout, maxRows)
+  }
+  return out
+}

--- a/src/main/remote-thumbnail.ts
+++ b/src/main/remote-thumbnail.ts
@@ -10,13 +10,26 @@ export interface RemoteSessionEntry {
 export interface CaptureOptions {
   exec: (host: Host, argv: string[], opts?: { timeoutMs?: number }) => Promise<ExecResult>
   maxRows?: number
+  timeoutMs?: number
 }
 
 export const DEFAULT_REMOTE_THUMBNAIL_ROWS = 24
+// Matches the local `tmux capture-pane` timeout in pty-manager.captureThumbnails.
+// Bounds a hung remote so it can't stall the 3 s thumbnail interval — the
+// in-flight guard in index.ts skips overlapping ticks, so without this cap a
+// single dead session would freeze every other session's thumbnail too.
+export const DEFAULT_REMOTE_THUMBNAIL_TIMEOUT_MS = 3000
 
 export function capLines(text: string, maxRows: number): string {
-  const lines = text.split('\n')
-  return lines.slice(-maxRows).join('\n')
+  // `tmux capture-pane -p` emits a trailing newline. A naive split + slice would
+  // count the resulting empty tail element as a "row" and drop a real one when
+  // the visible pane exactly fills `maxRows`. Strip the terminator before the
+  // cap and re-attach it so the output round-trips for already-bounded input.
+  const trailing = text.endsWith('\n')
+  const body = trailing ? text.slice(0, -1) : text
+  const lines = body.split('\n')
+  if (lines.length <= maxRows) return text
+  return lines.slice(-maxRows).join('\n') + (trailing ? '\n' : '')
 }
 
 export async function captureRemotePaneTexts(
@@ -24,15 +37,14 @@ export async function captureRemotePaneTexts(
   options: CaptureOptions
 ): Promise<Record<string, string>> {
   const maxRows = options.maxRows ?? DEFAULT_REMOTE_THUMBNAIL_ROWS
+  const timeoutMs = options.timeoutMs ?? DEFAULT_REMOTE_THUMBNAIL_TIMEOUT_MS
   const settled = await Promise.allSettled(
     entries.map(async (entry) => {
-      const result = await options.exec(entry.host, [
-        'tmux',
-        'capture-pane',
-        '-t',
-        entry.tmuxSession,
-        '-p',
-      ])
+      const result = await options.exec(
+        entry.host,
+        ['tmux', 'capture-pane', '-t', entry.tmuxSession, '-p'],
+        { timeoutMs }
+      )
       return { entry, result }
     })
   )

--- a/src/main/remote-thumbnail.ts
+++ b/src/main/remote-thumbnail.ts
@@ -11,6 +11,12 @@ export interface CaptureOptions {
   exec: (host: Host, argv: string[], opts?: { timeoutMs?: number }) => Promise<ExecResult>
   maxRows?: number
   timeoutMs?: number
+  // Fired as soon as an individual session's capture settles successfully.
+  // Lets callers broadcast / persist per-session results without waiting for
+  // the slowest sibling in the batch — without this, one timed-out session
+  // would gate the whole tick and halve the effective update rate of every
+  // healthy thumbnail.
+  onCapture?: (sessionId: string, text: string) => void
 }
 
 export const DEFAULT_REMOTE_THUMBNAIL_ROWS = 24
@@ -38,22 +44,25 @@ export async function captureRemotePaneTexts(
 ): Promise<Record<string, string>> {
   const maxRows = options.maxRows ?? DEFAULT_REMOTE_THUMBNAIL_ROWS
   const timeoutMs = options.timeoutMs ?? DEFAULT_REMOTE_THUMBNAIL_TIMEOUT_MS
-  const settled = await Promise.allSettled(
+  const out: Record<string, string> = {}
+  await Promise.all(
     entries.map(async (entry) => {
-      const result = await options.exec(
-        entry.host,
-        ['tmux', 'capture-pane', '-t', entry.tmuxSession, '-p'],
-        { timeoutMs }
-      )
-      return { entry, result }
+      try {
+        const result = await options.exec(
+          entry.host,
+          ['tmux', 'capture-pane', '-t', entry.tmuxSession, '-p'],
+          { timeoutMs }
+        )
+        if (result.timedOut || result.code !== 0) return
+        const text = capLines(result.stdout, maxRows)
+        out[entry.sessionId] = text
+        // Fire inside the per-entry async function so a fast session's result
+        // surfaces before a slow sibling has even resolved its exec promise.
+        options.onCapture?.(entry.sessionId, text)
+      } catch {
+        // Swallow per-session errors so one rejection can't poison the batch.
+      }
     })
   )
-  const out: Record<string, string> = {}
-  for (const item of settled) {
-    if (item.status !== 'fulfilled') continue
-    const { entry, result } = item.value
-    if (result.timedOut || result.code !== 0) continue
-    out[entry.sessionId] = capLines(result.stdout, maxRows)
-  }
   return out
 }

--- a/src/renderer/stores/sessions.test.ts
+++ b/src/renderer/stores/sessions.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useSessionsStore } from './sessions'
+import type { Session } from '../../shared/types'
+
+const store = useSessionsStore
+
+function makeSession(id: string): Session {
+  return {
+    id,
+    projectPath: '/p',
+    projectName: 'p',
+    worktreeName: 'w',
+    worktreePath: '/p/w',
+    branch: 'main',
+    pid: 0,
+    tmuxSession: `cc-pewpew-${id}`,
+    status: 'idle',
+    lastActivity: 0,
+    hookEvents: [],
+    hostId: null,
+  }
+}
+
+beforeEach(() => {
+  store.setState({
+    sessions: [],
+    thumbnails: {},
+    selectedIds: new Set<string>(),
+    lastSelectedId: null,
+    broadcastDialogOpen: false,
+  })
+})
+
+describe('applyThumbnailPatch', () => {
+  it('merges incoming entries with existing thumbnails instead of replacing them', () => {
+    store.setState({ thumbnails: { s1: 'one\n', s2: 'two\n' } })
+
+    store.getState().applyThumbnailPatch({ s1: 'one-updated\n' })
+
+    expect(store.getState().thumbnails).toEqual({
+      s1: 'one-updated\n',
+      s2: 'two\n',
+    })
+  })
+})
+
+describe('syncSessions', () => {
+  it('drops thumbnails for sessions that no longer exist', () => {
+    store.setState({
+      sessions: [makeSession('s1'), makeSession('s2')],
+      thumbnails: { s1: 'one\n', s2: 'two\n' },
+    })
+
+    store.getState().syncSessions([makeSession('s1')])
+
+    expect(store.getState().thumbnails).toEqual({ s1: 'one\n' })
+  })
+
+  it('preserves thumbnails for sessions still present', () => {
+    store.setState({
+      sessions: [makeSession('s1')],
+      thumbnails: { s1: 'one\n' },
+    })
+
+    store.getState().syncSessions([makeSession('s1'), makeSession('s2')])
+
+    expect(store.getState().thumbnails).toEqual({ s1: 'one\n' })
+  })
+})

--- a/src/renderer/stores/sessions.ts
+++ b/src/renderer/stores/sessions.ts
@@ -9,6 +9,14 @@ interface SessionsState {
   broadcastDialogOpen: boolean
   fetchSessions: () => Promise<void>
   init: () => () => void
+  // Merge a partial thumbnail update into the existing map. The main process
+  // emits one entry at a time so a slow remote capture can't gate healthy
+  // siblings, so this MUST merge, not replace — otherwise each event would
+  // wipe every other live session's thumbnail.
+  applyThumbnailPatch: (patch: Record<string, string>) => void
+  // Replace the sessions list and prune any thumbnail entries whose session
+  // no longer exists, so dead sessions don't leak stale entries forever.
+  syncSessions: (sessions: Session[]) => void
   toggleSelect: (id: string, multi: boolean) => void
   rangeSelect: (id: string, orderedIds: string[]) => void
   selectAll: (projectPath: string) => void
@@ -30,24 +38,29 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
   init: () => {
     window.api.getSessions().then((sessions) => set({ sessions }))
 
-    const cleanupSessions = window.api.onSessionsUpdated((sessions) => {
-      const { selectedIds } = get()
-      const validIds = new Set(sessions.map((s) => s.id))
-      const pruned = new Set([...selectedIds].filter((id) => validIds.has(id)))
-      set({
-        sessions,
-        selectedIds: pruned.size !== selectedIds.size ? pruned : selectedIds,
-      })
-    })
-
-    const cleanupThumbnails = window.api.onTextThumbnails((thumbnails) => {
-      set({ thumbnails })
-    })
+    const cleanupSessions = window.api.onSessionsUpdated(get().syncSessions)
+    const cleanupThumbnails = window.api.onTextThumbnails(get().applyThumbnailPatch)
 
     return () => {
       cleanupSessions()
       cleanupThumbnails()
     }
+  },
+  applyThumbnailPatch: (patch) => {
+    set((s) => ({ thumbnails: { ...s.thumbnails, ...patch } }))
+  },
+  syncSessions: (sessions) => {
+    const { selectedIds, thumbnails } = get()
+    const validIds = new Set(sessions.map((s) => s.id))
+    const prunedSel = new Set([...selectedIds].filter((id) => validIds.has(id)))
+    const hasStaleThumb = Object.keys(thumbnails).some((id) => !validIds.has(id))
+    set({
+      sessions,
+      selectedIds: prunedSel.size !== selectedIds.size ? prunedSel : selectedIds,
+      thumbnails: hasStaleThumb
+        ? Object.fromEntries(Object.entries(thumbnails).filter(([id]) => validIds.has(id)))
+        : thumbnails,
+    })
   },
   toggleSelect: (id, multi) => {
     if (multi) {


### PR DESCRIPTION
Closes #13.

## Summary

- New `src/main/remote-thumbnail.ts` module exposes `capLines` and `captureRemotePaneTexts(entries, { exec, maxRows = 24 })`. The helper issues `tmux capture-pane -t cc-pewpew-{id} -p` per remote entry through an injected exec, isolates per-session failures with `Promise.allSettled`, and drops non-zero / timed-out captures so the underlying control connection is never poisoned by a single dead session.
- `captureThumbnails()` is now async. Local sessions still use the existing sync `execFileSync` path (unchanged); remote sessions route through `host-connection.exec`, which transparently reuses the live `ControlMaster` socket — so the per-tick cost is N tmux invocations multiplexed over a single SSH connection, no new handshakes.
- Successful remote captures overwrite `entry.lastSnapshot`, so the slice #12 `lastKnownState` cache persisted to `sessions.json` reflects the most recent coherent pane snapshot (capped at ~24 rows) rather than the raw streamed-byte tail.
- The `thumbInterval` in `index.ts` awaits the async capture and skips overlapping ticks while a slow host is in flight.

## Acceptance criteria

- [x] Thumbnail capture routes remote sessions through `HostConnection.exec` (`tmux capture-pane -t cc-pewpew-{id} -p`)
- [x] Capture invocations share the per-host control connection; no new SSH handshakes per tick
- [x] Captured output updates the Canvas thumbnail rendering for remote sessions on the same cadence as local sessions
- [x] Most recent capture feeds the `lastKnownState` cache that slice #12 persists to `sessions.json`
- [x] Capture output capped to last 24 rows so payload size stays bounded
- [x] A failed capture on one session does not affect other sessions' captures or the underlying control connection
- [x] Local thumbnail behavior unchanged

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 194/194 pass (6 new tests in `remote-thumbnail.test.ts` driven TDD red→green)
- [x] `npx eslint .` — clean
- [x] `npx prettier --check` — clean
- [ ] Manual: register a remote project, launch a remote session, verify the canvas thumbnail updates at the same cadence as local sessions and survives an app restart with the cached preview