### PR TITLE
feat: codex agent support alongside claude (#50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,13 @@ When debugging visual issues, **always use this approach first** rather than ask
 - Conventional Commits: `feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`
 - Prefer editing existing files over creating new ones
 
+## Supported agents
+
+- **Claude Code** (`claude`) — default. Uses `--continue` to resume. Hooks installed at `<worktree>/.claude/settings.local.json`.
+- **OpenAI Codex** (`codex`) — opt-in per session. Resume uses `codex resume <session_id>` (the `agentSessionId` is captured from the `SessionStart` hook payload). Hooks installed at `<worktree>/.codex/hooks.json` and gated behind `[features].codex_hooks = true` in `~/.codex/config.toml`, which cc-pewpew enables idempotently on first codex session install.
+
+The default tool is configurable via `defaultTool` in `~/.config/cc-pewpew/config.json`. Per-session selection is exposed in the "New session" dialog. Both `claude` and `codex` must be in `PATH` (locally and on every remote host where the corresponding tool is selected).
+
 ## Implementation
 
 The project follows PLAN.md (v2). Terminals are embedded via xterm.js + node-pty + tmux (no external windows). Sessions persist across app restarts.

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import type { Host, RemoteProject } from '../shared/types'
+import type { AgentTool, Host, RemoteProject } from '../shared/types'
 
 export interface CanvasState {
   zoom: number
@@ -30,6 +30,7 @@ export interface AppConfig {
   hosts: Host[]
   gitignoreWarned: string[]
   remoteProjects: RemoteProject[]
+  defaultTool: AgentTool
 }
 
 export const CONFIG_DIR = join(
@@ -50,6 +51,7 @@ const DEFAULT_CONFIG: AppConfig = {
   hosts: [],
   gitignoreWarned: [],
   remoteProjects: [],
+  defaultTool: 'claude',
 }
 
 export function shouldWarnGitignore(projectPath: string): boolean {

--- a/src/main/hook-installer.test.ts
+++ b/src/main/hook-installer.test.ts
@@ -86,6 +86,28 @@ describe('installCodexHooks', () => {
     expect(json.hooks.Stop).toHaveLength(1)
     expect(json.hooks.PostToolUse).toHaveLength(1)
   })
+
+  it.each([
+    ['null', 'null'],
+    ['number', '42'],
+    ['string', '"hello"'],
+    ['array', '[1,2,3]'],
+    ['malformed', '{not json}'],
+  ])('tolerates a %s hooks.json without throwing', async (_label, body) => {
+    const codexDir = join(state.tmpProject, '.codex')
+    mkdirSync(codexDir, { recursive: true })
+    writeFileSync(join(codexDir, 'hooks.json'), body)
+
+    const { installCodexHooks } = await loadInstaller()
+    await expect(
+      installCodexHooks(state.tmpProject, { skipGitignore: true })
+    ).resolves.toBeDefined()
+
+    const json = JSON.parse(
+      readFileSync(join(state.tmpProject, '.codex', 'hooks.json'), 'utf-8')
+    ) as { hooks: Record<string, unknown[]> }
+    expect(json.hooks.SessionStart).toHaveLength(1)
+  })
 })
 
 describe('mergeCodexHooksFlag', () => {

--- a/src/main/hook-installer.test.ts
+++ b/src/main/hook-installer.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const state = {
+  tmpHome: '',
+  tmpProject: '',
+}
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return { ...actual, homedir: () => state.tmpHome }
+})
+
+vi.mock('./config', () => ({
+  CONFIG_DIR: '/tmp/cc-pewpew-test-config',
+}))
+
+beforeEach(() => {
+  state.tmpHome = mkdtempSync(join(tmpdir(), 'codex-home-'))
+  state.tmpProject = mkdtempSync(join(tmpdir(), 'codex-proj-'))
+})
+
+afterEach(() => {
+  rmSync(state.tmpHome, { recursive: true, force: true })
+  rmSync(state.tmpProject, { recursive: true, force: true })
+})
+
+async function loadInstaller(): Promise<typeof import('./hook-installer')> {
+  vi.resetModules()
+  return import('./hook-installer')
+}
+
+describe('installCodexHooks', () => {
+  it('writes .codex/hooks.json with codex event shape', async () => {
+    const { installCodexHooks } = await loadInstaller()
+    await installCodexHooks(state.tmpProject, { skipGitignore: true })
+
+    const json = JSON.parse(
+      readFileSync(join(state.tmpProject, '.codex', 'hooks.json'), 'utf-8')
+    ) as { hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string }> }>> }
+
+    expect(json.hooks.SessionStart).toHaveLength(1)
+    expect(json.hooks.Stop).toHaveLength(1)
+    expect(json.hooks.PostToolUse).toHaveLength(1)
+    expect(json.hooks.PostToolUse[0].matcher).toBe('.*')
+    expect(json.hooks.SessionStart[0].hooks[0].command).toContain('cc-pewpew')
+  })
+
+  it('preserves existing non-cc-pewpew entries when merging', async () => {
+    const codexDir = join(state.tmpProject, '.codex')
+    mkdirSync(codexDir, { recursive: true })
+    writeFileSync(
+      join(codexDir, 'hooks.json'),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [{ hooks: [{ type: 'command', command: '/usr/local/bin/other-hook.sh' }] }],
+        },
+      })
+    )
+
+    const { installCodexHooks } = await loadInstaller()
+    await installCodexHooks(state.tmpProject, { skipGitignore: true })
+
+    const json = JSON.parse(
+      readFileSync(join(state.tmpProject, '.codex', 'hooks.json'), 'utf-8')
+    ) as { hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>> }
+
+    expect(json.hooks.SessionStart).toHaveLength(2)
+    const commands = json.hooks.SessionStart.map((g) => g.hooks[0].command)
+    expect(commands).toContain('/usr/local/bin/other-hook.sh')
+    expect(commands.some((c: string) => c.includes('cc-pewpew'))).toBe(true)
+  })
+
+  it('replaces stale cc-pewpew entries on re-install', async () => {
+    const { installCodexHooks } = await loadInstaller()
+    await installCodexHooks(state.tmpProject, { skipGitignore: true })
+    await installCodexHooks(state.tmpProject, { skipGitignore: true })
+
+    const json = JSON.parse(
+      readFileSync(join(state.tmpProject, '.codex', 'hooks.json'), 'utf-8')
+    ) as { hooks: Record<string, unknown[]> }
+
+    expect(json.hooks.SessionStart).toHaveLength(1)
+    expect(json.hooks.Stop).toHaveLength(1)
+    expect(json.hooks.PostToolUse).toHaveLength(1)
+  })
+})
+
+describe('mergeCodexHooksFlag', () => {
+  it('inserts [features] table when missing', async () => {
+    const { mergeCodexHooksFlag } = await loadInstaller()
+    const out = mergeCodexHooksFlag('')
+    expect(out).toContain('[features]')
+    expect(out).toContain('codex_hooks = true')
+  })
+
+  it('inserts codex_hooks key into existing [features] table', async () => {
+    const { mergeCodexHooksFlag } = await loadInstaller()
+    const input = '[features]\nother_flag = true\n'
+    const out = mergeCodexHooksFlag(input)
+    expect(out).toContain('other_flag = true')
+    expect(out).toContain('codex_hooks = true')
+  })
+
+  it('replaces codex_hooks = false with true', async () => {
+    const { mergeCodexHooksFlag } = await loadInstaller()
+    const input = '[features]\ncodex_hooks = false\n'
+    const out = mergeCodexHooksFlag(input)
+    expect(out).toContain('codex_hooks = true')
+    expect(out).not.toContain('codex_hooks = false')
+  })
+
+  it('is idempotent when codex_hooks = true is already set', async () => {
+    const { mergeCodexHooksFlag } = await loadInstaller()
+    const input = '[features]\ncodex_hooks = true\n'
+    const out = mergeCodexHooksFlag(input)
+    expect(out).toBe(input)
+  })
+
+  it('preserves unrelated tables', async () => {
+    const { mergeCodexHooksFlag } = await loadInstaller()
+    const input = '[model]\nname = "gpt-5"\n\n[mcp]\nfoo = "bar"\n'
+    const out = mergeCodexHooksFlag(input)
+    expect(out).toContain('[model]')
+    expect(out).toContain('name = "gpt-5"')
+    expect(out).toContain('[mcp]')
+    expect(out).toContain('foo = "bar"')
+    expect(out).toContain('[features]')
+    expect(out).toContain('codex_hooks = true')
+  })
+
+  it('only matches codex_hooks inside [features], not in other tables', async () => {
+    const { mergeCodexHooksFlag } = await loadInstaller()
+    const input = '[other]\ncodex_hooks = false\n\n[features]\nfoo = true\n'
+    const out = mergeCodexHooksFlag(input)
+    // The decoy in [other] must remain untouched
+    expect(out).toContain('[other]\ncodex_hooks = false')
+    // And [features] must gain codex_hooks = true
+    expect(out).toMatch(/\[features\][^[]*codex_hooks = true/)
+  })
+})
+
+describe('ensureCodexHooksFeatureFlag', () => {
+  it('creates ~/.codex/config.toml with [features].codex_hooks = true when missing', async () => {
+    const { ensureCodexHooksFeatureFlag } = await loadInstaller()
+    ensureCodexHooksFeatureFlag()
+    const out = readFileSync(join(state.tmpHome, '.codex', 'config.toml'), 'utf-8')
+    expect(out).toContain('[features]')
+    expect(out).toContain('codex_hooks = true')
+  })
+
+  it('is idempotent', async () => {
+    const { ensureCodexHooksFeatureFlag } = await loadInstaller()
+    ensureCodexHooksFeatureFlag()
+    const first = readFileSync(join(state.tmpHome, '.codex', 'config.toml'), 'utf-8')
+    ensureCodexHooksFeatureFlag()
+    const second = readFileSync(join(state.tmpHome, '.codex', 'config.toml'), 'utf-8')
+    expect(second).toBe(first)
+  })
+
+  it('preserves existing config.toml content', async () => {
+    mkdirSync(join(state.tmpHome, '.codex'), { recursive: true })
+    writeFileSync(
+      join(state.tmpHome, '.codex', 'config.toml'),
+      '[model]\nname = "gpt-5"\n\n[features]\nother_flag = true\n'
+    )
+
+    const { ensureCodexHooksFeatureFlag } = await loadInstaller()
+    ensureCodexHooksFeatureFlag()
+
+    const out = readFileSync(join(state.tmpHome, '.codex', 'config.toml'), 'utf-8')
+    expect(out).toContain('[model]')
+    expect(out).toContain('name = "gpt-5"')
+    expect(out).toContain('other_flag = true')
+    expect(out).toContain('codex_hooks = true')
+  })
+})
+
+describe('rollbackCodexHooks', () => {
+  it('removes .codex/hooks.json if present', async () => {
+    const { installCodexHooks, rollbackCodexHooks } = await loadInstaller()
+    await installCodexHooks(state.tmpProject, { skipGitignore: true })
+    expect(existsSync(join(state.tmpProject, '.codex', 'hooks.json'))).toBe(true)
+    rollbackCodexHooks(state.tmpProject)
+    expect(existsSync(join(state.tmpProject, '.codex', 'hooks.json'))).toBe(false)
+  })
+
+  it('is a no-op when hooks.json is absent', async () => {
+    const { rollbackCodexHooks } = await loadInstaller()
+    expect(() => rollbackCodexHooks(state.tmpProject)).not.toThrow()
+  })
+})

--- a/src/main/hook-installer.test.ts
+++ b/src/main/hook-installer.test.ts
@@ -179,16 +179,31 @@ describe('ensureCodexHooksFeatureFlag', () => {
 })
 
 describe('rollbackCodexHooks', () => {
-  it('removes .codex/hooks.json if present', async () => {
+  it('removes .codex/hooks.json when there was no prior file', async () => {
     const { installCodexHooks, rollbackCodexHooks } = await loadInstaller()
-    await installCodexHooks(state.tmpProject, { skipGitignore: true })
+    const snapshot = await installCodexHooks(state.tmpProject, { skipGitignore: true })
     expect(existsSync(join(state.tmpProject, '.codex', 'hooks.json'))).toBe(true)
-    rollbackCodexHooks(state.tmpProject)
+    rollbackCodexHooks(snapshot)
     expect(existsSync(join(state.tmpProject, '.codex', 'hooks.json'))).toBe(false)
   })
 
-  it('is a no-op when hooks.json is absent', async () => {
-    const { rollbackCodexHooks } = await loadInstaller()
-    expect(() => rollbackCodexHooks(state.tmpProject)).not.toThrow()
+  it('restores the prior file content (preserving unrelated user hooks)', async () => {
+    const codexDir = join(state.tmpProject, '.codex')
+    mkdirSync(codexDir, { recursive: true })
+    const priorJson = JSON.stringify({
+      hooks: {
+        SessionStart: [{ hooks: [{ type: 'command', command: '/usr/local/bin/other-hook.sh' }] }],
+      },
+    })
+    writeFileSync(join(codexDir, 'hooks.json'), priorJson)
+
+    const { installCodexHooks, rollbackCodexHooks } = await loadInstaller()
+    const snapshot = await installCodexHooks(state.tmpProject, { skipGitignore: true })
+
+    // Pretend the feature-flag step failed; rollback must put the original back.
+    rollbackCodexHooks(snapshot)
+
+    const restored = readFileSync(join(state.tmpProject, '.codex', 'hooks.json'), 'utf-8')
+    expect(restored).toBe(priorJson)
   })
 })

--- a/src/main/hook-installer.ts
+++ b/src/main/hook-installer.ts
@@ -231,6 +231,11 @@ export async function installRemoteCodexHooks(
   // hooks), then run the same merge logic as before. Echo a single line —
   // "1" if a prior file existed, "0" otherwise — so the caller knows
   // whether rollback should restore from the backup or unlink.
+  // Mirror the local installer's tolerance for a malformed/non-object prior
+  // file. Pre-validate with `jq -e empty`: if the existing hooks.json is
+  // unparseable (or not an object), feed `{}` to the merge step instead of
+  // letting `jq` abort the whole pipeline. The backup is still made so
+  // rollback can restore exactly what was there.
   const script =
     'set -e\n' +
     'codex_dir="$1/.codex"\n' +
@@ -238,7 +243,11 @@ export async function installRemoteCodexHooks(
     'backup="$codex_dir/hooks.json.cc-pewpew.bak"\n' +
     'mkdir -p "$codex_dir"\n' +
     'if [ -f "$hooks" ]; then cp "$hooks" "$backup"; printf "1"; else printf "0"; fi\n' +
-    'if [ -s "$hooks" ]; then cat "$hooks"; else printf "{}"; fi |\n' +
+    'if [ -s "$hooks" ] && jq -e \'type == "object"\' "$hooks" >/dev/null 2>&1; then\n' +
+    '  cat "$hooks"\n' +
+    'else\n' +
+    '  printf "{}"\n' +
+    'fi |\n' +
     'jq --argjson newHooks "$2" \'\n' +
     '  .hooks = (.hooks // {}) |\n' +
     '  reduce ($newHooks | keys[]) as $k (.;\n' +

--- a/src/main/hook-installer.ts
+++ b/src/main/hook-installer.ts
@@ -1,7 +1,16 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync, appendFileSync } from 'fs'
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  appendFileSync,
+  renameSync,
+  rmSync,
+} from 'fs'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { join } from 'path'
+import { homedir } from 'os'
 import { CONFIG_DIR } from './config'
 import type { ExecResult } from './host-connection'
 
@@ -20,8 +29,27 @@ function buildHooks(notifyScript: string): Record<string, unknown[]> {
   }
 }
 
+function buildCodexHooks(notifyScript: string): Record<string, unknown[]> {
+  const hook = { type: 'command', command: notifyScript }
+  return {
+    SessionStart: [{ hooks: [hook] }],
+    Stop: [{ hooks: [hook] }],
+    PostToolUse: [{ matcher: '.*', hooks: [hook] }],
+  }
+}
+
 function ccPewpewHookJson(notifyScript: string): string {
   return JSON.stringify(buildHooks(notifyScript))
+}
+
+function ccPewpewCodexHookJson(notifyScript: string): string {
+  return JSON.stringify(buildCodexHooks(notifyScript))
+}
+
+function atomicWrite(path: string, contents: string): void {
+  const tmp = `${path}.tmp`
+  writeFileSync(tmp, contents)
+  renameSync(tmp, path)
 }
 
 export async function installHooks(
@@ -112,5 +140,176 @@ function ensureGitignore(projectPath: string, entry: string): void {
     appendFileSync(gitignorePath, `\n${entry}\n`)
   } else {
     writeFileSync(gitignorePath, `${entry}\n`)
+  }
+}
+
+// Codex hook config is a JSON file at <project>/.codex/hooks.json. The shape
+// mirrors Claude's `hooks` block (event → matcher groups → handlers) but lives
+// in its own file rather than under a settings key.
+export async function installCodexHooks(
+  projectPath: string,
+  { skipGitignore = false }: { skipGitignore?: boolean } = {}
+): Promise<void> {
+  const codexDir = join(projectPath, '.codex')
+  mkdirSync(codexDir, { recursive: true })
+
+  const hooksPath = join(codexDir, 'hooks.json')
+
+  let existing: Record<string, unknown> = {}
+  if (existsSync(hooksPath)) {
+    try {
+      existing = JSON.parse(readFileSync(hooksPath, 'utf-8'))
+    } catch {
+      existing = {}
+    }
+  }
+
+  const newHooks = buildCodexHooks(NOTIFY_SCRIPT)
+  const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>
+  const merged: Record<string, unknown[]> = { ...existingHooks }
+
+  for (const [event, entries] of Object.entries(newHooks)) {
+    const kept = (existingHooks[event] || []).filter((entry) => {
+      const json = JSON.stringify(entry)
+      return !json.includes('cc-pewpew')
+    })
+    merged[event] = [...kept, ...entries]
+  }
+
+  existing.hooks = merged
+  atomicWrite(hooksPath, JSON.stringify(existing, null, 2))
+
+  if (!skipGitignore) {
+    ensureGitignore(projectPath, '.codex/hooks.json')
+  }
+}
+
+export async function installRemoteCodexHooks(
+  execRemote: (argv: string[], opts?: { timeoutMs?: number }) => Promise<ExecResult>,
+  worktreePath: string,
+  notifyScriptPath: string
+): Promise<void> {
+  const hooksJson = ccPewpewCodexHookJson(notifyScriptPath)
+  const script =
+    'set -e\n' +
+    'codex_dir="$1/.codex"\n' +
+    'hooks="$codex_dir/hooks.json"\n' +
+    'mkdir -p "$codex_dir"\n' +
+    'if [ -s "$hooks" ]; then cat "$hooks"; else printf "{}"; fi |\n' +
+    'jq --argjson newHooks "$2" \'\n' +
+    '  .hooks = (.hooks // {}) |\n' +
+    '  reduce ($newHooks | keys[]) as $k (.;\n' +
+    '    .hooks[$k] = (((.hooks[$k] // []) | map(select(((. | tostring) | contains("cc-pewpew")) | not))) + $newHooks[$k])\n' +
+    '  )\n' +
+    '\' > "$hooks.tmp"\n' +
+    'mv "$hooks.tmp" "$hooks"\n'
+  const result = await execRemote(['sh', '-c', script, '_', worktreePath, hooksJson], {
+    timeoutMs: 15000,
+  })
+  if (result.timedOut || result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`
+    throw new Error(`Failed to install remote codex hooks: ${detail}`)
+  }
+}
+
+// Best-effort cleanup if the feature-flag enable step fails after we've already
+// written .codex/hooks.json. The caller re-throws the original error.
+export function rollbackCodexHooks(projectPath: string): void {
+  try {
+    rmSync(join(projectPath, '.codex', 'hooks.json'), { force: true })
+  } catch {
+    // ignore — best-effort
+  }
+}
+
+const CODEX_CONFIG_PATH = join(homedir(), '.codex', 'config.toml')
+
+// Hand-rolled minimal TOML merge — codex hooks are gated behind
+// `[features].codex_hooks = true`. We avoid pulling a TOML dep just for one
+// boolean, so this finds the [features] table and either sets, replaces, or
+// inserts the key. Any other content is preserved verbatim.
+export function mergeCodexHooksFlag(input: string): string {
+  const lines = input.split('\n')
+  const isFeaturesHeader = (l: string): boolean => /^\s*\[\s*features\s*\]\s*(#.*)?$/.test(l)
+  const isOtherTable = (l: string): boolean => /^\s*\[/.test(l) && !isFeaturesHeader(l)
+  const codexHooksKey = /^\s*codex_hooks\s*=/
+
+  let inFeatures = false
+  let featuresHeaderIdx = -1
+  let foundKeyIdx = -1
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (isFeaturesHeader(line)) {
+      inFeatures = true
+      featuresHeaderIdx = i
+      continue
+    }
+    if (inFeatures && isOtherTable(line)) {
+      inFeatures = false
+      continue
+    }
+    if (inFeatures && codexHooksKey.test(line)) {
+      foundKeyIdx = i
+      break
+    }
+  }
+
+  if (foundKeyIdx >= 0) {
+    if (/^\s*codex_hooks\s*=\s*true\s*(#.*)?$/.test(lines[foundKeyIdx])) return input
+    lines[foundKeyIdx] = 'codex_hooks = true'
+    return lines.join('\n')
+  }
+
+  if (featuresHeaderIdx >= 0) {
+    lines.splice(featuresHeaderIdx + 1, 0, 'codex_hooks = true')
+    return lines.join('\n')
+  }
+
+  const trailing = input.length === 0 || input.endsWith('\n') ? '' : '\n'
+  return `${input}${trailing}\n[features]\ncodex_hooks = true\n`
+}
+
+export function ensureCodexHooksFeatureFlag(): void {
+  mkdirSync(join(homedir(), '.codex'), { recursive: true })
+  let current = ''
+  if (existsSync(CODEX_CONFIG_PATH)) {
+    current = readFileSync(CODEX_CONFIG_PATH, 'utf-8')
+  }
+  const next = mergeCodexHooksFlag(current)
+  if (next === current) return
+  atomicWrite(CODEX_CONFIG_PATH, next)
+}
+
+export async function ensureRemoteCodexHooksFeatureFlag(
+  execRemote: (argv: string[], opts?: { timeoutMs?: number }) => Promise<ExecResult>
+): Promise<void> {
+  // Mirrors mergeCodexHooksFlag in shell: parse line-by-line via awk, set
+  // codex_hooks=true inside [features], inserting the table if absent. Atomic
+  // via tmp+mv. Idempotent — re-running yields identical content.
+  const script =
+    'set -e\n' +
+    'cfg="$HOME/.codex/config.toml"\n' +
+    'mkdir -p "$HOME/.codex"\n' +
+    '[ -f "$cfg" ] || printf "" > "$cfg"\n' +
+    "awk '\n" +
+    '  BEGIN { inFeat=0; injected=0; replaced=0 }\n' +
+    '  /^[[:space:]]*\\[[[:space:]]*features[[:space:]]*\\][[:space:]]*(#.*)?$/ { print; inFeat=1; next }\n' +
+    '  /^[[:space:]]*\\[/ {\n' +
+    '    if (inFeat==1 && injected==0 && replaced==0) { print "codex_hooks = true"; injected=1 }\n' +
+    '    inFeat=0; print; next\n' +
+    '  }\n' +
+    '  inFeat==1 && /^[[:space:]]*codex_hooks[[:space:]]*=/ { print "codex_hooks = true"; replaced=1; next }\n' +
+    '  { print }\n' +
+    '  END {\n' +
+    '    if (replaced==1) exit 0\n' +
+    '    if (inFeat==1 && injected==0) { print "codex_hooks = true"; exit 0 }\n' +
+    '    if (injected==0) { print ""; print "[features]"; print "codex_hooks = true" }\n' +
+    '  }\n' +
+    '\' "$cfg" > "$cfg.tmp"\n' +
+    'mv "$cfg.tmp" "$cfg"\n'
+  const result = await execRemote(['sh', '-c', script], { timeoutMs: 10000 })
+  if (result.timedOut || result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`
+    throw new Error(`Failed to enable codex hooks feature flag on remote: ${detail}`)
   }
 }

--- a/src/main/hook-installer.ts
+++ b/src/main/hook-installer.ts
@@ -52,6 +52,19 @@ function atomicWrite(path: string, contents: string): void {
   renameSync(tmp, path)
 }
 
+// Read file contents or return a fallback if the file is absent. The
+// existsSync-then-readFileSync pattern is a classic TOCTOU race (the file
+// can vanish between the two calls); doing the read directly inside a
+// try/catch on ENOENT removes the gap.
+function tryReadFile(path: string, fallback: string | null = null): string | null {
+  try {
+    return readFileSync(path, 'utf-8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return fallback
+    throw err
+  }
+}
+
 // JSON.parse can return any valid JSON value — null, primitives, arrays — so
 // callers that go on to read `.hooks` need to coerce non-object results back
 // to an empty object. Without this, a syntactically valid `null` or `"text"`
@@ -77,9 +90,8 @@ export async function installHooks(
 
   const settingsPath = join(claudeDir, 'settings.local.json')
 
-  const existing: Record<string, unknown> = existsSync(settingsPath)
-    ? parseAsObject(readFileSync(settingsPath, 'utf-8'))
-    : {}
+  const raw = tryReadFile(settingsPath)
+  const existing: Record<string, unknown> = raw === null ? {} : parseAsObject(raw)
 
   const newHooks = buildHooks(NOTIFY_SCRIPT)
   const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>
@@ -174,7 +186,7 @@ export async function installCodexHooks(
   // Snapshot the prior file (or its absence) so a rollback after a partial
   // install can restore exactly what was there — including any unrelated
   // user-authored hooks that the merge step folded into the new file.
-  const priorContent = existsSync(hooksPath) ? readFileSync(hooksPath, 'utf-8') : null
+  const priorContent = tryReadFile(hooksPath)
 
   const existing: Record<string, unknown> = priorContent !== null ? parseAsObject(priorContent) : {}
 
@@ -340,10 +352,7 @@ export function mergeCodexHooksFlag(input: string): string {
 
 export function ensureCodexHooksFeatureFlag(): void {
   mkdirSync(join(homedir(), '.codex'), { recursive: true })
-  let current = ''
-  if (existsSync(CODEX_CONFIG_PATH)) {
-    current = readFileSync(CODEX_CONFIG_PATH, 'utf-8')
-  }
+  const current = tryReadFile(CODEX_CONFIG_PATH, '') ?? ''
   const next = mergeCodexHooksFlag(current)
   if (next === current) return
   atomicWrite(CODEX_CONFIG_PATH, next)

--- a/src/main/hook-installer.ts
+++ b/src/main/hook-installer.ts
@@ -52,6 +52,22 @@ function atomicWrite(path: string, contents: string): void {
   renameSync(tmp, path)
 }
 
+// JSON.parse can return any valid JSON value — null, primitives, arrays — so
+// callers that go on to read `.hooks` need to coerce non-object results back
+// to an empty object. Without this, a syntactically valid `null` or `"text"`
+// hooks file would crash session setup at the next property access.
+function parseAsObject(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    // fall through to empty object
+  }
+  return {}
+}
+
 export async function installHooks(
   projectPath: string,
   { skipGitignore = false }: { skipGitignore?: boolean } = {}
@@ -61,14 +77,9 @@ export async function installHooks(
 
   const settingsPath = join(claudeDir, 'settings.local.json')
 
-  let existing: Record<string, unknown> = {}
-  if (existsSync(settingsPath)) {
-    try {
-      existing = JSON.parse(readFileSync(settingsPath, 'utf-8'))
-    } catch {
-      existing = {}
-    }
-  }
+  const existing: Record<string, unknown> = existsSync(settingsPath)
+    ? parseAsObject(readFileSync(settingsPath, 'utf-8'))
+    : {}
 
   const newHooks = buildHooks(NOTIFY_SCRIPT)
   const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>
@@ -165,14 +176,7 @@ export async function installCodexHooks(
   // user-authored hooks that the merge step folded into the new file.
   const priorContent = existsSync(hooksPath) ? readFileSync(hooksPath, 'utf-8') : null
 
-  let existing: Record<string, unknown> = {}
-  if (priorContent !== null) {
-    try {
-      existing = JSON.parse(priorContent)
-    } catch {
-      existing = {}
-    }
-  }
+  const existing: Record<string, unknown> = priorContent !== null ? parseAsObject(priorContent) : {}
 
   const newHooks = buildCodexHooks(NOTIFY_SCRIPT)
   const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>

--- a/src/main/hook-installer.ts
+++ b/src/main/hook-installer.ts
@@ -146,19 +146,29 @@ function ensureGitignore(projectPath: string, entry: string): void {
 // Codex hook config is a JSON file at <project>/.codex/hooks.json. The shape
 // mirrors Claude's `hooks` block (event → matcher groups → handlers) but lives
 // in its own file rather than under a settings key.
+export interface CodexHooksInstallSnapshot {
+  hooksPath: string
+  priorContent: string | null
+}
+
 export async function installCodexHooks(
   projectPath: string,
   { skipGitignore = false }: { skipGitignore?: boolean } = {}
-): Promise<void> {
+): Promise<CodexHooksInstallSnapshot> {
   const codexDir = join(projectPath, '.codex')
   mkdirSync(codexDir, { recursive: true })
 
   const hooksPath = join(codexDir, 'hooks.json')
 
+  // Snapshot the prior file (or its absence) so a rollback after a partial
+  // install can restore exactly what was there — including any unrelated
+  // user-authored hooks that the merge step folded into the new file.
+  const priorContent = existsSync(hooksPath) ? readFileSync(hooksPath, 'utf-8') : null
+
   let existing: Record<string, unknown> = {}
-  if (existsSync(hooksPath)) {
+  if (priorContent !== null) {
     try {
-      existing = JSON.parse(readFileSync(hooksPath, 'utf-8'))
+      existing = JSON.parse(priorContent)
     } catch {
       existing = {}
     }
@@ -182,19 +192,36 @@ export async function installCodexHooks(
   if (!skipGitignore) {
     ensureGitignore(projectPath, '.codex/hooks.json')
   }
+
+  return { hooksPath, priorContent }
+}
+
+export interface RemoteCodexHooksSnapshot {
+  worktreePath: string
+  // True when a prior `.codex/hooks.json` existed and was backed up to
+  // `.codex/hooks.json.cc-pewpew.bak` before merge. Rollback restores from
+  // that backup. False means there was no prior file; rollback unlinks.
+  hadPrior: boolean
 }
 
 export async function installRemoteCodexHooks(
   execRemote: (argv: string[], opts?: { timeoutMs?: number }) => Promise<ExecResult>,
   worktreePath: string,
   notifyScriptPath: string
-): Promise<void> {
+): Promise<RemoteCodexHooksSnapshot> {
   const hooksJson = ccPewpewCodexHookJson(notifyScriptPath)
+  // Snapshot-and-merge in a single SSH round trip: `cp` the prior file to
+  // a known backup path (so rollback can restore unrelated user-authored
+  // hooks), then run the same merge logic as before. Echo a single line —
+  // "1" if a prior file existed, "0" otherwise — so the caller knows
+  // whether rollback should restore from the backup or unlink.
   const script =
     'set -e\n' +
     'codex_dir="$1/.codex"\n' +
     'hooks="$codex_dir/hooks.json"\n' +
+    'backup="$codex_dir/hooks.json.cc-pewpew.bak"\n' +
     'mkdir -p "$codex_dir"\n' +
+    'if [ -f "$hooks" ]; then cp "$hooks" "$backup"; printf "1"; else printf "0"; fi\n' +
     'if [ -s "$hooks" ]; then cat "$hooks"; else printf "{}"; fi |\n' +
     'jq --argjson newHooks "$2" \'\n' +
     '  .hooks = (.hooks // {}) |\n' +
@@ -210,13 +237,51 @@ export async function installRemoteCodexHooks(
     const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`
     throw new Error(`Failed to install remote codex hooks: ${detail}`)
   }
+  const hadPrior = result.stdout.trim() === '1'
+  return { worktreePath, hadPrior }
 }
 
-// Best-effort cleanup if the feature-flag enable step fails after we've already
-// written .codex/hooks.json. The caller re-throws the original error.
-export function rollbackCodexHooks(projectPath: string): void {
+export async function rollbackRemoteCodexHooks(
+  execRemote: (argv: string[], opts?: { timeoutMs?: number }) => Promise<ExecResult>,
+  snapshot: RemoteCodexHooksSnapshot
+): Promise<void> {
+  const script = snapshot.hadPrior
+    ? // Restore prior file from the backup; clean up the backup. If the
+      // backup mysteriously vanished, leave the post-merge file in place
+      // rather than deleting it (less destructive).
+      'set -e\n' +
+      'hooks="$1/.codex/hooks.json"\n' +
+      'backup="$1/.codex/hooks.json.cc-pewpew.bak"\n' +
+      'if [ -f "$backup" ]; then mv "$backup" "$hooks"; fi\n'
+    : 'set -e\n' + 'rm -f "$1/.codex/hooks.json"\n'
+  await execRemote(['sh', '-c', script, '_', snapshot.worktreePath], {
+    timeoutMs: 10000,
+  }).catch(() => undefined)
+}
+
+// Successful install: drop the .bak we left for rollback. Best-effort.
+export async function commitRemoteCodexHooks(
+  execRemote: (argv: string[], opts?: { timeoutMs?: number }) => Promise<ExecResult>,
+  snapshot: RemoteCodexHooksSnapshot
+): Promise<void> {
+  if (!snapshot.hadPrior) return
+  await execRemote(
+    ['sh', '-c', 'rm -f "$1/.codex/hooks.json.cc-pewpew.bak"', '_', snapshot.worktreePath],
+    { timeoutMs: 5000 }
+  ).catch(() => undefined)
+}
+
+// Best-effort restoration if the feature-flag enable step fails after we've
+// already written .codex/hooks.json. The snapshot lets us restore unrelated
+// user-authored hooks that the merge folded in — deleting unconditionally
+// would silently lose them. The caller re-throws the original error.
+export function rollbackCodexHooks(snapshot: CodexHooksInstallSnapshot): void {
   try {
-    rmSync(join(projectPath, '.codex', 'hooks.json'), { force: true })
+    if (snapshot.priorContent === null) {
+      rmSync(snapshot.hooksPath, { force: true })
+    } else {
+      atomicWrite(snapshot.hooksPath, snapshot.priorContent)
+    }
   } catch {
     // ignore — best-effort
   }

--- a/src/main/host-bootstrap.test.ts
+++ b/src/main/host-bootstrap.test.ts
@@ -37,22 +37,47 @@ describe('bootstrapHost', () => {
     expect(result).toEqual({
       notifyScriptPath: '/home/dev/.config/cc-pewpew/hooks/notify-v1.sh',
       remoteSocketPath: '/tmp/ipc',
+      availableAgents: { claude: true, codex: true },
     })
-    expect(calls.some((argv) => argv.includes('tmux') && argv.includes('claude'))).toBe(true)
+    expect(
+      calls.some(
+        (argv) => argv.includes('tmux') && argv.includes('claude') && argv.includes('codex')
+      )
+    ).toBe(true)
     expect(calls.some((argv) => argv.includes('/tmp/ipc'))).toBe(true)
     expect(
       calls.some((argv) => argv.includes('/home/dev/.config/cc-pewpew/hooks/notify-v1.sh'))
     ).toBe(true)
   })
 
-  it('returns a typed missing-deps error with the selective missing set', async () => {
+  it('hard-fails on missing strict deps but tolerates missing agent CLIs', async () => {
     const calls: string[][] = []
     await expect(
-      bootstrapHost('host-bootstrap-missing', fakeConnection(calls, ' jq claude\n'), '/tmp/ipc')
+      bootstrapHost('host-bootstrap-missing', fakeConnection(calls, ' jq\n'), '/tmp/ipc')
     ).rejects.toMatchObject({
       kind: 'missing-deps',
-      missingDeps: ['jq', 'claude'],
+      missingDeps: ['jq'],
     } satisfies Partial<HostBootstrapError>)
+  })
+
+  it('reports availableAgents.codex=false when only codex is missing', async () => {
+    const calls: string[][] = []
+    const result = await bootstrapHost(
+      'host-bootstrap-no-codex',
+      fakeConnection(calls, ' codex\n'),
+      '/tmp/ipc'
+    )
+    expect(result.availableAgents).toEqual({ claude: true, codex: false })
+  })
+
+  it('reports availableAgents.claude=false when only claude is missing', async () => {
+    const calls: string[][] = []
+    const result = await bootstrapHost(
+      'host-bootstrap-no-claude',
+      fakeConnection(calls, ' claude\n'),
+      '/tmp/ipc'
+    )
+    expect(result.availableAgents).toEqual({ claude: false, codex: true })
   })
 
   it('installs through a version guard so already-installed notify scripts are kept', async () => {

--- a/src/main/host-bootstrap.test.ts
+++ b/src/main/host-bootstrap.test.ts
@@ -91,4 +91,35 @@ describe('bootstrapHost', () => {
     expect(installCall?.[2]).toContain('grep -q "CC_PEWPEW_NOTIFY_VERSION=$5"')
     expect(installCall).toContain(String(NOTIFY_SCRIPT_VERSION))
   })
+
+  it('re-probes agent availability on cache hits (codex installed after first bootstrap)', async () => {
+    // First call: codex missing on remote.
+    let depsStdout = ' codex\n'
+    const calls: string[][] = []
+    const conn: HostBootstrapConnection = {
+      exec: async (argv) => {
+        calls.push(argv)
+        const script = argv[2]
+        if (script.includes('command -v')) return ok(depsStdout)
+        if (script === 'test -S "$1"') return ok()
+        if (script.includes('XDG_CONFIG_HOME')) return ok('/home/dev/.config')
+        return ok()
+      },
+    }
+
+    const first = await bootstrapHost('host-reprobe', conn, '/tmp/ipc')
+    expect(first.availableAgents).toEqual({ claude: true, codex: false })
+
+    // User installs codex out-of-band; second call must reflect it.
+    depsStdout = '\n'
+    const second = await bootstrapHost('host-reprobe', conn, '/tmp/ipc')
+    expect(second.availableAgents).toEqual({ claude: true, codex: true })
+
+    // Sanity: the heavy install path didn't run twice. The "notify-v" install
+    // command should appear at most once even though we bootstrapped twice.
+    const installCalls = calls.filter((argv) =>
+      argv.some((part) => part.includes(`notify-v${NOTIFY_SCRIPT_VERSION}.sh`))
+    )
+    expect(installCalls).toHaveLength(1)
+  })
 })

--- a/src/main/host-bootstrap.test.ts
+++ b/src/main/host-bootstrap.test.ts
@@ -122,4 +122,45 @@ describe('bootstrapHost', () => {
     )
     expect(installCalls).toHaveLength(1)
   })
+
+  it('throws install-failed when the agent probe times out on a cache hit', async () => {
+    // Prime the cache with a successful first bootstrap.
+    const calls: string[][] = []
+    const okConn = fakeConnection(calls)
+    await bootstrapHost('host-probe-fail', okConn, '/tmp/ipc')
+
+    // Second call: probe times out. Must NOT silently report both agents
+    // unavailable — that would surface as a misleading "<tool> not installed"
+    // downstream.
+    const failingConn: HostBootstrapConnection = {
+      exec: async (argv) => {
+        const script = argv[2]
+        if (script.includes('command -v')) {
+          return { stdout: '', stderr: '', code: 0, timedOut: true }
+        }
+        return ok()
+      },
+    }
+    await expect(bootstrapHost('host-probe-fail', failingConn, '/tmp/ipc')).rejects.toMatchObject({
+      kind: 'install-failed',
+    })
+  })
+
+  it('throws install-failed when the agent probe exits non-zero on a cache hit', async () => {
+    const calls: string[][] = []
+    await bootstrapHost('host-probe-nonzero', fakeConnection(calls), '/tmp/ipc')
+
+    const failingConn: HostBootstrapConnection = {
+      exec: async (argv) => {
+        const script = argv[2]
+        if (script.includes('command -v')) {
+          return { stdout: '', stderr: 'permission denied', code: 1, timedOut: false }
+        }
+        return ok()
+      },
+    }
+    await expect(
+      bootstrapHost('host-probe-nonzero', failingConn, '/tmp/ipc')
+    ).rejects.toMatchObject({ kind: 'install-failed' })
+  })
 })

--- a/src/main/host-bootstrap.ts
+++ b/src/main/host-bootstrap.ts
@@ -57,13 +57,47 @@ export interface HostBootstrapConnection {
 
 export type AgentAvailability = Record<AgentTool, boolean>
 
+// The cached portion of bootstrap — the parts that genuinely don't change
+// between calls (notify script install, socket path). Agent availability is
+// deliberately *not* cached because users install/remove `claude` or `codex`
+// out-of-band, and stale availability would block valid session creation.
+interface CachedBootstrap {
+  notifyScriptPath: string
+  remoteSocketPath: string
+}
+
 export interface HostBootstrapResult {
   notifyScriptPath: string
   remoteSocketPath: string
   availableAgents: AgentAvailability
 }
 
-const bootstrapped = new Map<string, HostBootstrapResult>()
+const bootstrapped = new Map<string, CachedBootstrap>()
+
+// Probe just the agent CLIs. Cheap — single SSH exec — so we re-run on every
+// bootstrapHost call to pick up codex/claude installs/removals that happened
+// after the first bootstrap. This is in the hot path of session creation,
+// not session attach, so the latency is bounded.
+export async function probeRemoteAgents(
+  connection: HostBootstrapConnection
+): Promise<AgentAvailability> {
+  const probe =
+    'missing=""; for dep in "$@"; do command -v "$dep" >/dev/null 2>&1 || missing="$missing $dep"; done; printf "%s\\n" "$missing"'
+  const result = await connection.exec(['sh', '-c', probe, '_', ...AGENT_DEPS], {
+    timeoutMs: 10000,
+  })
+  if (result.timedOut || result.code !== 0) {
+    // Fail closed: if we can't probe, treat both as unavailable so callers
+    // get a clear "not installed" error rather than silently spawning a
+    // session that immediately dies.
+    return { claude: false, codex: false }
+  }
+  const missing = new Set(result.stdout.trim().split(/\s+/).filter(Boolean))
+  return {
+    claude: !missing.has('claude'),
+    codex: !missing.has('codex'),
+  }
+}
 
 // Called when the SSH target for a host changes (alias edit). Drops the cached
 // bootstrap result so the next session re-probes dependencies and reinstalls
@@ -90,7 +124,12 @@ export async function bootstrapHost(
   remoteSocketPath: string
 ): Promise<HostBootstrapResult> {
   const cached = bootstrapped.get(hostId)
-  if (cached && cached.remoteSocketPath === remoteSocketPath) return cached
+  if (cached && cached.remoteSocketPath === remoteSocketPath) {
+    // Cache hit on the heavy work — but always re-probe agents to reflect
+    // out-of-band installs/removals.
+    const availableAgents = await probeRemoteAgents(connection)
+    return { ...cached, availableAgents }
+  }
 
   const allDeps = [...STRICT_DEPS, ...AGENT_DEPS]
   const depProbe =
@@ -165,7 +204,6 @@ export async function bootstrapHost(
   )
   await expectOk(install, 'install-failed', 'Unable to install remote notify hook')
 
-  const result: HostBootstrapResult = { notifyScriptPath, remoteSocketPath, availableAgents }
-  bootstrapped.set(hostId, result)
-  return result
+  bootstrapped.set(hostId, { notifyScriptPath, remoteSocketPath })
+  return { notifyScriptPath, remoteSocketPath, availableAgents }
 }

--- a/src/main/host-bootstrap.ts
+++ b/src/main/host-bootstrap.ts
@@ -1,9 +1,11 @@
 import { posix } from 'path'
 import type { ExecResult } from './host-connection'
+import type { AgentTool } from '../shared/types'
 
 export const NOTIFY_SCRIPT_VERSION = 1
 
-const REQUIRED_DEPS = ['tmux', 'git', 'jq', 'socat', 'claude'] as const
+const STRICT_DEPS = ['tmux', 'git', 'jq', 'socat'] as const
+const AGENT_DEPS: readonly AgentTool[] = ['claude', 'codex'] as const
 
 const notifyScript = `#!/usr/bin/env bash
 # cc-pewpew notify script v${NOTIFY_SCRIPT_VERSION}
@@ -53,9 +55,12 @@ export interface HostBootstrapConnection {
   exec(argv: string[], opts?: { timeoutMs?: number }): Promise<ExecResult>
 }
 
+export type AgentAvailability = Record<AgentTool, boolean>
+
 export interface HostBootstrapResult {
   notifyScriptPath: string
   remoteSocketPath: string
+  availableAgents: AgentAvailability
 }
 
 const bootstrapped = new Map<string, HostBootstrapResult>()
@@ -87,19 +92,25 @@ export async function bootstrapHost(
   const cached = bootstrapped.get(hostId)
   if (cached && cached.remoteSocketPath === remoteSocketPath) return cached
 
+  const allDeps = [...STRICT_DEPS, ...AGENT_DEPS]
   const depProbe =
     'missing=""; for dep in "$@"; do command -v "$dep" >/dev/null 2>&1 || missing="$missing $dep"; done; printf "%s\\n" "$missing"'
-  const deps = await connection.exec(['sh', '-c', depProbe, '_', ...REQUIRED_DEPS], {
+  const deps = await connection.exec(['sh', '-c', depProbe, '_', ...allDeps], {
     timeoutMs: 15000,
   })
   await expectOk(deps, 'missing-deps', 'Dependency probe failed')
-  const missingDeps = deps.stdout.trim().split(/\s+/).filter(Boolean)
-  if (missingDeps.length > 0) {
+  const missing = new Set(deps.stdout.trim().split(/\s+/).filter(Boolean))
+  const missingStrict = STRICT_DEPS.filter((d) => missing.has(d))
+  if (missingStrict.length > 0) {
     throw new HostBootstrapError(
       'missing-deps',
-      `Remote host is missing required tools: ${missingDeps.join(', ')}`,
-      missingDeps
+      `Remote host is missing required tools: ${missingStrict.join(', ')}`,
+      missingStrict
     )
+  }
+  const availableAgents: AgentAvailability = {
+    claude: !missing.has('claude'),
+    codex: !missing.has('codex'),
   }
 
   const socketProbe = await connection.exec(['sh', '-c', 'test -S "$1"', '_', remoteSocketPath], {
@@ -154,7 +165,7 @@ export async function bootstrapHost(
   )
   await expectOk(install, 'install-failed', 'Unable to install remote notify hook')
 
-  const result = { notifyScriptPath, remoteSocketPath }
+  const result: HostBootstrapResult = { notifyScriptPath, remoteSocketPath, availableAgents }
   bootstrapped.set(hostId, result)
   return result
 }

--- a/src/main/host-bootstrap.ts
+++ b/src/main/host-bootstrap.ts
@@ -86,11 +86,16 @@ export async function probeRemoteAgents(
   const result = await connection.exec(['sh', '-c', probe, '_', ...AGENT_DEPS], {
     timeoutMs: 10000,
   })
-  if (result.timedOut || result.code !== 0) {
-    // Fail closed: if we can't probe, treat both as unavailable so callers
-    // get a clear "not installed" error rather than silently spawning a
-    // session that immediately dies.
-    return { claude: false, codex: false }
+  // Surface probe failures as a typed bootstrap error rather than masquerading
+  // as "agent not installed". A transient SSH timeout otherwise shows up as a
+  // misleading "<tool> is not installed on host X" message that leads users to
+  // reinstall a binary that's actually present.
+  if (result.timedOut) {
+    throw new HostBootstrapError('install-failed', 'Agent availability probe timed out')
+  }
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`
+    throw new HostBootstrapError('install-failed', `Agent availability probe failed: ${detail}`)
   }
   const missing = new Set(result.stdout.trim().split(/\s+/).filter(Boolean))
   return {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,6 +63,7 @@ import {
   validateRemotePath,
 } from './remote-project-registry'
 import type {
+  AgentTool,
   DiffMode,
   ReviewBranchesResult,
   ReviewDefaultBranchResult,
@@ -264,8 +265,14 @@ app.whenReady().then(async () => {
 
   ipcMain.handle(
     'sessions:create',
-    async (_event, projectPath: string, name?: string, hostId?: string | null) => {
-      return createSession(projectPath, name, hostId ?? null)
+    async (
+      _event,
+      projectPath: string,
+      name?: string,
+      hostId?: string | null,
+      tool?: AgentTool
+    ) => {
+      return createSession(projectPath, name, hostId ?? null, tool)
     }
   )
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -560,6 +560,10 @@ app.whenReady().then(async () => {
     return getConfig().uiScale
   })
 
+  ipcMain.handle('config:get-default-tool', () => {
+    return getConfig().defaultTool
+  })
+
   ipcMain.handle('swim-lanes:open', (_event, sessionIds: string[]) => {
     const swimWindow = new BrowserWindow({
       width: 1200,

--- a/src/main/pty-manager.test.ts
+++ b/src/main/pty-manager.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { buildAgentArgs } from './pty-manager'
+
+describe('buildAgentArgs', () => {
+  it('defaults to claude with --dangerously-skip-permissions', () => {
+    expect(buildAgentArgs()).toEqual(['claude', '--dangerously-skip-permissions'])
+  })
+
+  it('claude with continueSession appends --continue', () => {
+    expect(buildAgentArgs({ tool: 'claude', continueSession: true })).toEqual([
+      'claude',
+      '--dangerously-skip-permissions',
+      '--continue',
+    ])
+  })
+
+  it('codex without resume uses bypass flag only', () => {
+    expect(buildAgentArgs({ tool: 'codex' })).toEqual([
+      'codex',
+      '--dangerously-bypass-approvals-and-sandbox',
+    ])
+  })
+
+  it('codex with continueSession + agentSessionId emits resume <id>', () => {
+    expect(
+      buildAgentArgs({
+        tool: 'codex',
+        continueSession: true,
+        agentSessionId: 'abc-123',
+      })
+    ).toEqual(['codex', 'resume', 'abc-123', '--dangerously-bypass-approvals-and-sandbox'])
+  })
+
+  it('codex with continueSession but no agentSessionId falls back to fresh spawn', () => {
+    expect(buildAgentArgs({ tool: 'codex', continueSession: true })).toEqual([
+      'codex',
+      '--dangerously-bypass-approvals-and-sandbox',
+    ])
+  })
+})

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -12,7 +12,31 @@ import {
 } from './host-connection'
 import { classifySshExit } from './ssh-exit-parser'
 import { captureRemotePaneTexts, type RemoteSessionEntry } from './remote-thumbnail'
-import type { Host } from '../shared/types'
+import type { AgentTool, Host } from '../shared/types'
+
+interface SpawnOptions {
+  continueSession?: boolean
+  tool?: AgentTool
+  agentSessionId?: string
+}
+
+export function buildAgentArgs(options?: SpawnOptions): string[] {
+  const tool = options?.tool ?? 'claude'
+  if (tool === 'codex') {
+    if (options?.continueSession && options?.agentSessionId) {
+      return [
+        'codex',
+        'resume',
+        options.agentSessionId,
+        '--dangerously-bypass-approvals-and-sandbox',
+      ]
+    }
+    return ['codex', '--dangerously-bypass-approvals-and-sandbox']
+  }
+  const args = ['claude', '--dangerously-skip-permissions']
+  if (options?.continueSession) args.push('--continue')
+  return args
+}
 
 interface PtyEntry {
   pty: IPty
@@ -54,11 +78,7 @@ export function stopPtyManager(): void {
   }
 }
 
-export function createPty(
-  sessionId: string,
-  cwd: string,
-  options?: { continueSession?: boolean }
-): void {
+export function createPty(sessionId: string, cwd: string, options?: SpawnOptions): void {
   if (!existsSync(cwd)) {
     throw new Error(`Working directory does not exist: ${cwd}`)
   }
@@ -72,13 +92,9 @@ export function createPty(
   }
 
   const tmuxSession = `cc-pewpew-${sessionId}`
+  const agentArgs = buildAgentArgs(options)
 
-  const claudeArgs = ['claude', '--dangerously-skip-permissions']
-  if (options?.continueSession) {
-    claudeArgs.push('--continue')
-  }
-
-  // Create a detached tmux session that directly runs claude
+  // Create a detached tmux session that directly runs the agent CLI.
   // Using tmux's shell command avoids issues with interactive shell init (omz, etc.)
   execFileSync('tmux', [
     'new-session',
@@ -91,7 +107,7 @@ export function createPty(
     '120',
     '-y',
     '30',
-    ...claudeArgs,
+    ...agentArgs,
   ])
 
   // Attach to it via node-pty
@@ -130,14 +146,10 @@ export async function createRemotePty(
   sessionId: string,
   cwd: string,
   host: Host,
-  options?: { continueSession?: boolean }
+  options?: SpawnOptions
 ): Promise<void> {
   const tmuxSession = `cc-pewpew-${sessionId}`
-
-  const claudeArgs = ['claude', '--dangerously-skip-permissions']
-  if (options?.continueSession) {
-    claudeArgs.push('--continue')
-  }
+  const agentArgs = buildAgentArgs(options)
 
   const create = await execRemote(host, [
     'tmux',
@@ -151,7 +163,7 @@ export async function createRemotePty(
     '120',
     '-y',
     '30',
-    ...claudeArgs,
+    ...agentArgs,
   ])
   if (create.timedOut || create.code !== 0) {
     const detail = create.stderr.trim() || create.stdout.trim() || `exit ${create.code}`

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -203,6 +203,7 @@ function baseRemoteSession(overrides: Partial<Session>): Session {
     status: 'idle',
     lastActivity: 1000,
     hookEvents: [],
+    tool: 'claude',
     ...overrides,
   }
 }
@@ -221,6 +222,7 @@ function baseLocalSession(overrides: Partial<Session>): Session {
     status: 'idle',
     lastActivity: 1000,
     hookEvents: [],
+    tool: 'claude',
     ...overrides,
   }
 }
@@ -841,5 +843,78 @@ describe('removeSessionsForHost (issue #14)', () => {
     expect(sm.getSessions().map((s) => s.id)).toEqual(['rA1'])
     expect(state.detachPtyCalls).toEqual([])
     expect(state.sessionsUpdatedBroadcasts).toBe(0)
+  })
+})
+
+describe('codex agent integration', () => {
+  it('backfills tool="claude" on legacy sessions missing the field', async () => {
+    // Persisted JSON omits `tool` to simulate a session created before the
+    // multi-agent change; restoreSessions must default it without crashing.
+    writeFileSync(
+      join(state.configDir, 'sessions.json'),
+      JSON.stringify([
+        {
+          id: 'legacy1',
+          hostId: null,
+          projectPath: '/p',
+          projectName: 'p',
+          worktreeName: 'w',
+          worktreePath: '/p/w',
+          branch: 'main',
+          pid: 0,
+          tmuxSession: 'cc-pewpew-legacy1',
+          status: 'idle',
+          lastActivity: 0,
+          hookEvents: [],
+        },
+      ])
+    )
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    const restored = sm.getSessions().find((s) => s.id === 'legacy1')
+    expect(restored?.tool).toBe('claude')
+  })
+
+  it('handleHookEvent session.start captures codex session_id as agentSessionId', async () => {
+    writeSessionsJson([baseLocalSession({ id: 'cx1', tool: 'codex', worktreePath: '/cx/wt' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.handleHookEvent('session.start', { cwd: '/cx/wt', session_id: 'codex-uuid-9' }, null)
+    const updated = sm.getSessions().find((s) => s.id === 'cx1')
+    expect(updated?.agentSessionId).toBe('codex-uuid-9')
+  })
+
+  it('handleHookEvent session.stop sets needs_input for codex sessions (parity with claude)', async () => {
+    writeSessionsJson([baseLocalSession({ id: 'cx2', tool: 'codex', worktreePath: '/cx/wt2' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.handleHookEvent('session.stop', { cwd: '/cx/wt2' }, null)
+    const updated = sm.getSessions().find((s) => s.id === 'cx2')
+    expect(updated?.status).toBe('needs_input')
+  })
+
+  it('does not overwrite agentSessionId once captured', async () => {
+    writeSessionsJson([
+      baseLocalSession({
+        id: 'cx3',
+        tool: 'codex',
+        worktreePath: '/cx/wt3',
+        agentSessionId: 'first',
+      }),
+    ])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.handleHookEvent('session.start', { cwd: '/cx/wt3', session_id: 'second' }, null)
+    const updated = sm.getSessions().find((s) => s.id === 'cx3')
+    expect(updated?.agentSessionId).toBe('first')
+  })
+
+  it('claude session.start does not set agentSessionId', async () => {
+    writeSessionsJson([baseLocalSession({ id: 'cl1', tool: 'claude', worktreePath: '/cl/wt' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.handleHookEvent('session.start', { cwd: '/cl/wt', session_id: 'should-not-store' }, null)
+    const updated = sm.getSessions().find((s) => s.id === 'cl1')
+    expect(updated?.agentSessionId).toBeUndefined()
   })
 })

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -33,6 +33,8 @@ import {
   ensureCodexHooksFeatureFlag,
   ensureRemoteCodexHooksFeatureFlag,
   rollbackCodexHooks,
+  rollbackRemoteCodexHooks,
+  commitRemoteCodexHooks,
 } from './hook-installer'
 import { getHost } from './host-registry'
 import { listRemoteProjects } from './remote-project-registry'
@@ -444,11 +446,11 @@ export async function createSessionForWorktree(
 
 async function installAgentHooks(tool: AgentTool, worktreePath: string): Promise<void> {
   if (tool === 'codex') {
-    await installCodexHooks(worktreePath, { skipGitignore: true })
+    const snapshot = await installCodexHooks(worktreePath, { skipGitignore: true })
     try {
       ensureCodexHooksFeatureFlag()
     } catch (err) {
-      rollbackCodexHooks(worktreePath)
+      rollbackCodexHooks(snapshot)
       throw err
     }
     return
@@ -545,16 +547,14 @@ async function installRemoteAgentHooks(
 ): Promise<void> {
   const remote = (argv: string[], opts?: { timeoutMs?: number }) => execRemote(host, argv, opts)
   if (tool === 'codex') {
-    await installRemoteCodexHooks(remote, worktreePath, notifyScriptPath)
+    const snapshot = await installRemoteCodexHooks(remote, worktreePath, notifyScriptPath)
     try {
       await ensureRemoteCodexHooksFeatureFlag(remote)
     } catch (err) {
-      // Best-effort rollback of the just-written hooks.json
-      await remote(['sh', '-c', 'rm -f "$1/.codex/hooks.json"', '_', worktreePath]).catch(
-        () => undefined
-      )
+      await rollbackRemoteCodexHooks(remote, snapshot)
       throw err
     }
+    await commitRemoteCodexHooks(remote, snapshot)
     return
   }
   await installRemoteHooks(remote, worktreePath, notifyScriptPath)

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -411,7 +411,14 @@ async function isGitWorktree(worktreePath: string): Promise<boolean> {
 // In-flight adoption promises keyed by canonical worktree path. Serializes
 // concurrent mirror requests for the same path (e.g. double-click on + Mirror,
 // racing against mirrorAllWorktrees) so only one session/PTY is created.
-const inflightAdoptions = new Map<string, Promise<Session>>()
+// Tracks the tool the in-flight adoption is using so a concurrent call with a
+// different tool gets a mixed-tool error rather than silently sharing the
+// wrong agent's session.
+interface InflightAdoption {
+  promise: Promise<Session>
+  tool: AgentTool
+}
+const inflightAdoptions = new Map<string, InflightAdoption>()
 
 export async function createSessionForWorktree(
   projectPath: string,
@@ -433,10 +440,17 @@ export async function createSessionForWorktree(
   }
 
   const inflight = inflightAdoptions.get(target)
-  if (inflight) return inflight
+  if (inflight) {
+    if (inflight.tool !== effectiveTool) {
+      throw new Error(
+        `Worktree already has a ${inflight.tool} session in-flight; mixed tools per worktree are not supported`
+      )
+    }
+    return inflight.promise
+  }
 
   const promise = adoptWorktree(projectPath, worktreePath, label, effectiveTool)
-  inflightAdoptions.set(target, promise)
+  inflightAdoptions.set(target, { promise, tool: effectiveTool })
   try {
     return await promise
   } finally {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -25,7 +25,15 @@ import {
   createRemotePty,
 } from './pty-manager'
 import { getRepoFingerprint, gitWorktrees } from './project-scanner'
-import { installHooks, installRemoteHooks } from './hook-installer'
+import {
+  installHooks,
+  installRemoteHooks,
+  installCodexHooks,
+  installRemoteCodexHooks,
+  ensureCodexHooksFeatureFlag,
+  ensureRemoteCodexHooksFeatureFlag,
+  rollbackCodexHooks,
+} from './hook-installer'
 import { getHost } from './host-registry'
 import { listRemoteProjects } from './remote-project-registry'
 import { listenHookServerForHost } from './hook-server'
@@ -41,7 +49,7 @@ import {
 } from './host-connection'
 import { bootstrapHost, HostBootstrapError } from './host-bootstrap'
 import { emitToast } from './notifications'
-import type { Host, RemoteProject, Session, SessionStatus } from '../shared/types'
+import type { AgentTool, Host, RemoteProject, Session, SessionStatus } from '../shared/types'
 
 const execFileAsync = promisify(execFile)
 const SESSIONS_PATH = join(CONFIG_DIR, 'sessions.json')
@@ -115,7 +123,9 @@ function getRequiredHost(hostId: string): Host {
 // failure still has to tear down the hook listener we started first (the
 // reverse-forward target); stopHostConnection triggers the
 // setOnHostConnectionStopped callback to do that.
-async function prepareRemoteHost(host: Host): Promise<{ notifyScriptPath: string }> {
+async function prepareRemoteHost(
+  host: Host
+): Promise<{ notifyScriptPath: string; availableAgents: { claude: boolean; codex: boolean } }> {
   const localSocketPath = listenHookServerForHost(host.hostId)
   let remoteSocketPath: string
   try {
@@ -148,7 +158,10 @@ async function prepareRemoteHost(host: Host): Promise<{ notifyScriptPath: string
       },
       remoteSocketPath
     )
-    return { notifyScriptPath: bootstrap.notifyScriptPath }
+    return {
+      notifyScriptPath: bootstrap.notifyScriptPath,
+      availableAgents: bootstrap.availableAgents,
+    }
   } catch (err) {
     await releaseHostConnection(host.hostId).catch(() => undefined)
     if (err instanceof HostBootstrapError) {
@@ -401,17 +414,26 @@ const inflightAdoptions = new Map<string, Promise<Session>>()
 export async function createSessionForWorktree(
   projectPath: string,
   worktreePath: string,
-  label?: string
+  label?: string,
+  tool?: AgentTool
 ): Promise<Session> {
+  const effectiveTool: AgentTool = tool ?? getConfig().defaultTool
   const target = canonicalPath(worktreePath)
   for (const e of sessions.values()) {
-    if (canonicalPath(e.session.worktreePath) === target) return e.session
+    if (canonicalPath(e.session.worktreePath) === target) {
+      if (e.session.tool !== effectiveTool) {
+        throw new Error(
+          `Worktree already has a ${e.session.tool} session; mixed tools per worktree are not supported`
+        )
+      }
+      return e.session
+    }
   }
 
   const inflight = inflightAdoptions.get(target)
   if (inflight) return inflight
 
-  const promise = adoptWorktree(projectPath, worktreePath, label)
+  const promise = adoptWorktree(projectPath, worktreePath, label, effectiveTool)
   inflightAdoptions.set(target, promise)
   try {
     return await promise
@@ -420,10 +442,25 @@ export async function createSessionForWorktree(
   }
 }
 
+async function installAgentHooks(tool: AgentTool, worktreePath: string): Promise<void> {
+  if (tool === 'codex') {
+    await installCodexHooks(worktreePath, { skipGitignore: true })
+    try {
+      ensureCodexHooksFeatureFlag()
+    } catch (err) {
+      rollbackCodexHooks(worktreePath)
+      throw err
+    }
+    return
+  }
+  await installHooks(worktreePath, { skipGitignore: true })
+}
+
 async function adoptWorktree(
   projectPath: string,
   worktreePath: string,
-  label: string | undefined
+  label: string | undefined,
+  tool: AgentTool
 ): Promise<Session> {
   if (!(await isGitWorktree(worktreePath))) {
     throw new Error(`${worktreePath} is not a valid git worktree`)
@@ -438,8 +475,8 @@ async function adoptWorktree(
   const tmuxSession = `cc-pewpew-${id}`
   const branch = resolveBranchFromWorktree(worktreePath, worktreeName)
 
-  await installHooks(worktreePath, { skipGitignore: true })
-  createPty(id, worktreePath)
+  await installAgentHooks(tool, worktreePath)
+  createPty(id, worktreePath, { tool })
 
   const session: Session = {
     id,
@@ -455,6 +492,7 @@ async function adoptWorktree(
     status: 'running',
     lastActivity: Date.now(),
     hookEvents: [],
+    tool,
   }
 
   sessions.set(id, { session })
@@ -499,15 +537,53 @@ export async function mirrorAllWorktrees(projectPath: string): Promise<MirrorAll
   return { mirrored, failed }
 }
 
+async function installRemoteAgentHooks(
+  tool: AgentTool,
+  host: Host,
+  worktreePath: string,
+  notifyScriptPath: string
+): Promise<void> {
+  const remote = (argv: string[], opts?: { timeoutMs?: number }) => execRemote(host, argv, opts)
+  if (tool === 'codex') {
+    await installRemoteCodexHooks(remote, worktreePath, notifyScriptPath)
+    try {
+      await ensureRemoteCodexHooksFeatureFlag(remote)
+    } catch (err) {
+      // Best-effort rollback of the just-written hooks.json
+      await remote(['sh', '-c', 'rm -f "$1/.codex/hooks.json"', '_', worktreePath]).catch(
+        () => undefined
+      )
+      throw err
+    }
+    return
+  }
+  await installRemoteHooks(remote, worktreePath, notifyScriptPath)
+}
+
 async function createRemoteSession(
   hostId: string,
   projectPath: string,
-  name?: string
+  name?: string,
+  tool?: AgentTool
 ): Promise<Session> {
+  const effectiveTool: AgentTool = tool ?? getConfig().defaultTool
   const host = getRequiredHost(hostId)
   const remoteProject = getRemoteProject(hostId, projectPath)
   const worktreeName = name || `session-${randomUUID().slice(0, 8)}`
   const worktreePath = posix.join(projectPath, '.claude', 'worktrees', worktreeName)
+
+  for (const e of sessions.values()) {
+    if (
+      e.session.hostId === hostId &&
+      e.session.worktreePath === worktreePath &&
+      e.session.tool !== effectiveTool
+    ) {
+      throw new Error(
+        `Worktree already has a ${e.session.tool} session; mixed tools per worktree are not supported`
+      )
+    }
+  }
+
   const id = randomUUID().slice(0, 8)
   const tmuxSession = `cc-pewpew-${id}`
   const branchName = `cc-pewpew/${worktreeName}`
@@ -515,7 +591,11 @@ async function createRemoteSession(
   // prepareRemoteHost retains the SSH runtime on success; we own the ref and
   // release it at the end (or in catch). createRemotePty takes its own retain
   // on success, which is what keeps the connection alive past this function.
-  const { notifyScriptPath } = await prepareRemoteHost(host)
+  const { notifyScriptPath, availableAgents } = await prepareRemoteHost(host)
+  if (!availableAgents[effectiveTool]) {
+    await releaseHostConnection(hostId).catch(() => undefined)
+    throw new Error(`${effectiveTool} is not installed on host ${host.label || host.alias}`)
+  }
   let branch: string
   try {
     const addWithBranch = await execRemote(host, [
@@ -545,12 +625,8 @@ async function createRemoteSession(
         )
       ).trim() || branchName
 
-    await installRemoteHooks(
-      (argv, opts) => execRemote(host, argv, opts),
-      worktreePath,
-      notifyScriptPath
-    )
-    await createRemotePty(id, worktreePath, host)
+    await installRemoteAgentHooks(effectiveTool, host, worktreePath, notifyScriptPath)
+    await createRemotePty(id, worktreePath, host, { tool: effectiveTool })
   } catch (err) {
     await releaseHostConnection(hostId).catch(() => undefined)
     throw err
@@ -572,6 +648,7 @@ async function createRemoteSession(
     connectionState: 'live',
     lastActivity: Date.now(),
     hookEvents: [],
+    tool: effectiveTool,
     ...(remoteProject.repoFingerprint ? { repoFingerprint: remoteProject.repoFingerprint } : {}),
   }
 
@@ -583,9 +660,10 @@ async function createRemoteSession(
 export async function createSession(
   projectPath: string,
   name?: string,
-  hostId: string | null = null
+  hostId: string | null = null,
+  tool?: AgentTool
 ): Promise<Session> {
-  if (hostId) return createRemoteSession(hostId, projectPath, name)
+  if (hostId) return createRemoteSession(hostId, projectPath, name, tool)
 
   const worktreeName = name || `session-${randomUUID().slice(0, 8)}`
   const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
@@ -605,7 +683,7 @@ export async function createSession(
     await execFileAsync('git', ['-C', projectPath, 'worktree', 'add', worktreePath])
   }
 
-  return createSessionForWorktree(projectPath, worktreePath, worktreeName)
+  return createSessionForWorktree(projectPath, worktreePath, worktreeName, tool)
 }
 
 export function handleHookEvent(
@@ -640,6 +718,12 @@ export function handleHookEvent(
     case 'session.start':
       entry.session.status = 'running'
       entry.session.connectionState = originHostId ? 'live' : entry.session.connectionState
+      // Capture codex's session_id so `codex resume <id>` can recover the same
+      // conversation after restart. Claude resumes via `--continue` and doesn't
+      // need this.
+      if (entry.session.tool === 'codex' && ccSessionId && !entry.session.agentSessionId) {
+        entry.session.agentSessionId = ccSessionId
+      }
       break
     case 'session.stop':
       entry.session.status = 'needs_input'
@@ -971,7 +1055,11 @@ export async function reviveSession(id: string): Promise<void> {
       if (await hasRemoteTmuxSession(id, host)) {
         await reattachRemotePty(id, host)
       } else {
-        await createRemotePty(id, session.worktreePath, host, { continueSession: true })
+        await createRemotePty(id, session.worktreePath, host, {
+          continueSession: true,
+          tool: session.tool,
+          agentSessionId: session.agentSessionId,
+        })
       }
     } catch (err) {
       session.connectionState = 'offline'
@@ -990,7 +1078,11 @@ export async function reviveSession(id: string): Promise<void> {
   if (hasTmuxSession(id)) {
     reattachPty(id)
   } else {
-    createPty(id, session.worktreePath, { continueSession: true })
+    createPty(id, session.worktreePath, {
+      continueSession: true,
+      tool: session.tool,
+      agentSessionId: session.agentSessionId,
+    })
   }
   updateSession(id, 'idle')
 }
@@ -1210,7 +1302,7 @@ export async function relocateProject(
     if (hasPty(s.id)) {
       destroyPty(s.id)
       if (existsSync(s.worktreePath)) {
-        createPty(s.id, s.worktreePath)
+        createPty(s.id, s.worktreePath, { tool: s.tool })
         s.status = 'idle'
       } else {
         s.status = 'dead'
@@ -1229,7 +1321,14 @@ export async function relocateProject(
   }
   saveConfig(config)
 
-  await installHooks(newProjectPath)
+  const toolsInUse = new Set(toMigrate.map((e) => e.session.tool))
+  if (toolsInUse.has('claude') || toolsInUse.size === 0) {
+    await installHooks(newProjectPath)
+  }
+  if (toolsInUse.has('codex')) {
+    await installCodexHooks(newProjectPath)
+    ensureCodexHooksFeatureFlag()
+  }
   onSessionsChanged()
 
   return { migratedCount: toMigrate.length }
@@ -1253,6 +1352,7 @@ function backfillDerivedFields(session: Session): void {
     const m = session.worktreeName.match(/^pr-(\d+)$/)
     if (m) session.prNumber = parseInt(m[1], 10)
   }
+  if (!session.tool) session.tool = 'claude'
 }
 
 export function restoreSessions(): void {
@@ -1308,7 +1408,17 @@ export function restoreSessions(): void {
           // tmux server lost the session (e.g., PC reboot) but the worktree
           // survives — auto-recreate and resume the claude conversation.
           try {
-            createPty(session.id, session.worktreePath, { continueSession: true })
+            const canResume = session.tool !== 'codex' || !!session.agentSessionId
+            if (session.tool === 'codex' && !session.agentSessionId) {
+              console.warn(
+                `codex session ${session.id} has no agentSessionId; spawning fresh instead of resuming`
+              )
+            }
+            createPty(session.id, session.worktreePath, {
+              continueSession: canResume,
+              tool: session.tool,
+              agentSessionId: session.agentSessionId,
+            })
             session.status = resumedStatus
             recoveredCount++
           } catch (err) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -51,6 +51,7 @@ contextBridge.exposeInMainWorld('api', {
   getSidebarWidth: () => ipcRenderer.invoke('config:get-sidebar-width'),
   saveSidebarWidth: (width: number) => ipcRenderer.invoke('config:save-sidebar-width', width),
   getUiScale: () => ipcRenderer.invoke('config:get-ui-scale'),
+  getDefaultTool: () => ipcRenderer.invoke('config:get-default-tool') as Promise<AgentTool>,
   onTextThumbnails: (callback: (data: Record<string, string>) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: Record<string, string>) =>
       callback(data)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { ToastEvent } from '../shared/types'
+import type { AgentTool, ToastEvent } from '../shared/types'
 
 contextBridge.exposeInMainWorld('api', {
   scanProjects: () => ipcRenderer.invoke('projects:scan'),
@@ -14,8 +14,8 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.on('hook:event', handler)
     return () => ipcRenderer.removeListener('hook:event', handler)
   },
-  createSession: (projectPath: string, name?: string, hostId?: string | null) =>
-    ipcRenderer.invoke('sessions:create', projectPath, name, hostId ?? null),
+  createSession: (projectPath: string, name?: string, hostId?: string | null, tool?: AgentTool) =>
+    ipcRenderer.invoke('sessions:create', projectPath, name, hostId ?? null, tool),
   createPrSession: (projectPath: string, prNumber: number) =>
     ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber),
   mirrorWorktree: (projectPath: string, worktreePath: string) =>

--- a/src/renderer/components/DetailPane.tsx
+++ b/src/renderer/components/DetailPane.tsx
@@ -48,9 +48,14 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
     refocusTerminal()
   }, [refocusTerminal])
 
+  // Review is Claude-only for now. Codex's diff/review flow is deferred to a
+  // separate slice (see issue #50). Gating both the trigger and the overlay
+  // keeps codex sessions out of the flip path entirely.
+  const reviewEnabled = !session || session.tool === 'claude'
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === 'r') {
+      if (e.ctrlKey && e.key === 'r' && reviewEnabled) {
         e.preventDefault()
         e.stopPropagation()
         setFlipCount((c) => {
@@ -81,7 +86,7 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
     }
     document.addEventListener('keydown', handler, true)
     return () => document.removeEventListener('keydown', handler, true)
-  }, [onClose, reviewOpen, closeReview, refocusTerminal])
+  }, [onClose, reviewOpen, closeReview, refocusTerminal, reviewEnabled])
 
   const handleRevive = async () => {
     setReviving(true)
@@ -198,7 +203,9 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
                 <Terminal sessionId={sessionId} />
               </div>
               <div className="flip-back">
-                {reviewOpen && <ReviewOverlay sessionId={sessionId} onClose={closeReview} />}
+                {reviewOpen && reviewEnabled && (
+                  <ReviewOverlay sessionId={sessionId} onClose={closeReview} />
+                )}
               </div>
             </div>
           </div>

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -49,16 +49,15 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
     window.api.getDefaultTool().then((tool) => {
       if (cancelled) return
       setDefaultTool(tool)
-      // Only seed pendingTool if the dialog isn't already open with an
-      // explicit user choice — avoid clobbering an in-flight selection.
-      setPendingTool((cur) => (pendingSessionPath === null ? tool : cur))
+      // Don't touch pendingTool here — the New Session menu-item handler is
+      // the only path that opens the dialog and it re-seeds pendingTool from
+      // defaultTool at click time. Mutating pendingTool from this async
+      // callback would race against any user toggle made between the click
+      // and getDefaultTool resolving.
     })
     return () => {
       cancelled = true
     }
-    // pendingSessionPath intentionally omitted: we only want the initial seed,
-    // not a re-fetch on every dialog open/close.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const toggle = (path: string) => {

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -27,6 +27,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const [pendingSessionPath, setPendingSessionPath] = useState<string | null>(null)
   const [pendingSessionHostId, setPendingSessionHostId] = useState<string | null>(null)
   const [sessionNameInput, setSessionNameInput] = useState('')
+  const [defaultTool, setDefaultTool] = useState<AgentTool>('claude')
   const [pendingTool, setPendingTool] = useState<AgentTool>('claude')
   const [creating, setCreating] = useState(false)
   const [pendingPrPath, setPendingPrPath] = useState<string | null>(null)
@@ -42,6 +43,23 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   useEffect(() => {
     scanProjects()
   }, [scanProjects])
+
+  useEffect(() => {
+    let cancelled = false
+    window.api.getDefaultTool().then((tool) => {
+      if (cancelled) return
+      setDefaultTool(tool)
+      // Only seed pendingTool if the dialog isn't already open with an
+      // explicit user choice — avoid clobbering an in-flight selection.
+      setPendingTool((cur) => (pendingSessionPath === null ? tool : cur))
+    })
+    return () => {
+      cancelled = true
+    }
+    // pendingSessionPath intentionally omitted: we only want the initial seed,
+    // not a re-fetch on every dialog open/close.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const toggle = (path: string) => {
     setExpanded((prev) => {
@@ -77,6 +95,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
           setPendingSessionPath(menu.projectPath)
           setPendingSessionHostId(hostId)
           setSessionNameInput('')
+          setPendingTool(defaultTool)
         },
       })
       items.push({ label: '', separator: true, onClick: () => {} })
@@ -104,6 +123,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
           setPendingSessionPath(menu.projectPath)
           setPendingSessionHostId(null)
           setSessionNameInput('')
+          setPendingTool(defaultTool)
         },
       })
       items.push({

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -3,6 +3,7 @@ import { useProjectsStore } from '../stores/projects'
 import { useSessionsStore } from '../stores/sessions'
 import { useHostsStore } from '../stores/hosts'
 import ContextMenu, { type MenuItem } from './ContextMenu'
+import type { AgentTool } from '../../shared/types'
 
 interface MenuState {
   x: number
@@ -26,6 +27,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const [pendingSessionPath, setPendingSessionPath] = useState<string | null>(null)
   const [pendingSessionHostId, setPendingSessionHostId] = useState<string | null>(null)
   const [sessionNameInput, setSessionNameInput] = useState('')
+  const [pendingTool, setPendingTool] = useState<AgentTool>('claude')
   const [creating, setCreating] = useState(false)
   const [pendingPrPath, setPendingPrPath] = useState<string | null>(null)
   const [prNumberInput, setPrNumberInput] = useState('')
@@ -183,7 +185,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
     setCreating(true)
     try {
       const name = sessionNameInput.trim() || undefined
-      await window.api.createSession(pendingSessionPath, name, pendingSessionHostId)
+      await window.api.createSession(pendingSessionPath, name, pendingSessionHostId, pendingTool)
       setPendingSessionPath(null)
       setPendingSessionHostId(null)
       setSessionNameInput('')
@@ -234,6 +236,29 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
             }}
             autoFocus
           />
+          <div className="session-name-label">Tool:</div>
+          <div className="tool-picker">
+            <label>
+              <input
+                type="radio"
+                name="tool"
+                value="claude"
+                checked={pendingTool === 'claude'}
+                onChange={() => setPendingTool('claude')}
+              />
+              Claude
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="tool"
+                value="codex"
+                checked={pendingTool === 'codex'}
+                onChange={() => setPendingTool('codex')}
+              />
+              Codex
+            </label>
+          </div>
           <div className="create-actions">
             <button className="create-btn" onClick={handleCreateSession} disabled={creating}>
               {creating ? 'Creating...' : 'Create'}

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -210,6 +210,12 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
         <div className="session-card-status">
           <span className={`status-dot ${statusClass}`} />
           <span>{label}</span>
+          <span
+            className={`tool-badge tool-${session.tool}`}
+            title={session.tool === 'codex' ? 'Codex' : 'Claude'}
+          >
+            {session.tool === 'codex' ? 'X' : 'C'}
+          </span>
           {host && connectionState && <span className="connection-label">{connectionState}</span>}
         </div>
         <div className="session-card-time">{timeAgo(session.lastActivity)}</div>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -56,6 +56,7 @@ declare global {
       getSidebarWidth: () => Promise<number>
       saveSidebarWidth: (width: number) => Promise<void>
       getUiScale: () => Promise<number>
+      getDefaultTool: () => Promise<AgentTool>
       onTextThumbnails: (callback: (data: Record<string, string>) => void) => () => void
       pickDirectory: () => Promise<string | null>
       relocateProject: (oldPath: string, newPath: string) => Promise<{ migratedCount: number }>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 import type {
+  AgentTool,
   DiffMode,
   Host,
   Project,
@@ -24,7 +25,8 @@ declare global {
       createSession: (
         projectPath: string,
         name?: string,
-        hostId?: string | null
+        hostId?: string | null,
+        tool?: AgentTool
       ) => Promise<Session>
       createPrSession: (projectPath: string, prNumber: number) => Promise<Session | string>
       mirrorWorktree: (

--- a/src/renderer/stores/sessions.test.ts
+++ b/src/renderer/stores/sessions.test.ts
@@ -18,6 +18,7 @@ function makeSession(id: string): Session {
     lastActivity: 0,
     hookEvents: [],
     hostId: null,
+    tool: 'claude',
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -28,6 +28,8 @@ export interface Worktree {
   isMain: boolean
 }
 
+export type AgentTool = 'claude' | 'codex'
+
 export interface Session {
   id: string
   hostId: string | null
@@ -46,6 +48,8 @@ export interface Session {
   hookEvents: HookEvent[]
   repoFingerprint?: string
   lastKnownState?: LastKnownState
+  tool: AgentTool
+  agentSessionId?: string
 }
 
 export interface HookEvent {


### PR DESCRIPTION
## Summary

- Adds OpenAI Codex CLI as a second supported agent alongside Claude Code (closes blocker on #50).
- Reuses the existing hook-server pipeline — codex emits identical hook field names (`hook_event_name`, `cwd`, `session_id`) and event names (`SessionStart`, `Stop`, `PostToolUse`), so `notify.sh` works unchanged.
- Per-session tool selection at creation time; default is `claude` for back-compat.

## Implementation

| Area | Change |
|---|---|
| Types / config | `Session.tool`, `Session.agentSessionId`, `AppConfig.defaultTool`. Legacy sessions backfilled to `claude` in `backfillDerivedFields`. |
| Spawn | `buildAgentArgs` branches on tool: `claude --dangerously-skip-permissions [--continue]` vs `codex [resume <id>] --dangerously-bypass-approvals-and-sandbox`. |
| Bootstrap | Probes both `claude` and `codex` non-fatally; strict deps (`tmux`/`git`/`jq`/`socat`) still hard-fail; per-tool availability enforced at session creation. |
| Hook install | New `installCodexHooks` writes `<worktree>/.codex/hooks.json` (atomic, marker-dedup, rollback). New `ensureCodexHooksFeatureFlag` idempotently sets `[features].codex_hooks = true` in `~/.codex/config.toml` via a hand-rolled minimal merger (no new TOML dep). |
| Concurrency | Mixed-tool-per-worktree guard in `createSessionForWorktree` + `createRemoteSession`. |
| Lifecycle | `handleHookEvent` captures codex `session_id` as `agentSessionId` on `session.start`. Resume paths thread `tool + agentSessionId`; codex without an id falls back to fresh spawn with a warning. |
| Renderer | "New session" dialog gains a Claude/Codex radio. `SessionCard` shows a tool badge. Review (Ctrl+R) is gated to `tool === 'claude'`; codex Review deferred. |

## Why this was small

Codex's hook contract is field-compatible with Claude's — same JSON shape on stdin, same event names, same socket transport. The only asymmetries are: codex lacks `Notification` and `SessionEnd` (acceptable — `Stop` already drives `needs_input`; pty exit covers session end), and `~/.codex/config.toml` needs a `codex_hooks = true` feature flag.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] `npx vitest run` — 17 files / 251 tests passing
- [x] New tests:
  - `hook-installer.test.ts` (15 cases): JSON merge, marker dedup, idempotent TOML merge, preserves unrelated tables, decoy `codex_hooks` outside `[features]` left alone, rollback.
  - `pty-manager.test.ts` (5 cases): argv for both tools, both resume paths.
  - `host-bootstrap.test.ts` (extended): per-agent availability, strict-vs-tolerant deps.
  - `session-manager.test.ts` (extended, 5 cases): legacy backfill, codex `agentSessionId` capture, codex `Stop → needs_input` parity, no overwrite, claude doesn't capture.
- [ ] Manual: `npm run dev`, create a codex session in a real repo, verify `<repo>/.codex/hooks.json` is written, `~/.codex/config.toml` contains `[features].codex_hooks = true`, status dot transitions `running → needs_input → running` as the codex turn cycles.

## Known runtime risks (need a live codex run to verify)

- `PostToolUse` matcher is `.*` (permissive). Tighten after observing real codex `tool_name` values in `hookEvents[]`.
- `tmux new-session -d -x 120 -y 30 codex` — the codex TUI behaviour at fixed 120x30 is unverified; if `apply_patch` opens an interactive sub-editor it may fight tmux signal handling.
- `codex resume <id>` failure detection: if codex GCs old session IDs, the spawn fails inside tmux. Existing pty-manager covers this for claude; needs verification for codex.

## Out of scope (separate PRs)

- OpenCode plugin support.
- Codex Review integration (`codex review` subcommand).
- Renaming `<project>/.claude/worktrees/` → `<project>/.cc-pewpew/worktrees/`.
- Per-project sticky tool default.

Plan: `.ultraplan/codex-support.md`.