### PR TITLE
Disable review pane on remote sessions with coming-soon UI

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,7 +61,13 @@ import {
   toProject as remoteToProject,
   validateRemotePath,
 } from './remote-project-registry'
-import type { DiffMode, ValidateRemoteRepoReason } from '../shared/types'
+import type {
+  DiffMode,
+  ReviewBranchesResult,
+  ReviewDefaultBranchResult,
+  ReviewDiffResult,
+  ValidateRemoteRepoReason,
+} from '../shared/types'
 
 // Use native Wayland rendering when available (avoids Xwayland scaling artifacts)
 app.commandLine.appendSwitch('ozone-platform-hint', 'auto')
@@ -366,9 +372,17 @@ app.whenReady().then(async () => {
 
   ipcMain.handle(
     'review:get-diff',
-    async (_event, sessionId: string, mode: DiffMode, baseBranch?: string) => {
+    async (
+      _event,
+      sessionId: string,
+      mode: DiffMode,
+      baseBranch?: string
+    ): Promise<ReviewDiffResult> => {
       const session = getSession(sessionId)
       if (!session) throw new Error(`Session not found: ${sessionId}`)
+      if (session.hostId != null) {
+        return { ok: false, reason: 'remote-unsupported' }
+      }
       const cwd = session.worktreePath || session.projectPath
       const { execFile: execFileCb } = await import('child_process')
       const { promisify: pfy } = await import('util')
@@ -422,40 +436,52 @@ app.whenReady().then(async () => {
         }
       }
 
-      return files
+      return { ok: true, files }
     }
   )
 
-  ipcMain.handle('review:list-branches', async (_event, sessionId: string) => {
-    const session = getSession(sessionId)
-    if (!session) throw new Error(`Session not found: ${sessionId}`)
-    const cwd = session.worktreePath || session.projectPath
-    const { execFile: execFileCb } = await import('child_process')
-    const { promisify: pfy } = await import('util')
-    const execAsync = pfy(execFileCb)
-    const { stdout } = await execAsync('git', ['branch', '-a', '--format=%(refname:short)'], {
-      cwd,
-    })
-    return stdout.split('\n').filter(Boolean)
-  })
-
-  ipcMain.handle('review:get-default-branch', async (_event, sessionId: string) => {
-    const session = getSession(sessionId)
-    if (!session) throw new Error(`Session not found: ${sessionId}`)
-    const cwd = session.worktreePath || session.projectPath
-    const { execFile: execFileCb } = await import('child_process')
-    const { promisify: pfy } = await import('util')
-    const execAsync = pfy(execFileCb)
-    try {
-      const { stdout } = await execAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+  ipcMain.handle(
+    'review:list-branches',
+    async (_event, sessionId: string): Promise<ReviewBranchesResult> => {
+      const session = getSession(sessionId)
+      if (!session) throw new Error(`Session not found: ${sessionId}`)
+      if (session.hostId != null) {
+        return { ok: false, reason: 'remote-unsupported' }
+      }
+      const cwd = session.worktreePath || session.projectPath
+      const { execFile: execFileCb } = await import('child_process')
+      const { promisify: pfy } = await import('util')
+      const execAsync = pfy(execFileCb)
+      const { stdout } = await execAsync('git', ['branch', '-a', '--format=%(refname:short)'], {
         cwd,
       })
-      const ref = stdout.trim()
-      return ref.replace('refs/remotes/origin/', '')
-    } catch {
-      return 'main'
+      return { ok: true, branches: stdout.split('\n').filter(Boolean) }
     }
-  })
+  )
+
+  ipcMain.handle(
+    'review:get-default-branch',
+    async (_event, sessionId: string): Promise<ReviewDefaultBranchResult> => {
+      const session = getSession(sessionId)
+      if (!session) throw new Error(`Session not found: ${sessionId}`)
+      if (session.hostId != null) {
+        return { ok: false, reason: 'remote-unsupported' }
+      }
+      const cwd = session.worktreePath || session.projectPath
+      const { execFile: execFileCb } = await import('child_process')
+      const { promisify: pfy } = await import('util')
+      const execAsync = pfy(execFileCb)
+      try {
+        const { stdout } = await execAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+          cwd,
+        })
+        const ref = stdout.trim()
+        return { ok: true, branch: ref.replace('refs/remotes/origin/', '') }
+      } catch {
+        return { ok: true, branch: 'main' }
+      }
+    }
+  )
 
   ipcMain.handle('config:get-canvas', () => {
     return getConfig().canvas

--- a/src/renderer/components/ReviewOverlay.tsx
+++ b/src/renderer/components/ReviewOverlay.tsx
@@ -27,6 +27,7 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
   const removeAnnotation = useReviewStore((s) => s.removeAnnotation)
   const clearAnnotations = useReviewStore((s) => s.clearAnnotations)
   const session = useSessionsStore((s) => s.sessions.find((s) => s.id === sessionId))
+  const isRemote = session?.hostId != null
 
   const [focusedHunkKey, setFocusedHunkKey] = useState<string | null>(null)
   const [scrollToFile, setScrollToFile] = useState<string | undefined>(undefined)
@@ -47,16 +48,21 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
   }, [])
 
   useEffect(() => {
+    if (isRemote) return
     fetchDiff(sessionId, 'uncommitted')
     window.api
       .getReviewBranches(sessionId)
-      .then(setBranches)
+      .then((r) => {
+        if (r.ok && r.branches) setBranches(r.branches)
+      })
       .catch(() => {})
     window.api
       .getReviewDefaultBranch(sessionId)
-      .then(setSelectedBranch)
+      .then((r) => {
+        if (r.ok && r.branch) setSelectedBranch(r.branch)
+      })
       .catch(() => {})
-  }, [sessionId, fetchDiff])
+  }, [sessionId, fetchDiff, isRemote])
 
   const files = useMemo(() => reviewState?.files ?? [], [reviewState?.files])
   const annotations = useMemo(() => reviewState?.annotations ?? {}, [reviewState?.annotations])
@@ -70,12 +76,13 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
 
   const switchMode = useCallback(
     (newMode: DiffMode, branch?: string) => {
+      if (isRemote) return
       setDiffMode(newMode)
       setFocusedHunkKey(null)
       clearAnnotations(sessionId)
       fetchDiff(sessionId, newMode, newMode === 'branch' ? (branch ?? selectedBranch) : undefined)
     },
-    [sessionId, selectedBranch, fetchDiff, clearAnnotations]
+    [sessionId, selectedBranch, fetchDiff, clearAnnotations, isRemote]
   )
 
   const handleModeChange = useCallback(
@@ -251,6 +258,22 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
   const loading = !reviewState || reviewState.loading
   const error = reviewState?.error
   const focusedFile = focusedHunkKey ? focusedHunkKey.split('::')[0] : undefined
+
+  if (isRemote || reviewState?.remoteUnsupported) {
+    return (
+      <div ref={containerRef} className="review-overlay" tabIndex={-1}>
+        <div className="review-remote-unsupported">
+          <div className="review-remote-unsupported-headline">
+            Review not yet available on remote sessions
+          </div>
+          <div className="review-remote-unsupported-body">
+            Diff and branch tools require local git access. Remote review support is planned for a
+            future release.
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div ref={containerRef} className="review-overlay" tabIndex={-1}>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -1,11 +1,13 @@
 /// <reference types="vite/client" />
 
 import type {
-  DiffFile,
   DiffMode,
   Host,
   Project,
   RemoteProject,
+  ReviewBranchesResult,
+  ReviewDefaultBranchResult,
+  ReviewDiffResult,
   Session,
   TestConnectionResult,
 } from '../shared/types'
@@ -61,9 +63,13 @@ declare global {
       ptyGetScrollback: (sessionId: string) => Promise<string>
       onPtyData: (callback: (data: { sessionId: string; data: string }) => void) => () => void
       openSwimLanes: (sessionIds: string[]) => Promise<void>
-      getReviewDiff: (sessionId: string, mode: DiffMode, baseBranch?: string) => Promise<DiffFile[]>
-      getReviewBranches: (sessionId: string) => Promise<string[]>
-      getReviewDefaultBranch: (sessionId: string) => Promise<string>
+      getReviewDiff: (
+        sessionId: string,
+        mode: DiffMode,
+        baseBranch?: string
+      ) => Promise<ReviewDiffResult>
+      getReviewBranches: (sessionId: string) => Promise<ReviewBranchesResult>
+      getReviewDefaultBranch: (sessionId: string) => Promise<ReviewDefaultBranchResult>
       listHosts: () => Promise<Host[]>
       addHost: (alias: string, label: string) => Promise<Host>
       updateHost: (hostId: string, alias: string, label: string) => Promise<Host>

--- a/src/renderer/stores/review.test.ts
+++ b/src/renderer/stores/review.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { useReviewStore, getReviewProgress } from './review'
 import type { HunkAnnotation, DiffFile } from '../../shared/types'
 
@@ -124,6 +124,7 @@ describe('getReviewProgress', () => {
           focusedHunkKey: null,
           cachedMode: null,
           diffUpdated: false,
+          remoteUnsupported: false,
         },
       },
     })
@@ -149,6 +150,7 @@ describe('getReviewProgress', () => {
           focusedHunkKey: null,
           cachedMode: null,
           diffUpdated: false,
+          remoteUnsupported: false,
         },
       },
     })
@@ -171,6 +173,7 @@ describe('getReviewProgress', () => {
           focusedHunkKey: null,
           cachedMode: null,
           diffUpdated: false,
+          remoteUnsupported: false,
         },
       },
     })
@@ -190,5 +193,44 @@ describe('multiple sessions isolation', () => {
 
     expect(s1.annotations['f::0']).toEqual([makeAnnotation('a1', 'approved')])
     expect(s2.annotations['f::0']).toEqual([makeAnnotation('a2', 'rejected')])
+  })
+})
+
+describe('fetchDiff envelope handling', () => {
+  const getReviewDiff = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('window', { api: { getReviewDiff } })
+    getReviewDiff.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('marks session remoteUnsupported when handler returns the gated envelope', async () => {
+    getReviewDiff.mockResolvedValueOnce({ ok: false, reason: 'remote-unsupported' })
+
+    await store.getState().fetchDiff('s1', 'uncommitted')
+
+    const session = store.getState().sessions['s1']
+    expect(session).toBeDefined()
+    expect(session.remoteUnsupported).toBe(true)
+    expect(session.files).toEqual([])
+    expect(session.loading).toBe(false)
+    expect(session.error).toBeNull()
+  })
+
+  it('populates files from a successful envelope and leaves remoteUnsupported false', async () => {
+    const file = makeFile('a.ts', 1)
+    getReviewDiff.mockResolvedValueOnce({ ok: true, files: [file] })
+
+    await store.getState().fetchDiff('s1', 'uncommitted')
+
+    const session = store.getState().sessions['s1']
+    expect(session.files).toEqual([file])
+    expect(session.remoteUnsupported).toBe(false)
+    expect(session.loading).toBe(false)
+    expect(session.cachedMode).toBe('uncommitted')
   })
 })

--- a/src/renderer/stores/review.ts
+++ b/src/renderer/stores/review.ts
@@ -9,6 +9,7 @@ interface SessionReviewState {
   focusedHunkKey: string | null
   cachedMode: DiffMode | null
   diffUpdated: boolean
+  remoteUnsupported: boolean
 }
 
 export function getReviewProgress(state: SessionReviewState): {
@@ -60,6 +61,7 @@ function emptySession(): SessionReviewState {
     focusedHunkKey: null,
     cachedMode: null,
     diffUpdated: false,
+    remoteUnsupported: false,
   }
 }
 
@@ -91,7 +93,19 @@ export const useReviewStore = create<ReviewStore>((set, get) => ({
     }
 
     try {
-      const files = await window.api.getReviewDiff(sessionId, mode, baseBranch)
+      const result = await window.api.getReviewDiff(sessionId, mode, baseBranch)
+
+      if (!result.ok && result.reason === 'remote-unsupported') {
+        set((state) => ({
+          sessions: {
+            ...state.sessions,
+            [sessionId]: { ...emptySession(), remoteUnsupported: true },
+          },
+        }))
+        return
+      }
+
+      const files = result.files ?? []
 
       // Guard against stale async responses: if mode changed while awaiting, discard
       const currentSession = get().sessions[sessionId]

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1219,6 +1219,29 @@ body,
   line-height: 1.5;
 }
 
+.review-remote-unsupported {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 32px;
+  max-width: 480px;
+  text-align: center;
+}
+
+.review-remote-unsupported-headline {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+
+.review-remote-unsupported-body {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
 .review-loading {
   display: flex;
   flex-direction: column;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -136,3 +136,21 @@ export interface ValidateRemoteRepoResult {
   reason?: ValidateRemoteRepoReason
   message?: string
 }
+
+export interface ReviewDiffResult {
+  ok: boolean
+  files?: DiffFile[]
+  reason?: 'remote-unsupported'
+}
+
+export interface ReviewBranchesResult {
+  ok: boolean
+  branches?: string[]
+  reason?: 'remote-unsupported'
+}
+
+export interface ReviewDefaultBranchResult {
+  ok: boolean
+  branch?: string
+  reason?: 'remote-unsupported'
+}


### PR DESCRIPTION
## Summary

- Three review IPC handlers (`review:get-diff`, `review:list-branches`, `review:get-default-branch`) now early-return a typed `{ ok: false, reason: 'remote-unsupported' }` envelope when `session.hostId` is non-null; success paths return `{ ok: true, ... }`. New envelope types added to `src/shared/types.ts` matching the existing `TestConnectionResult` / `ValidateRemoteRepoResult` shape.
- `ReviewOverlay` derives `isRemote = session?.hostId != null`, short-circuits the IPC effect (and `switchMode`) for remote sessions, unwraps the new envelopes for local-session calls to `getReviewBranches` / `getReviewDefaultBranch`, and renders an inline coming-soon placeholder before any other render branch.
- Review store gains `remoteUnsupported: boolean`; `fetchDiff` resets the session to `{ ...empty, remoteUnsupported: true }` when the envelope reports gated. Two new vitest cases cover the gated and successful envelope paths; existing `getReviewProgress` literals updated for the new field.

Closes #15.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] `npx vitest run` — 208/208 passing (includes 2 new envelope tests)
- [ ] Manual: open a remote session, hit Ctrl+R — verify coming-soon placeholder appears with no IPC fired and no console error
- [ ] Manual: open a local session, hit Ctrl+R — verify diff loads as before