### PR TITLE
fix: send LF for Shift+Enter in embedded terminal

### DIFF
--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -60,7 +60,7 @@ export default function Terminal({ sessionId }: Props) {
       }
       if (e.shiftKey && !e.ctrlKey && !e.altKey && e.key === 'Enter') {
         if (e.type === 'keydown') {
-          window.api.ptyWrite(sessionId, '\x1b[13;2u')
+          window.api.ptyWrite(sessionId, '\n')
         }
         return false
       }


### PR DESCRIPTION
## Summary
- Replace the CSI-u sequence `\x1b[13;2u` with a bare `\n` in `Terminal.tsx`'s Shift+Enter handler so Claude Code receives a literal newline instead of having the modifier stripped by tmux.

## Why the previous approach didn't work
The CSI-u byte path goes xterm.js → node-pty → tmux → claude. tmux's `extended-keys` server option is `off` by default, so the modifier is dropped and claude only sees `\r` — i.e. submit. Setting `extended-keys=on` would require claude to opt in (it doesn't), and `extended-keys=always` only forces mode 1, which doesn't re-encode keys with a well-known representation (Enter has `\r`). So no tmux config change actually fixes the bug.

`\n` (LF) sidesteps all of that: tmux passes it through verbatim and claude's input handler treats a bare LF mid-prompt as a literal newline-insert, while plain Enter (still `\r` from xterm.js) keeps submitting.

Closes #51.

## Test plan
- [ ] `npm run dev`, attach to a session running claude, type a few words, press Shift+Enter, type more words → newline appears in the prompt, no submission.
- [ ] Press Enter alone → multi-line prompt is submitted.
- [ ] Repeat against a remote session if available — the byte path is the same.