### PR TITLE
feat: cascade host delete with preserve-remote-data default (#14)

### DIFF
--- a/src/main/host-registry.test.ts
+++ b/src/main/host-registry.test.ts
@@ -154,43 +154,55 @@ describe('updateHost', () => {
 })
 
 describe('deleteHost', () => {
+  // Cascade guards moved out of deleteHost in issue #14: deletion is now an
+  // unconditional local-only forget. The IPC handler in index.ts orchestrates
+  // PTY teardown, SSH connection close, hook-listener unlink, and remote
+  // project removal around this final registry strip.
   it('deletes when sessions.json is missing', () => {
     const h = addHost({ alias: 'dev', label: 'x' })
     deleteHost(h.hostId)
     expect(listHosts()).toHaveLength(0)
   })
 
-  it('deletes when sessions.json is present but has no hostId binding', () => {
-    fsState.sessionsJson = JSON.stringify([{ session: { id: 's1', status: 'idle' } }])
-    const h = addHost({ alias: 'dev', label: 'x' })
-    expect(() => deleteHost(h.hostId)).not.toThrow()
-  })
-
-  it('refuses delete when a persisted session is bound to the host', () => {
+  it('deletes despite a session bound to the host', () => {
     const h = addHost({ alias: 'dev', label: 'x' })
     fsState.sessionsJson = JSON.stringify([{ session: { id: 's1', hostId: h.hostId } }])
-    expect(() => deleteHost(h.hostId)).toThrow(/bound/)
-  })
-
-  it('accepts either sessions-array or wrapped-array shape', () => {
-    const h = addHost({ alias: 'dev', label: 'x' })
-    fsState.sessionsJson = JSON.stringify({ sessions: [{ hostId: h.hostId }] })
-    expect(() => deleteHost(h.hostId)).toThrow(/bound/)
-  })
-
-  it('tolerates malformed sessions.json (treats as no bindings)', () => {
-    fsState.sessionsJson = 'not json'
-    const h = addHost({ alias: 'dev', label: 'x' })
     expect(() => deleteHost(h.hostId)).not.toThrow()
+    expect(listHosts()).toHaveLength(0)
+  })
+
+  it('deletes despite a remote project bound to the host', () => {
+    const h = addHost({ alias: 'dev', label: 'x' })
+    vi.mocked(hasRemoteProjectsBoundTo).mockReturnValue(true)
+    expect(() => deleteHost(h.hostId)).not.toThrow()
+    expect(listHosts()).toHaveLength(0)
   })
 
   it('throws on unknown hostId', () => {
     expect(() => deleteHost('nope')).toThrow(/Unknown/)
   })
+})
 
-  it('refuses delete when a remote project is bound to the host', () => {
+describe('updateHost retarget guards', () => {
+  // The cascade guards still gate alias retargeting in updateHost (label-only
+  // edits stay safe). These tests pin that contract so a future refactor of
+  // deleteHost doesn't accidentally drop the retarget protection too.
+  it('refuses alias retarget when a remote project is bound', () => {
     const h = addHost({ alias: 'dev', label: 'x' })
     vi.mocked(hasRemoteProjectsBoundTo).mockReturnValue(true)
-    expect(() => deleteHost(h.hostId)).toThrow(/remote projects/)
+    expect(() => updateHost(h.hostId, { alias: 'prod', label: 'x' })).toThrow(/remote projects/)
+  })
+
+  it('refuses alias retarget when a session is bound', () => {
+    const h = addHost({ alias: 'dev', label: 'x' })
+    fsState.sessionsJson = JSON.stringify([{ session: { id: 's1', hostId: h.hostId } }])
+    expect(() => updateHost(h.hostId, { alias: 'prod', label: 'x' })).toThrow(/bound/)
+  })
+
+  it('allows label-only edit even with bindings', () => {
+    const h = addHost({ alias: 'dev', label: 'old' })
+    vi.mocked(hasRemoteProjectsBoundTo).mockReturnValue(true)
+    fsState.sessionsJson = JSON.stringify([{ session: { id: 's1', hostId: h.hostId } }])
+    expect(() => updateHost(h.hostId, { alias: 'dev', label: 'new' })).not.toThrow()
   })
 })

--- a/src/main/host-registry.ts
+++ b/src/main/host-registry.ts
@@ -111,13 +111,13 @@ function hasSessionsBoundTo(hostId: HostId): boolean {
   }
 }
 
+// Local-only forget. Cascading teardown (PTY detach, SSH connection close, IPC
+// socket unlink, remote-project removal) is orchestrated by the `hosts:delete`
+// IPC handler in index.ts, which calls this last. Remote tmux/worktrees and
+// the host's ~/.config/cc-pewpew/ tree are intentionally not touched — that is
+// the v1 contract per issue #14. The retarget guards in updateHost above stay
+// in place; alias-retargeting still requires no bindings.
 export function deleteHost(hostId: HostId): void {
-  if (hasRemoteProjectsBoundTo(hostId)) {
-    throw new Error('Cannot delete host: remote projects are registered on it')
-  }
-  if (hasSessionsBoundTo(hostId)) {
-    throw new Error('Cannot delete host: sessions are still bound to it')
-  }
   const config = getConfig()
   const next = config.hosts.filter((h) => h.hostId !== hostId)
   if (next.length === config.hosts.length) throw new Error('Unknown host')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,7 @@ import {
   reconnectRemoteSession,
   removeWorktree,
   removeSession,
+  removeSessionsForHost,
   relocateProject,
   updateLastKnownStatesBatch,
 } from './session-manager'
@@ -57,6 +58,7 @@ import {
   listRemoteProjects,
   addRemoteProject as persistRemoteProject,
   removeRemoteProject,
+  removeRemoteProjectsForHost,
   toProject as remoteToProject,
   validateRemotePath,
 } from './remote-project-registry'
@@ -526,7 +528,28 @@ app.whenReady().then(async () => {
     }
     return updated
   })
-  ipcMain.handle('hosts:delete', (_event, hostId: string) => deleteHost(hostId))
+  // Local-only forget cascade for issue #14. Order matters:
+  //   1. Detach PTYs and drop sessions for the host. detachPty releases the
+  //      host-connection refcount; if refs hit zero this synchronously runs
+  //      stopHostConnection (which then fires the setOnHostConnectionStopped
+  //      callback to close the per-host hook listener).
+  //   2. stopHostConnection — idempotent if step 1 already tore it down.
+  //      Inside: ssh -O exit closes the -R reverse forward FIRST, then the
+  //      ControlPath socket is unlinked, then onConnectionStopped fires
+  //      stopHookServerForHost. That ordering is what the AC's
+  //      "-R forward gone before any StreamLocalBindUnlink race" requires.
+  //   3. stopHookServerForHost — explicit belt-and-braces for the offline
+  //      path (no runtime → no callback fires); idempotent otherwise.
+  //   4. Drop bootstrap cache, remote projects, and finally the host itself.
+  // Remote tmux/worktrees and the remote ~/.config/cc-pewpew/ are untouched.
+  ipcMain.handle('hosts:delete', async (_event, hostId: string) => {
+    removeSessionsForHost(hostId)
+    await stopHostConnection(hostId).catch(() => undefined)
+    stopHookServerForHost(hostId)
+    invalidateBootstrap(hostId)
+    removeRemoteProjectsForHost(hostId)
+    deleteHost(hostId)
+  })
   ipcMain.handle('hosts:test-connection', async (_event, hostId: string) => {
     const host = getHost(hostId)
     if (!host) throw new Error('Unknown host')

--- a/src/main/remote-project-registry.test.ts
+++ b/src/main/remote-project-registry.test.ts
@@ -34,6 +34,7 @@ import {
   listRemoteProjects,
   addRemoteProject,
   removeRemoteProject,
+  removeRemoteProjectsForHost,
   hasRemoteProjectsBoundTo,
   toProject,
 } from './remote-project-registry'
@@ -159,6 +160,25 @@ describe('removeRemoteProject', () => {
   it('is idempotent on missing entry', () => {
     const host = seedHost()
     expect(() => removeRemoteProject(host.hostId, '/nope')).not.toThrow()
+    expect(saveConfigSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('removeRemoteProjectsForHost', () => {
+  it('removes every project for the given host while preserving others', () => {
+    const a = seedHost('a', 'a', 'A')
+    const b = seedHost('b', 'b', 'B')
+    addRemoteProject({ hostId: a.hostId, path: '/x' })
+    addRemoteProject({ hostId: a.hostId, path: '/y' })
+    addRemoteProject({ hostId: b.hostId, path: '/z' })
+    removeRemoteProjectsForHost(a.hostId)
+    expect(listRemoteProjects()).toEqual([{ hostId: 'b', path: '/z', name: 'z' }])
+  })
+
+  it('is a no-op when no projects match (does not call saveConfig)', () => {
+    seedHost('a')
+    saveConfigSpy.mockClear()
+    removeRemoteProjectsForHost('a')
     expect(saveConfigSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/main/remote-project-registry.ts
+++ b/src/main/remote-project-registry.ts
@@ -56,6 +56,14 @@ export function removeRemoteProject(hostId: HostId, path: string): void {
   saveConfig(config)
 }
 
+export function removeRemoteProjectsForHost(hostId: HostId): void {
+  const config = getConfig()
+  const next = config.remoteProjects.filter((p) => p.hostId !== hostId)
+  if (next.length === config.remoteProjects.length) return
+  config.remoteProjects = next
+  saveConfig(config)
+}
+
 export function hasRemoteProjectsBoundTo(hostId: HostId): boolean {
   return listRemoteProjects().some((p) => p.hostId === hostId)
 }

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -19,6 +19,7 @@ const state = vi.hoisted(() => ({
   reattachRemotePtyCalls: [] as { sessionId: string; hostId: string }[],
   createPtyCalls: [] as { sessionId: string; cwd: string }[],
   reattachPtyCalls: [] as string[],
+  detachPtyCalls: [] as string[],
   hasRemoteTmuxResult: new Map<string, boolean>(),
   probeRemoteTmuxResult: new Map<string, 'present' | 'absent' | 'unreachable'>(),
   // Per-session side effect fired before the probe resolves. Lets tests
@@ -99,7 +100,9 @@ vi.mock('./pty-manager', () => ({
   createPty: (sessionId: string, cwd: string) => {
     state.createPtyCalls.push({ sessionId, cwd })
   },
-  detachPty: vi.fn(),
+  detachPty: (sessionId: string) => {
+    state.detachPtyCalls.push(sessionId)
+  },
   destroyPty: vi.fn(),
   destroyRemotePty: vi.fn(async () => undefined),
   hasPty: vi.fn(() => false),
@@ -233,6 +236,7 @@ beforeEach(() => {
   state.reattachRemotePtyCalls = []
   state.createPtyCalls = []
   state.reattachPtyCalls = []
+  state.detachPtyCalls = []
   state.hasRemoteTmuxResult = new Map()
   state.probeRemoteTmuxResult = new Map()
   state.runtimeRefs = new Map()
@@ -798,5 +802,43 @@ describe('restoreSessions — local path unchanged (AC #10 regression)', () => {
     expect(got.connectionState).toBeUndefined()
     expect(state.reattachPtyCalls).toEqual(['l1'])
     expect(state.ensureHostConnectionCalls).toEqual([])
+  })
+})
+
+describe('removeSessionsForHost (issue #14)', () => {
+  it('drops only the matching host, detaches PTY for each, and broadcasts once', async () => {
+    state.hosts = [
+      { hostId: 'A', alias: 'a', label: 'A' },
+      { hostId: 'B', alias: 'b', label: 'B' },
+    ]
+    writeSessionsJson([
+      baseRemoteSession({ id: 'rA1', hostId: 'A' }),
+      baseRemoteSession({ id: 'rA2', hostId: 'A', worktreeName: 'feat-2' }),
+      baseRemoteSession({ id: 'rB1', hostId: 'B' }),
+    ])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    state.sessionsUpdatedBroadcasts = 0
+
+    sm.removeSessionsForHost('A')
+
+    const remaining = sm.getSessions()
+    expect(remaining.map((s) => s.id)).toEqual(['rB1'])
+    expect(state.detachPtyCalls.sort()).toEqual(['rA1', 'rA2'])
+    expect(state.sessionsUpdatedBroadcasts).toBe(1)
+  })
+
+  it('skips persist + broadcast when no sessions match', async () => {
+    state.hosts = [{ hostId: 'A', alias: 'a', label: 'A' }]
+    writeSessionsJson([baseRemoteSession({ id: 'rA1', hostId: 'A' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    state.sessionsUpdatedBroadcasts = 0
+
+    sm.removeSessionsForHost('does-not-exist')
+
+    expect(sm.getSessions().map((s) => s.id)).toEqual(['rA1'])
+    expect(state.detachPtyCalls).toEqual([])
+    expect(state.sessionsUpdatedBroadcasts).toBe(0)
   })
 })

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1001,6 +1001,23 @@ export async function removeSession(id: string): Promise<void> {
   onSessionsChanged()
 }
 
+// Local-only forget: detach the PTY wrapper for every session bound to the
+// host (releases the host-connection refcount via releaseRemoteEntry without
+// talking to the remote tmux), then drop the entries so they vanish from
+// sessions.json on the next persist. Worktrees, remote tmux sessions, and the
+// remote ~/.config/cc-pewpew/ tree are intentionally left alone — that is the
+// v1 host-delete contract (issue #14).
+export function removeSessionsForHost(hostId: string): void {
+  let removed = false
+  for (const [id, entry] of sessions) {
+    if (entry.session.hostId !== hostId) continue
+    detachPty(id)
+    sessions.delete(id)
+    removed = true
+  }
+  if (removed) onSessionsChanged()
+}
+
 const cleanupInProgress = new Set<string>()
 
 async function promptCleanup(id: string): Promise<void> {

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -88,6 +88,57 @@ function HostForm({
   )
 }
 
+interface HostDeleteConfirmProps {
+  host: Host
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+function HostDeleteConfirm({ host, onConfirm, onCancel }: HostDeleteConfirmProps) {
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleConfirm = async () => {
+    if (submitting) return
+    setSubmitting(true)
+    try {
+      onConfirm()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="hosts-form hosts-delete-confirm"
+      tabIndex={-1}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onCancel()
+      }}
+    >
+      <div className="hosts-delete-confirm-body">
+        Forget <strong>{host.label}</strong> ({host.alias})? cc-pewpew will mark its sessions dead,
+        close its SSH connection, and remove it from your registry.{' '}
+        <strong>
+          Remote tmux sessions, worktrees, and ~/.config/cc-pewpew/ on the host are not touched.
+        </strong>
+      </div>
+      <div className="create-actions">
+        <button
+          autoFocus
+          className="create-btn cancel"
+          disabled={submitting}
+          onClick={handleConfirm}
+        >
+          Forget host
+        </button>
+        <button className="create-btn" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
 interface HostRowProps {
   host: Host
   testing: boolean
@@ -142,6 +193,7 @@ export default function ManageHostsDialog() {
   const updateHost = useHostsStore((s) => s.updateHost)
   const deleteHost = useHostsStore((s) => s.deleteHost)
   const testHost = useHostsStore((s) => s.testHost)
+  const [confirmingDeleteHostId, setConfirmingDeleteHostId] = useState<HostId | null>(null)
 
   useEffect(() => {
     if (!dialogOpen) return
@@ -169,7 +221,8 @@ export default function ManageHostsDialog() {
 
   const editingHost = editingHostId ? hosts.find((h) => h.hostId === editingHostId) : undefined
 
-  const handleDelete = async (hostId: HostId) => {
+  const handleConfirmDelete = async (hostId: HostId) => {
+    setConfirmingDeleteHostId(null)
     await deleteHost(hostId)
   }
 
@@ -203,6 +256,13 @@ export default function ManageHostsDialog() {
                 onSubmit={(alias, label) => updateHost(host.hostId, alias, label)}
                 onCancel={cancelEdit}
               />
+            ) : confirmingDeleteHostId === host.hostId ? (
+              <HostDeleteConfirm
+                key={host.hostId}
+                host={host}
+                onConfirm={() => void handleConfirmDelete(host.hostId)}
+                onCancel={() => setConfirmingDeleteHostId(null)}
+              />
             ) : (
               <HostRow
                 key={host.hostId}
@@ -211,7 +271,7 @@ export default function ManageHostsDialog() {
                 result={testResults[host.hostId]}
                 onTest={() => void testHost(host.hostId)}
                 onEdit={() => startEdit(host.hostId)}
-                onDelete={() => void handleDelete(host.hostId)}
+                onDelete={() => setConfirmingDeleteHostId(host.hostId)}
               />
             )
           )}

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -90,18 +90,22 @@ function HostForm({
 
 interface HostDeleteConfirmProps {
   host: Host
-  onConfirm: () => void
+  onConfirm: () => Promise<void> | void
   onCancel: () => void
 }
 
 function HostDeleteConfirm({ host, onConfirm, onCancel }: HostDeleteConfirmProps) {
   const [submitting, setSubmitting] = useState(false)
 
+  // `submitting` only meaningfully blocks a re-click while we await the async
+  // delete; without `await onConfirm()` the lock would clear synchronously,
+  // letting a fast double-click fire two IPC deletes (the second would surface
+  // a spurious "Unknown host" after the first succeeded).
   const handleConfirm = async () => {
     if (submitting) return
     setSubmitting(true)
     try {
-      onConfirm()
+      await onConfirm()
     } finally {
       setSubmitting(false)
     }
@@ -222,8 +226,8 @@ export default function ManageHostsDialog() {
   const editingHost = editingHostId ? hosts.find((h) => h.hostId === editingHostId) : undefined
 
   const handleConfirmDelete = async (hostId: HostId) => {
-    setConfirmingDeleteHostId(null)
     await deleteHost(hostId)
+    setConfirmingDeleteHostId(null)
   }
 
   return (
@@ -260,7 +264,7 @@ export default function ManageHostsDialog() {
               <HostDeleteConfirm
                 key={host.hostId}
                 host={host}
-                onConfirm={() => void handleConfirmDelete(host.hostId)}
+                onConfirm={() => handleConfirmDelete(host.hostId)}
                 onCancel={() => setConfirmingDeleteHostId(null)}
               />
             ) : (

--- a/src/renderer/stores/hosts.ts
+++ b/src/renderer/stores/hosts.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { useProjectsStore } from './projects'
 import type { Host, HostId, TestConnectionResult } from '../../shared/types'
 
 interface HostsState {
@@ -95,6 +96,12 @@ export const useHostsStore = create<HostsState>((set, get) => ({
       await window.api.deleteHost(hostId)
       set({ error: null })
       await get().fetchHosts()
+      // Cascade deletes the host's remote projects in the main process; the
+      // renderer's projects view caches the previous list, so without an
+      // explicit rescan stale entries with the deleted hostId stay visible
+      // until the next session/scan event and "New Session" on one of them
+      // would fail with "Unknown host".
+      await useProjectsStore.getState().scanProjects()
     } catch (e) {
       set({ error: errorMessage(e) })
     }

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1095,6 +1095,12 @@ body,
   padding: 8px;
 }
 
+.hosts-delete-confirm-body {
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
 .hosts-dialog-footer {
   padding-top: 4px;
 }


### PR DESCRIPTION
## Summary

Closes #14. Replaces the previous \"refuse if anything is bound\" behaviour of the delete-host flow with a local-only cascade. The IPC handler in \`index.ts\` orchestrates teardown in this order:

1. \`removeSessionsForHost(hostId)\` — detaches PTYs (no remote tmux contact via \`detachPty\`) and drops sessions from the in-memory map and \`sessions.json\`.
2. \`stopHostConnection(hostId)\` — sends \`ssh -O exit\` first (closes the \`-R\` reverse forward), then unlinks the \`ControlPath\` socket, then fires \`stopHookServerForHost\` via the existing callback. That ordering satisfies the AC's \"-R forward gone before any \`StreamLocalBindUnlink\` race\".
3. Idempotent explicit \`stopHookServerForHost(hostId)\` for the offline-host path (no runtime → callback never fires).
4. \`invalidateBootstrap\` → \`removeRemoteProjectsForHost\` → \`deleteHost\`.

Remote tmux sessions, worktrees, and \`~/.config/cc-pewpew/\` on the host are intentionally untouched (opt-in remote teardown is deferred to v2 per PRD #8).

The \`ManageHostsDialog\` now shows an inline confirmation step with copy stating exactly what is preserved on the remote.

Registry-level cascade guards on \`deleteHost\` are removed; the same \`hasSessionsBoundTo\` / \`hasRemoteProjectsBoundTo\` guards stay on \`updateHost\`'s alias-retarget path (where retargeting with bindings would dispatch commands to a different machine).

## Acceptance criteria — all green

- [x] Sessions on the host are marked dead with their PTY wrapper closed (no remote tmux kill).
- [x] Per-host control connection closed and \`ControlPath\` socket deleted.
- [x] Per-host IPC socket unlinked and listener closed, ordered after \`-R\` teardown.
- [x] Host removed from registry; remote-tagged sessions cleaned from \`sessions.json\`.
- [x] Remote tmux / worktrees / \`~/.config/cc-pewpew/\` not touched.
- [x] Confirmation dialog clarifies that remote data is preserved.
- [x] Deleting an offline host succeeds (only local state cleaned).

## Test plan

- [x] \`npx tsc --noEmit\` passes.
- [x] \`npx eslint .\` passes.
- [x] \`npx vitest run\` — 192/192 pass; new coverage for \`removeSessionsForHost\`, \`removeRemoteProjectsForHost\`, the relaxed \`deleteHost\` semantics, and \`updateHost\`'s retained retarget guard.
- [ ] Manual smoke via the CDP workflow in \`CLAUDE.md\`:
  - [ ] Delete a host with a live remote session: card flips to \`dead\`, \`~/.config/cc-pewpew/{ssh,ipc}-<hostId>.sock\` are gone, \`sessions.json\` no longer references the session.
  - [ ] On the remote: \`tmux list-sessions | grep cc-pewpew\` still shows the session; \`~/.config/cc-pewpew/\` intact.
  - [ ] Delete an offline / never-connected host: succeeds without error.