### PR TITLE
feat: per-host ssh ring buffer + diagnostic toasts

### DIFF
--- a/src/main/host-connection.test.ts
+++ b/src/main/host-connection.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { EventEmitter } from 'events'
+import type { Host, SshLogEntry, ToastEvent } from '../shared/types'
 
 interface FakeResult {
   stdout: string
@@ -10,6 +11,8 @@ interface FakeResult {
 
 let nextResult: FakeResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
 const execFileCalls: { file: string; args: string[] }[] = []
+const recordedEntries: SshLogEntry[] = []
+const emittedToasts: Omit<ToastEvent, 'id'>[] = []
 
 vi.mock('child_process', () => ({
   execFile: (
@@ -30,11 +33,34 @@ vi.mock('child_process', () => ({
   },
 }))
 
-import { validateRemoteRepo } from './host-connection'
+vi.mock('./ssh-log-buffer', () => ({
+  recordSshInvocation: (entry: SshLogEntry) => {
+    recordedEntries.push(entry)
+  },
+  getSshLog: () => [],
+  clearSshLog: () => {},
+}))
+
+vi.mock('./notifications', () => ({
+  emitToast: (event: Omit<ToastEvent, 'id'>) => {
+    emittedToasts.push(event)
+  },
+}))
+
+vi.mock('./host-registry', () => ({
+  getHost: (hostId: string) =>
+    hostId === 'h1' ? { hostId: 'h1', alias: 'dev', label: 'Devbox' } : undefined,
+}))
+
+import { exec, validateRemoteRepo } from './host-connection'
+
+const HOST: Host = { hostId: 'h1', alias: 'dev', label: 'Devbox' }
 
 beforeEach(() => {
   nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
   execFileCalls.length = 0
+  recordedEntries.length = 0
+  emittedToasts.length = 0
 })
 
 describe('validateRemoteRepo', () => {
@@ -150,5 +176,68 @@ describe('validateRemoteRepo', () => {
     expect(call.args[call.args.length - 1]).toBe("'/pa'\"'\"'th'")
     expect(call.args).toContain('--')
     expect(call.args).toContain('dev')
+  })
+})
+
+describe('exec ring-buffer + toast wiring', () => {
+  it('records every ssh exec keyed by hostId and kind=exec', async () => {
+    nextResult = { stdout: 'ok', stderr: '', error: null, exitCode: 0 }
+    await exec(HOST, ['true'])
+    expect(recordedEntries).toHaveLength(1)
+    expect(recordedEntries[0].hostId).toBe('h1')
+    expect(recordedEntries[0].kind).toBe('exec')
+    expect(recordedEntries[0].exitCode).toBe(0)
+  })
+
+  it('does NOT record when called with a bare alias (no hostId)', async () => {
+    nextResult = { stdout: 'ok', stderr: '', error: null, exitCode: 0 }
+    await exec('dev', ['true'])
+    expect(recordedEntries).toHaveLength(0)
+  })
+
+  it('does NOT emit a toast on a successful exec (exit 0)', async () => {
+    nextResult = { stdout: 'ok', stderr: '', error: null, exitCode: 0 }
+    await exec(HOST, ['true'])
+    expect(emittedToasts).toHaveLength(0)
+  })
+
+  it('emits an auth-failed toast carrying the host label on Permission denied', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: 'Permission denied (publickey).',
+      error: { name: 'Error', message: 'x', code: 255 } as unknown as NodeJS.ErrnoException,
+      exitCode: 255,
+    }
+    await exec(HOST, ['true'])
+    expect(emittedToasts).toHaveLength(1)
+    expect(emittedToasts[0].severity).toBe('error')
+    expect(emittedToasts[0].title).toContain('Devbox')
+    expect(emittedToasts[0].title).toMatch(/authentication failed/i)
+    expect(emittedToasts[0].hostLabel).toBe('Devbox')
+  })
+
+  it('emits a bind-unlink toast naming the StreamLocalBindUnlink fix', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: 'StreamLocalBindUnlink requires StreamLocalBindUnlink yes on the server',
+      error: { name: 'Error', message: 'x', code: 255 } as unknown as NodeJS.ErrnoException,
+      exitCode: 255,
+    }
+    await exec(HOST, ['true'])
+    expect(emittedToasts).toHaveLength(1)
+    expect(emittedToasts[0].title).toMatch(/StreamLocalBindUnlink/)
+  })
+
+  it('falls back to a generic warning toast for unrecognized failures', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: 'something weird',
+      error: { name: 'Error', message: 'x', code: 7 } as unknown as NodeJS.ErrnoException,
+      exitCode: 7,
+    }
+    await exec(HOST, ['true'])
+    expect(emittedToasts).toHaveLength(1)
+    expect(emittedToasts[0].severity).toBe('warning')
+    expect(emittedToasts[0].title).toMatch(/exit 7/)
   })
 })

--- a/src/main/host-connection.test.ts
+++ b/src/main/host-connection.test.ts
@@ -228,16 +228,18 @@ describe('exec ring-buffer + toast wiring', () => {
     expect(emittedToasts[0].title).toMatch(/StreamLocalBindUnlink/)
   })
 
-  it('falls back to a generic warning toast for unrecognized failures', async () => {
+  it('does NOT emit a toast for an unrecognized exec failure (likely an app-level non-zero like tmux has-session "absent")', async () => {
     nextResult = {
       stdout: '',
-      stderr: 'something weird',
-      error: { name: 'Error', message: 'x', code: 7 } as unknown as NodeJS.ErrnoException,
-      exitCode: 7,
+      stderr: '',
+      error: { name: 'Error', message: 'x', code: 1 } as unknown as NodeJS.ErrnoException,
+      exitCode: 1,
     }
-    await exec(HOST, ['true'])
-    expect(emittedToasts).toHaveLength(1)
-    expect(emittedToasts[0].severity).toBe('warning')
-    expect(emittedToasts[0].title).toMatch(/exit 7/)
+    await exec(HOST, ['tmux', 'has-session', '-t', 'cc-pewpew-x'])
+    expect(emittedToasts).toHaveLength(0)
+    // The ring buffer still records the exec, so diagnostics retain it.
+    expect(recordedEntries).toHaveLength(1)
+    expect(recordedEntries[0].kind).toBe('exec')
+    expect(recordedEntries[0].exitCode).toBe(1)
   })
 })

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -86,6 +86,14 @@ function maybeEmitFailureToast(
   if (kind === 'probe' && bootstrapInProgress.has(host.hostId)) return
 
   const { reason, message } = classifySshExit({ exitCode, stderr })
+  // For exec invocations, an unrecognized non-zero exit is most often the
+  // remote command's own exit code (e.g. `tmux has-session` returning 1 when
+  // the session is absent). Surface only the four reasons we can attribute to
+  // SSH itself so legitimate "absent"/"empty" probe outcomes don't spam the
+  // user with "ssh failed: exit 1" warnings during reconnect / batch probes.
+  // Control-connection failures are different: any non-zero there *is* an
+  // SSH-level problem, so the generic toast still fires for kind='control'.
+  if (kind === 'exec' && reason === 'unknown') return
   const detail = firstStderrLine(stderr) || message
   const label = hostLabel(host)
   let severity: ToastSeverity = 'error'
@@ -356,6 +364,10 @@ async function startRuntime(runtime: HostRuntime): Promise<void> {
         errno.code === 'ENOENT'
           ? 'ssh: command not found'
           : `ssh failed to spawn: ${errno.message || errno.code || 'unknown'}`
+      // Spawn errors fire before child.stderr produces any data, so the outer
+      // `stderr` buffer is empty. Surface the synthesized errStderr there so
+      // the catch block's toast (and classifyConnectionFailure) see it.
+      stderr = errStderr
       logSshInvocation(
         { hostId: runtime.host.hostId, kind: 'control' },
         argv,

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -13,8 +13,102 @@ import * as pty from 'node-pty'
 import type { IPty, IPtyForkOptions } from 'node-pty'
 import { shellQuote } from './shell-quote'
 import { classifySshExit } from './ssh-exit-parser'
+import { recordSshInvocation } from './ssh-log-buffer'
+import { emitToast } from './notifications'
+import { getHost } from './host-registry'
 import { CONFIG_DIR } from './config'
-import type { Host, HostId, TestConnectionResult, ValidateRemoteRepoResult } from '../shared/types'
+import type {
+  Host,
+  HostId,
+  SshInvocationKind,
+  TestConnectionResult,
+  ToastSeverity,
+  ValidateRemoteRepoResult,
+} from '../shared/types'
+
+interface SshLogContext {
+  hostId?: HostId
+  kind: SshInvocationKind
+}
+
+function logSshInvocation(
+  ctx: SshLogContext | undefined,
+  argv: string[],
+  exitCode: number | null,
+  stderr: string,
+  durationMs: number
+): void {
+  if (!ctx?.hostId) return
+  recordSshInvocation({
+    ts: Date.now(),
+    hostId: ctx.hostId,
+    kind: ctx.kind,
+    argv,
+    exitCode,
+    stderrSnippet: stderr.slice(0, 1024),
+    durationMs,
+  })
+}
+
+// Bootstrap signals that an early dep-missing toast from a probe would be
+// redundant with the richer toast bootstrap will emit on completion. Cleared
+// when bootstrap finishes (success or failure) — see startBootstrapWindow.
+const bootstrapInProgress = new Set<HostId>()
+export function startBootstrapWindow(hostId: HostId): () => void {
+  bootstrapInProgress.add(hostId)
+  return () => bootstrapInProgress.delete(hostId)
+}
+
+function firstStderrLine(stderr: string): string {
+  for (const raw of stderr.split('\n')) {
+    const line = raw.trim()
+    if (line) return line
+  }
+  return ''
+}
+
+function hostLabel(host: Host): string {
+  return getHost(host.hostId)?.label ?? host.alias
+}
+
+function maybeEmitFailureToast(
+  host: Host,
+  kind: SshInvocationKind,
+  exitCode: number | null,
+  stderr: string
+): void {
+  if (exitCode === 0) return
+  // `-O exit` non-zero typically means the control socket was already gone;
+  // not actionable. The PTY attach exit is surfaced through the session card's
+  // connection-state UI; a parallel toast would spam every disconnect. Probes
+  // taken during bootstrap collide with the bootstrap layer's own toast.
+  if (kind === 'control-exit' || kind === 'attach') return
+  if (kind === 'probe' && bootstrapInProgress.has(host.hostId)) return
+
+  const { reason, message } = classifySshExit({ exitCode, stderr })
+  const detail = firstStderrLine(stderr) || message
+  const label = hostLabel(host)
+  let severity: ToastSeverity = 'error'
+  let title: string
+  switch (reason) {
+    case 'auth-failed':
+      title = `SSH authentication failed on ${label}`
+      break
+    case 'network':
+      title = `Cannot reach ${label}`
+      break
+    case 'bind-unlink':
+      title = `${label}: remote sshd needs StreamLocalBindUnlink yes`
+      break
+    case 'dep-missing':
+      title = `${label}: tool missing on remote`
+      break
+    default:
+      severity = 'warning'
+      title = `ssh failed on ${label}: exit ${exitCode ?? '?'}`
+  }
+  emitToast({ severity, title, detail, hostLabel: label })
+}
 
 export interface ExecResult {
   stdout: string
@@ -105,8 +199,10 @@ const DEFAULT_MAX_BUFFER = 16 * 1024 * 1024
 function runSsh(
   argv: string[],
   timeoutMs: number,
+  ctx?: SshLogContext,
   maxBuffer = DEFAULT_MAX_BUFFER
 ): Promise<ExecResult> {
+  const t0 = Date.now()
   return new Promise((resolve) => {
     const child = execFile(
       'ssh',
@@ -123,9 +219,11 @@ function runSsh(
         // as an exit-127 "command not found" so classifySshExit routes it to
         // `dep-missing` instead of the generic `unknown`.
         if (!timedOut && errno && errno.code === 'ENOENT') {
+          const enoentStderr = 'ssh: command not found'
+          logSshInvocation(ctx, argv, 127, enoentStderr, Date.now() - t0)
           resolve({
             stdout: '',
-            stderr: 'ssh: command not found',
+            stderr: enoentStderr,
             code: 127,
             timedOut: false,
           })
@@ -136,9 +234,11 @@ function runSsh(
             ? (error as { code: number }).code
             : (child.exitCode ?? 1)
           : 0
+        const stderrStr = stderr.toString()
+        logSshInvocation(ctx, argv, code, stderrStr, Date.now() - t0)
         resolve({
           stdout: stdout.toString(),
-          stderr: stderr.toString(),
+          stderr: stderrStr,
           code,
           timedOut,
         })
@@ -185,7 +285,8 @@ async function controlCheck(runtime: HostRuntime): Promise<boolean> {
       '--',
       runtime.host.alias,
     ],
-    1000
+    1000,
+    { hostId: runtime.host.hostId, kind: 'probe' }
   )
   return result.code === 0
 }
@@ -206,7 +307,7 @@ export function classifyConnectionFailure(
 ): HostConnectionState {
   const { reason } = classifySshExit({ exitCode: code, stderr })
   if (reason === 'auth-failed') return 'auth-failed'
-  if (reason === 'network') return 'unreachable'
+  if (reason === 'network' || reason === 'bind-unlink') return 'unreachable'
   return 'offline'
 }
 
@@ -217,8 +318,10 @@ export function runtimeStateFor(hostId: HostId): HostConnectionState | undefined
 async function startRuntime(runtime: HostRuntime): Promise<void> {
   runtime.state = 'connecting'
   let stderr = ''
+  const argv = controlArgs(runtime)
+  const t0 = Date.now()
 
-  const child = spawn('ssh', controlArgs(runtime), {
+  const child = spawn('ssh', argv, {
     stdio: ['ignore', 'ignore', 'pipe'],
   })
   runtime.child = child
@@ -230,6 +333,13 @@ async function startRuntime(runtime: HostRuntime): Promise<void> {
   const exitPromise = new Promise<never>((_, reject) => {
     child.once('exit', (code) => {
       runtime.child = null
+      logSshInvocation(
+        { hostId: runtime.host.hostId, kind: 'control' },
+        argv,
+        code,
+        stderr,
+        Date.now() - t0
+      )
       runtime.state = classifyConnectionFailure(code, stderr)
       reject(new Error(stderr.trim() || `ssh control connection exited: ${code ?? 'signal'}`))
     })
@@ -242,13 +352,18 @@ async function startRuntime(runtime: HostRuntime): Promise<void> {
       runtime.child = null
       runtime.state = 'offline'
       const errno = err as NodeJS.ErrnoException
-      reject(
-        new Error(
-          errno.code === 'ENOENT'
-            ? 'ssh: command not found'
-            : `ssh failed to spawn: ${errno.message || errno.code || 'unknown'}`
-        )
+      const errStderr =
+        errno.code === 'ENOENT'
+          ? 'ssh: command not found'
+          : `ssh failed to spawn: ${errno.message || errno.code || 'unknown'}`
+      logSshInvocation(
+        { hostId: runtime.host.hostId, kind: 'control' },
+        argv,
+        null,
+        errStderr,
+        Date.now() - t0
       )
+      reject(new Error(errStderr))
     })
   })
 
@@ -265,6 +380,7 @@ async function startRuntime(runtime: HostRuntime): Promise<void> {
       }
     }
     runtime.child = null
+    maybeEmitFailureToast(runtime.host, 'control', exitCode, stderr)
     runtime.state = classifyConnectionFailure(exitCode, stderr)
     throw err
   }
@@ -316,7 +432,8 @@ export async function stopHostConnection(hostId: HostId): Promise<void> {
         '--',
         runtime.host.alias,
       ],
-      2000
+      2000,
+      { hostId: runtime.host.hostId, kind: 'control-exit' }
     ).catch(() => undefined)
     try {
       runtime.child.kill()
@@ -388,7 +505,13 @@ export async function exec(
         ...quoted,
       ]
     : ['-o', 'BatchMode=yes', '--', aliasOf(aliasOrHost), ...quoted]
-  return runSsh(sshArgv, timeoutMs)
+  const ctx: SshLogContext | undefined =
+    typeof aliasOrHost === 'string' ? undefined : { hostId: aliasOrHost.hostId, kind: 'exec' }
+  const result = await runSsh(sshArgv, timeoutMs, ctx)
+  if (typeof aliasOrHost !== 'string' && !result.timedOut && result.code !== 0) {
+    maybeEmitFailureToast(aliasOrHost, 'exec', result.code, result.stderr)
+  }
+  return result
 }
 
 export function spawnAttach(host: Host, argv: string[], options: IPtyForkOptions): IPty {
@@ -403,7 +526,21 @@ export function spawnAttach(host: Host, argv: string[], options: IPtyForkOptions
     host.alias,
     ...quoted,
   ]
-  return pty.spawn('ssh', sshArgv, options)
+  const t0 = Date.now()
+  const ptyProcess = pty.spawn('ssh', sshArgv, options)
+  // Stderr is piped to the PTY (the user sees it in xterm); we record the
+  // exit code and full argv for ring-buffer reproducibility, leaving the
+  // stderr snippet empty.
+  ptyProcess.onExit(({ exitCode }) => {
+    logSshInvocation(
+      { hostId: host.hostId, kind: 'attach' },
+      sshArgv,
+      exitCode,
+      '',
+      Date.now() - t0
+    )
+  })
+  return ptyProcess
 }
 
 // Validates that a remote path is a git repository ROOT (not a subdirectory)
@@ -452,8 +589,17 @@ export async function validateRemoteRepo(
     return { ok: true, fingerprint }
   }
   const { reason, message } = classifySshExit({ exitCode: code, stderr })
-  if (reason === 'auth-failed' || reason === 'network' || reason === 'dep-missing') {
-    return { ok: false, reason, message }
+  if (
+    reason === 'auth-failed' ||
+    reason === 'network' ||
+    reason === 'dep-missing' ||
+    reason === 'bind-unlink'
+  ) {
+    // ValidateRemoteRepoReason has no 'bind-unlink' variant — coerce to
+    // 'network' since the user-facing outcome (cannot use this host) is the
+    // same and `message` already carries the specific stderr line.
+    const coercedReason = reason === 'bind-unlink' ? 'network' : reason
+    return { ok: false, reason: coercedReason, message }
   }
   return {
     ok: false,

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -83,7 +83,13 @@ function maybeEmitFailureToast(
   // connection-state UI; a parallel toast would spam every disconnect. Probes
   // taken during bootstrap collide with the bootstrap layer's own toast.
   if (kind === 'control-exit' || kind === 'attach') return
-  if (kind === 'probe' && bootstrapInProgress.has(host.hostId)) return
+  // Probes and execs taken during bootstrap collide with the bootstrap
+  // layer's own toast. bootstrapHost runs all its probes through
+  // connection.exec (kind='exec'), not the runtime's internal controlCheck
+  // (kind='probe'), so both must be suppressed here. session-manager's
+  // HostBootstrapError handler is the single source of truth during the
+  // bootstrap window.
+  if ((kind === 'probe' || kind === 'exec') && bootstrapInProgress.has(host.hostId)) return
 
   const { reason, message } = classifySshExit({ exitCode, stderr })
   // For exec invocations, an unrecognized non-zero exit is most often the

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,6 +52,7 @@ import {
   setOnHostConnectionStopped,
 } from './host-connection'
 import { invalidateBootstrap } from './host-bootstrap'
+import { clearSshLog } from './ssh-log-buffer'
 import { stopHookServerForHost } from './hook-server'
 import {
   listRemoteProjects,
@@ -604,6 +605,7 @@ app.whenReady().then(async () => {
     await stopHostConnection(hostId).catch(() => undefined)
     stopHookServerForHost(hostId)
     invalidateBootstrap(hostId)
+    clearSshLog(hostId)
     removeRemoteProjectsForHost(hostId)
     deleteHost(hostId)
   })

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -1,6 +1,7 @@
-import { Notification } from 'electron'
+import { BrowserWindow, Notification } from 'electron'
+import { randomUUID } from 'crypto'
 import { getMainWindow } from './window-registry'
-import type { Session } from '../shared/types'
+import type { Session, ToastEvent } from '../shared/types'
 
 export function notifyNeedsInput(session: Session): void {
   if (!Notification.isSupported()) return
@@ -20,4 +21,19 @@ export function notifyNeedsInput(session: Session): void {
   })
 
   notification.show()
+}
+
+export function emitToast(event: Omit<ToastEvent, 'id'> & { id?: string }): void {
+  const payload: ToastEvent = {
+    id: event.id ?? randomUUID(),
+    ttlMs: event.ttlMs ?? 6000,
+    severity: event.severity,
+    title: event.title,
+    detail: event.detail,
+    hostLabel: event.hostLabel,
+  }
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue
+    win.webContents.send('toast:show', payload)
+  }
 }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -258,7 +258,12 @@ export async function destroyRemotePty(sessionId: string, host: Host): Promise<v
   }
   if (result.code !== 0) {
     const { reason, message } = classifySshExit({ exitCode: result.code, stderr: result.stderr })
-    if (reason === 'auth-failed' || reason === 'network' || reason === 'dep-missing') {
+    if (
+      reason === 'auth-failed' ||
+      reason === 'network' ||
+      reason === 'dep-missing' ||
+      reason === 'bind-unlink'
+    ) {
       throw new Error(`Remote tmux kill-session failed on host ${host.alias}: ${message}`)
     }
   }
@@ -357,7 +362,12 @@ export async function probeRemoteTmuxSession(
   if (result.timedOut) return 'unreachable'
   if (result.code === 0) return 'present'
   const { reason } = classifySshExit({ exitCode: result.code, stderr: result.stderr })
-  if (reason === 'auth-failed' || reason === 'network' || reason === 'dep-missing') {
+  if (
+    reason === 'auth-failed' ||
+    reason === 'network' ||
+    reason === 'dep-missing' ||
+    reason === 'bind-unlink'
+  ) {
     return 'unreachable'
   }
   // Non-zero exit with no SSH-level failure marker is tmux's own "can't find

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -176,6 +176,7 @@ vi.mock('./host-connection', () => ({
   }),
   runtimeStateFor: (hostId: string) => state.runtimeStates.get(hostId),
   classifyConnectionFailure: (_code: number | null, _stderr: string) => 'offline',
+  startBootstrapWindow: () => () => {},
 }))
 
 // Import SUT after all mocks are registered.

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -36,9 +36,11 @@ import {
   releaseHostConnection,
   stopHostConnection,
   runtimeStateFor,
+  startBootstrapWindow,
   type HostConnectionState,
 } from './host-connection'
-import { bootstrapHost } from './host-bootstrap'
+import { bootstrapHost, HostBootstrapError } from './host-bootstrap'
+import { emitToast } from './notifications'
 import type { Host, RemoteProject, Session, SessionStatus } from '../shared/types'
 
 const execFileAsync = promisify(execFile)
@@ -137,6 +139,7 @@ async function prepareRemoteHost(host: Host): Promise<{ notifyScriptPath: string
     throw err
   }
   retainHostConnection(host.hostId)
+  const endBootstrapWindow = startBootstrapWindow(host.hostId)
   try {
     const bootstrap = await bootstrapHost(
       host.hostId,
@@ -148,7 +151,34 @@ async function prepareRemoteHost(host: Host): Promise<{ notifyScriptPath: string
     return { notifyScriptPath: bootstrap.notifyScriptPath }
   } catch (err) {
     await releaseHostConnection(host.hostId).catch(() => undefined)
+    if (err instanceof HostBootstrapError) {
+      const label = host.label || host.alias
+      if (err.kind === 'missing-deps') {
+        emitToast({
+          severity: 'error',
+          title: `${label}: missing required tools`,
+          detail: err.missingDeps.join(', '),
+          hostLabel: label,
+        })
+      } else if (err.kind === 'stream-local-bind') {
+        emitToast({
+          severity: 'error',
+          title: `${label}: hook socket missing`,
+          detail: err.message,
+          hostLabel: label,
+        })
+      } else {
+        emitToast({
+          severity: 'error',
+          title: `${label}: failed to install hook script`,
+          detail: err.message,
+          hostLabel: label,
+        })
+      }
+    }
     throw err
+  } finally {
+    endBootstrapWindow()
   }
 }
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -153,11 +153,24 @@ async function prepareRemoteHost(host: Host): Promise<{ notifyScriptPath: string
     await releaseHostConnection(host.hostId).catch(() => undefined)
     if (err instanceof HostBootstrapError) {
       const label = host.label || host.alias
-      if (err.kind === 'missing-deps') {
+      // bootstrapHost re-uses kind='missing-deps' for two scenarios: the
+      // dep-probe ssh command itself failing (auth/network/timeout — empty
+      // missingDeps) and the probe succeeding with an actually-missing tool
+      // (populated missingDeps). Only the second deserves the "missing
+      // required tools" remediation toast; the first should surface the
+      // underlying err.message so the user sees the real ssh failure.
+      if (err.kind === 'missing-deps' && err.missingDeps.length > 0) {
         emitToast({
           severity: 'error',
           title: `${label}: missing required tools`,
           detail: err.missingDeps.join(', '),
+          hostLabel: label,
+        })
+      } else if (err.kind === 'missing-deps') {
+        emitToast({
+          severity: 'error',
+          title: `${label}: bootstrap probe failed`,
+          detail: err.message,
           hostLabel: label,
         })
       } else if (err.kind === 'stream-local-bind') {

--- a/src/main/ssh-exit-parser.test.ts
+++ b/src/main/ssh-exit-parser.test.ts
@@ -98,6 +98,28 @@ const cases: Case[] = [
     stderr: 'bash: socat: command not found',
     expected: 'dep-missing',
   },
+  // bind-unlink (remote sshd lacks `StreamLocalBindUnlink yes`)
+  {
+    name: 'StreamLocalBindUnlink requires (single line)',
+    exitCode: 255,
+    stderr: 'StreamLocalBindUnlink requires StreamLocalBindUnlink yes on the server',
+    expected: 'bind-unlink',
+  },
+  {
+    name: 'StreamLocalBindUnlink with debug prefix',
+    exitCode: 255,
+    stderr:
+      'debug1: forwarding remote socket\nStreamLocalBindUnlink requires StreamLocalBindUnlink yes',
+    expected: 'bind-unlink',
+  },
+  // ordering: auth markers win over a co-occurring bind-unlink line
+  {
+    name: 'permission denied wins over bind-unlink',
+    exitCode: 255,
+    stderr:
+      'StreamLocalBindUnlink requires StreamLocalBindUnlink yes\nPermission denied (publickey).',
+    expected: 'auth-failed',
+  },
   // unknown / defensive
   { name: 'empty stderr + 255', exitCode: 255, stderr: '', expected: 'unknown' },
   { name: 'null exit code (signal kill)', exitCode: null, stderr: '', expected: 'unknown' },

--- a/src/main/ssh-exit-parser.ts
+++ b/src/main/ssh-exit-parser.ts
@@ -30,6 +30,8 @@ const NETWORK_MARKERS = [
   'connection closed by',
 ]
 
+const BIND_UNLINK_MARKERS = ['streamlocalbindunlink requires']
+
 function firstNonEmptyLine(stderr: string): string {
   for (const raw of stderr.split('\n')) {
     const line = raw.trim()
@@ -48,6 +50,10 @@ export function classifySshExit({ exitCode, stderr }: SshExitInput): SshExitClas
 
   if (AUTH_MARKERS.some((m) => haystack.includes(m))) {
     return { reason: 'auth-failed', message }
+  }
+
+  if (BIND_UNLINK_MARKERS.some((m) => haystack.includes(m))) {
+    return { reason: 'bind-unlink', message }
   }
 
   if (NETWORK_MARKERS.some((m) => haystack.includes(m))) {

--- a/src/main/ssh-log-buffer.test.ts
+++ b/src/main/ssh-log-buffer.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { recordSshInvocation, getSshLog, clearSshLog, _resetSshLogForTests } from './ssh-log-buffer'
+import type { SshLogEntry } from '../shared/types'
+
+function makeEntry(overrides: Partial<SshLogEntry> = {}): SshLogEntry {
+  return {
+    ts: Date.now(),
+    hostId: 'host-a',
+    kind: 'exec',
+    argv: ['ssh', 'alias', 'true'],
+    exitCode: 0,
+    stderrSnippet: '',
+    ...overrides,
+  }
+}
+
+describe('ssh-log-buffer', () => {
+  beforeEach(() => {
+    _resetSshLogForTests()
+  })
+
+  it('records entries in chronological order', () => {
+    recordSshInvocation(makeEntry({ ts: 1, kind: 'control' }))
+    recordSshInvocation(makeEntry({ ts: 2, kind: 'exec' }))
+    recordSshInvocation(makeEntry({ ts: 3, kind: 'attach' }))
+    const log = getSshLog('host-a')
+    expect(log.map((e) => e.kind)).toEqual(['control', 'exec', 'attach'])
+  })
+
+  it('caps the per-host buffer at 200 entries, retaining the latest', () => {
+    for (let i = 0; i < 250; i++) {
+      recordSshInvocation(makeEntry({ ts: i, exitCode: i }))
+    }
+    const log = getSshLog('host-a')
+    expect(log).toHaveLength(200)
+    expect(log[0].exitCode).toBe(50)
+    expect(log[199].exitCode).toBe(249)
+  })
+
+  it('isolates entries per hostId', () => {
+    recordSshInvocation(makeEntry({ hostId: 'host-a', kind: 'exec' }))
+    recordSshInvocation(makeEntry({ hostId: 'host-b', kind: 'control' }))
+    expect(getSshLog('host-a').map((e) => e.kind)).toEqual(['exec'])
+    expect(getSshLog('host-b').map((e) => e.kind)).toEqual(['control'])
+  })
+
+  it('truncates oversized argv elements to 256 chars with an ellipsis', () => {
+    const giant = 'x'.repeat(500)
+    recordSshInvocation(makeEntry({ argv: ['ssh', giant] }))
+    const stored = getSshLog('host-a')[0]
+    expect(stored.argv[1]).toHaveLength(256)
+    expect(stored.argv[1].endsWith('…')).toBe(true)
+    expect(stored.argv[0]).toBe('ssh')
+  })
+
+  it('truncates oversized stderr snippets to 1024 chars with an ellipsis', () => {
+    const giant = 'e'.repeat(2000)
+    recordSshInvocation(makeEntry({ stderrSnippet: giant }))
+    const stored = getSshLog('host-a')[0]
+    expect(stored.stderrSnippet).toHaveLength(1024)
+    expect(stored.stderrSnippet.endsWith('…')).toBe(true)
+  })
+
+  it('returns a defensive copy from getSshLog', () => {
+    recordSshInvocation(makeEntry({ kind: 'exec' }))
+    const log = getSshLog('host-a')
+    log.length = 0
+    expect(getSshLog('host-a')).toHaveLength(1)
+  })
+
+  it('returns an empty array for an unknown host', () => {
+    expect(getSshLog('host-zzz')).toEqual([])
+  })
+
+  it('clears only the targeted host', () => {
+    recordSshInvocation(makeEntry({ hostId: 'host-a' }))
+    recordSshInvocation(makeEntry({ hostId: 'host-b' }))
+    clearSshLog('host-a')
+    expect(getSshLog('host-a')).toEqual([])
+    expect(getSshLog('host-b')).toHaveLength(1)
+  })
+})

--- a/src/main/ssh-log-buffer.ts
+++ b/src/main/ssh-log-buffer.ts
@@ -1,0 +1,39 @@
+import type { HostId, SshLogEntry } from '../shared/types'
+
+const MAX_ENTRIES_PER_HOST = 200
+const MAX_ARGV_ELEMENT_LEN = 256
+const MAX_STDERR_SNIPPET_LEN = 1024
+
+const buffers = new Map<HostId, SshLogEntry[]>()
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value
+  return value.slice(0, max - 1) + '…'
+}
+
+export function recordSshInvocation(entry: SshLogEntry): void {
+  const argv = entry.argv.map((a) => truncate(a, MAX_ARGV_ELEMENT_LEN))
+  const stderrSnippet = truncate(entry.stderrSnippet, MAX_STDERR_SNIPPET_LEN)
+  const sanitized: SshLogEntry = { ...entry, argv, stderrSnippet }
+
+  const list = buffers.get(entry.hostId) ?? []
+  list.push(sanitized)
+  if (list.length > MAX_ENTRIES_PER_HOST) {
+    list.splice(0, list.length - MAX_ENTRIES_PER_HOST)
+  }
+  buffers.set(entry.hostId, list)
+}
+
+export function getSshLog(hostId: HostId): SshLogEntry[] {
+  const list = buffers.get(hostId)
+  return list ? list.slice() : []
+}
+
+export function clearSshLog(hostId: HostId): void {
+  buffers.delete(hostId)
+}
+
+// Test-only helper. Not exported to consumers but reachable via the module.
+export function _resetSshLogForTests(): void {
+  buffers.clear()
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import type { ToastEvent } from '../shared/types'
 
 contextBridge.exposeInMainWorld('api', {
   scanProjects: () => ipcRenderer.invoke('projects:scan'),
@@ -89,4 +90,9 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.invoke('projects:add-remote', input),
   removeRemoteProject: (hostId: string, path: string) =>
     ipcRenderer.invoke('projects:remove-remote', hostId, path),
+  onToast: (callback: (event: ToastEvent) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: ToastEvent) => callback(data)
+    ipcRenderer.on('toast:show', handler)
+    return () => ipcRenderer.removeListener('toast:show', handler)
+  },
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,9 +6,11 @@ import StatusBar from './components/StatusBar'
 import ManageHostsDialog from './components/ManageHostsDialog'
 import ZoomOpenMorph from './components/ZoomOpenMorph'
 import AddRemoteProjectDialog from './components/AddRemoteProjectDialog'
+import ToastContainer from './components/ToastContainer'
 import { useProjectsStore } from './stores/projects'
 import { useSessionsStore } from './stores/sessions'
 import { useHostsStore } from './stores/hosts'
+import { useToastsStore } from './stores/toasts'
 
 export default function App() {
   const { scanProjects, filterReady, toggleFilterReady } = useProjectsStore()
@@ -49,6 +51,13 @@ export default function App() {
         setActiveSessionId(sessionId)
         setActiveSessionName(`${session.projectName}/${session.worktreeName}`)
       }
+    })
+  }, [])
+
+  // Subscribe to toast IPC from main (SSH failures, bootstrap errors, etc.)
+  useEffect(() => {
+    return window.api.onToast((event) => {
+      useToastsStore.getState().enqueue(event)
     })
   }, [])
 
@@ -232,6 +241,7 @@ export default function App() {
 
       <ManageHostsDialog />
       <AddRemoteProjectDialog />
+      <ToastContainer />
       {morphPayload && (
         <ZoomOpenMorph
           startRect={morphPayload.startRect}

--- a/src/renderer/components/ToastContainer.tsx
+++ b/src/renderer/components/ToastContainer.tsx
@@ -1,0 +1,29 @@
+import { useToastsStore } from '../stores/toasts'
+
+export default function ToastContainer() {
+  const toasts = useToastsStore((s) => s.toasts)
+  const dismiss = useToastsStore((s) => s.dismiss)
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div className="toast-stack">
+      {toasts.map((t) => (
+        <div key={t.id} className={`toast toast-${t.severity}`} role="alert">
+          <div className="toast-body">
+            <div className="toast-title">{t.title}</div>
+            {t.detail && <div className="toast-detail">{t.detail}</div>}
+          </div>
+          <button
+            type="button"
+            className="toast-dismiss"
+            aria-label="Dismiss"
+            onClick={() => dismiss(t.id)}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -10,6 +10,7 @@ import type {
   ReviewDiffResult,
   Session,
   TestConnectionResult,
+  ToastEvent,
 } from '../shared/types'
 
 declare global {
@@ -77,6 +78,7 @@ declare global {
       testHostConnection: (hostId: string) => Promise<TestConnectionResult>
       addRemoteProject: (input: { hostId: string; path: string }) => Promise<RemoteProject>
       removeRemoteProject: (hostId: string, path: string) => Promise<void>
+      onToast: (callback: (event: ToastEvent) => void) => () => void
     }
   }
 }

--- a/src/renderer/stores/toasts.ts
+++ b/src/renderer/stores/toasts.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand'
+import type { ToastEvent } from '../../shared/types'
+
+interface ToastsState {
+  toasts: ToastEvent[]
+  enqueue: (event: ToastEvent) => void
+  dismiss: (id: string) => void
+}
+
+const timers = new Map<string, ReturnType<typeof setTimeout>>()
+
+export const useToastsStore = create<ToastsState>((set, get) => ({
+  toasts: [],
+  enqueue: (event) => {
+    const ttlMs = event.ttlMs ?? 6000
+    // Dedup on (severity, title, hostLabel): refresh ttl rather than stack
+    // identical errors during a backoff or retry loop.
+    const existing = get().toasts.find(
+      (t) =>
+        t.severity === event.severity && t.title === event.title && t.hostLabel === event.hostLabel
+    )
+    if (existing) {
+      const timer = timers.get(existing.id)
+      if (timer) clearTimeout(timer)
+      const refreshed: ToastEvent = { ...existing, detail: event.detail, ttlMs }
+      set({
+        toasts: get().toasts.map((t) => (t.id === existing.id ? refreshed : t)),
+      })
+      timers.set(
+        existing.id,
+        setTimeout(() => get().dismiss(existing.id), ttlMs)
+      )
+      return
+    }
+    set({ toasts: [...get().toasts, event] })
+    timers.set(
+      event.id,
+      setTimeout(() => get().dismiss(event.id), ttlMs)
+    )
+  },
+  dismiss: (id) => {
+    const timer = timers.get(id)
+    if (timer) clearTimeout(timer)
+    timers.delete(id)
+    set({ toasts: get().toasts.filter((t) => t.id !== id) })
+  },
+}))

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -690,6 +690,79 @@ body,
   z-index: 100;
 }
 
+/* z-index above modals (host dialog, zoom-open morph) so SSH-failure toasts
+   stay visible while a dialog is open. */
+.toast-stack {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 10000;
+  max-width: 420px;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  background: var(--bg-context-menu);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-left-width: 4px;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 13px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  pointer-events: auto;
+}
+
+.toast-error {
+  border-left-color: var(--accent-red);
+}
+
+.toast-warning {
+  border-left-color: var(--accent-yellow);
+}
+
+.toast-info {
+  border-left-color: var(--accent-blue);
+}
+
+.toast-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.toast-title {
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.toast-detail {
+  margin-top: 2px;
+  font-size: 12px;
+  opacity: 0.75;
+  word-break: break-word;
+}
+
+.toast-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+  opacity: 0.6;
+}
+
+.toast-dismiss:hover {
+  opacity: 1;
+}
+
 .context-menu {
   position: fixed;
   background: var(--bg-context-menu);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -108,7 +108,7 @@ export interface Host {
   label: string
 }
 
-export type SshExitReason = 'auth-failed' | 'network' | 'dep-missing' | 'unknown'
+export type SshExitReason = 'auth-failed' | 'network' | 'dep-missing' | 'bind-unlink' | 'unknown'
 
 export interface TestConnectionResult {
   ok: boolean
@@ -153,4 +153,27 @@ export interface ReviewDefaultBranchResult {
   ok: boolean
   branch?: string
   reason?: 'remote-unsupported'
+}
+
+export type SshInvocationKind = 'control' | 'control-exit' | 'exec' | 'attach' | 'probe'
+
+export interface SshLogEntry {
+  ts: number
+  hostId: HostId
+  kind: SshInvocationKind
+  argv: string[]
+  exitCode: number | null
+  stderrSnippet: string
+  durationMs?: number
+}
+
+export type ToastSeverity = 'error' | 'warning' | 'info'
+
+export interface ToastEvent {
+  id: string
+  severity: ToastSeverity
+  title: string
+  detail?: string
+  hostLabel?: string
+  ttlMs?: number
 }


### PR DESCRIPTION
## Summary

- Per-host in-memory ring buffer (cap 200) recording every ssh invocation through `HostConnection` (control startup, `-O exit` teardown, `controlCheck` probe, `exec`, `spawnAttach`) with argv, exit code, stderr snippet, and duration. Cleared on host delete; never persisted.
- Stderr-signature matcher classifies known failures (Permission denied, Connection refused/timed out, `StreamLocalBindUnlink requires`, missing-deps) into specific toasts naming the host label; unknown failures fall through to a generic "ssh failed on {host}: exit {code}" toast. Bootstrap dep-missing surfaces a richer toast at session create.
- Toast emission suppresses noise: control teardown, attach disconnects, and probes during bootstrap stay silent. New global `<ToastContainer>` + Zustand store with dedup and auto-dismiss.

Closes #16. Completes the v1 cut of remote-SSH (#8).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] `npx prettier --check src/` — clean
- [x] `npx vitest run` — 225/225 passing (incl. 8 new ring-buffer tests, 4 new parser cases for `StreamLocalBindUnlink`, 5 new host-connection recorder/toast assertions)
- [x] `npm run build` — production build succeeds
- [ ] Manual UI smoke (recommended): register a host with bad alias → "Cannot reach {label}" toast; with sshd lacking `StreamLocalBindUnlink yes` → bind-unlink toast; with `jq` missing → "missing required tools: jq" toast