### PR TITLE
feat: prefix session branches with project name

### DIFF
--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -845,7 +845,6 @@ describe('removeSessionsForHost (issue #14)', () => {
     expect(state.sessionsUpdatedBroadcasts).toBe(0)
   })
 })
-
 describe('codex agent integration', () => {
   it('backfills tool="claude" on legacy sessions missing the field', async () => {
     // Persisted JSON omits `tool` to simulate a session created before the
@@ -916,5 +915,45 @@ describe('codex agent integration', () => {
     sm.handleHookEvent('session.start', { cwd: '/cl/wt', session_id: 'should-not-store' }, null)
     const updated = sm.getSessions().find((s) => s.id === 'cl1')
     expect(updated?.agentSessionId).toBeUndefined()
+  })
+})
+
+describe('sanitizeBranchPrefix', () => {
+  it('preserves valid ref-component characters', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.sanitizeBranchPrefix('cc-pewpew')).toBe('cc-pewpew')
+    expect(sm.sanitizeBranchPrefix('my_repo.v2')).toBe('my_repo.v2')
+  })
+
+  it('replaces git-illegal characters with `-`', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.sanitizeBranchPrefix('My Repo')).toBe('My-Repo')
+    expect(sm.sanitizeBranchPrefix('repo:with~bad^chars?*[\\]')).toBe('repo-with-bad-chars')
+  })
+
+  it('strips consecutive dots rejected by git ref names', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.sanitizeBranchPrefix('my..repo')).toBe('my-repo')
+    expect(sm.sanitizeBranchPrefix('repo...v2')).toBe('repo-v2')
+  })
+
+  it('strips leading and trailing punctuation', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.sanitizeBranchPrefix('-leading')).toBe('leading')
+    expect(sm.sanitizeBranchPrefix('.dot.')).toBe('dot')
+  })
+
+  it('strips trailing `.lock` suffixes (illegal as ref-component suffixes)', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.sanitizeBranchPrefix('proj.lock')).toBe('proj')
+    expect(sm.sanitizeBranchPrefix('proj.lock.lock')).toBe('proj')
+    expect(sm.sanitizeBranchPrefix('proj-.lock')).toBe('proj')
+  })
+
+  it('falls back to `cc-pewpew` when nothing valid remains', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.sanitizeBranchPrefix('   ')).toBe('cc-pewpew')
+    expect(sm.sanitizeBranchPrefix(':::')).toBe('cc-pewpew')
+    expect(sm.sanitizeBranchPrefix('')).toBe('cc-pewpew')
   })
 })

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -69,6 +69,22 @@ function parseIssueNumber(...sources: (string | undefined)[]): number | undefine
   return undefined
 }
 
+// Project names come from arbitrary directory basenames (or a user-supplied
+// remote-project label), so they can contain characters that are illegal in a
+// git ref component (space, `:`, `~`, `^`, `?`, `*`, `[`, `\`, control chars,
+// `..`, leading `-`/`.`, etc.). Coerce to a safe slug; fall back to
+// `cc-pewpew` when nothing valid remains.
+export function sanitizeBranchPrefix(name: string): string {
+  const slug = name
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/\.{2,}/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-._]+|[-._]+$/g, '')
+    .replace(/(?:\.lock)+$/i, '')
+    .replace(/^[-._]+|[-._]+$/g, '')
+  return slug || 'cc-pewpew'
+}
+
 // Read the actual branch checked out in a worktree. Falls back to the
 // conventional `<project>/<worktree>` name if the worktree is missing or git fails.
 function resolveBranchFromWorktree(
@@ -86,7 +102,7 @@ function resolveBranchFromWorktree(
       // fall through to default
     }
   }
-  return `${projectName}/${worktreeName}`
+  return `${sanitizeBranchPrefix(projectName)}/${worktreeName}`
 }
 
 // Extract the owner segment from a GitHub `origin` remote URL. Used to
@@ -604,7 +620,7 @@ async function createRemoteSession(
 
   const id = randomUUID().slice(0, 8)
   const tmuxSession = `cc-pewpew-${id}`
-  const branchName = `${remoteProject.name}/${worktreeName}`
+  const branchName = `${sanitizeBranchPrefix(remoteProject.name)}/${worktreeName}`
 
   // prepareRemoteHost retains the SSH runtime on success; we own the ref and
   // release it at the end (or in catch). createRemotePty takes its own retain
@@ -694,7 +710,7 @@ export async function createSession(
       'add',
       worktreePath,
       '-b',
-      `${basename(projectPath)}/${worktreeName}`,
+      `${sanitizeBranchPrefix(basename(projectPath))}/${worktreeName}`,
     ])
   } catch {
     // Branch may already exist — try without -b
@@ -1365,7 +1381,7 @@ function backfillDerivedFields(session: Session): void {
       session.projectName
     )
   } else if (!session.branch) {
-    session.branch = `${session.projectName}/${session.worktreeName}`
+    session.branch = `${sanitizeBranchPrefix(session.projectName)}/${session.worktreeName}`
   }
   if (session.issueNumber === undefined) {
     session.issueNumber = parseIssueNumber(session.worktreeName, session.branch)

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -70,8 +70,12 @@ function parseIssueNumber(...sources: (string | undefined)[]): number | undefine
 }
 
 // Read the actual branch checked out in a worktree. Falls back to the
-// cc-pewpew-conventional name if the worktree is missing or git fails.
-function resolveBranchFromWorktree(worktreePath: string, worktreeName: string): string {
+// conventional `<project>/<worktree>` name if the worktree is missing or git fails.
+function resolveBranchFromWorktree(
+  worktreePath: string,
+  worktreeName: string,
+  projectName: string
+): string {
   if (existsSync(worktreePath)) {
     try {
       const out = execFileSync('git', ['-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'], {
@@ -82,7 +86,7 @@ function resolveBranchFromWorktree(worktreePath: string, worktreeName: string): 
       // fall through to default
     }
   }
-  return `cc-pewpew/${worktreeName}`
+  return `${projectName}/${worktreeName}`
 }
 
 // Extract the owner segment from a GitHub `origin` remote URL. Used to
@@ -489,7 +493,7 @@ async function adoptWorktree(
   const projectName = basename(projectPath)
   const worktreeName = label || (await deriveLabel(worktreePath))
   const tmuxSession = `cc-pewpew-${id}`
-  const branch = resolveBranchFromWorktree(worktreePath, worktreeName)
+  const branch = resolveBranchFromWorktree(worktreePath, worktreeName, projectName)
 
   await installAgentHooks(tool, worktreePath)
   createPty(id, worktreePath, { tool })
@@ -600,7 +604,7 @@ async function createRemoteSession(
 
   const id = randomUUID().slice(0, 8)
   const tmuxSession = `cc-pewpew-${id}`
-  const branchName = `cc-pewpew/${worktreeName}`
+  const branchName = `${remoteProject.name}/${worktreeName}`
 
   // prepareRemoteHost retains the SSH runtime on success; we own the ref and
   // release it at the end (or in catch). createRemotePty takes its own retain
@@ -690,7 +694,7 @@ export async function createSession(
       'add',
       worktreePath,
       '-b',
-      `cc-pewpew/${worktreeName}`,
+      `${basename(projectPath)}/${worktreeName}`,
     ])
   } catch {
     // Branch may already exist — try without -b
@@ -1304,7 +1308,7 @@ export async function relocateProject(
     s.projectName = basename(newProjectPath)
     // Only rewrite worktreePath for managed worktrees under the old project's
     // .claude/worktrees tree, preserving the exact subpath (worktreeName may be
-    // a branch label like "cc-pewpew/feat-x" that doesn't match the dirname).
+    // a branch label like "<project>/feat-x" that doesn't match the dirname).
     // External mirrored paths are kept verbatim.
     if (s.worktreePath.startsWith(oldManagedRoot)) {
       const suffix = s.worktreePath.slice(oldManagedRoot.length)
@@ -1355,9 +1359,13 @@ export async function relocateProject(
 // persisted branch and only fall back when it's missing.
 function backfillDerivedFields(session: Session): void {
   if (!session.hostId && existsSync(session.worktreePath)) {
-    session.branch = resolveBranchFromWorktree(session.worktreePath, session.worktreeName)
+    session.branch = resolveBranchFromWorktree(
+      session.worktreePath,
+      session.worktreeName,
+      session.projectName
+    )
   } else if (!session.branch) {
-    session.branch = `cc-pewpew/${session.worktreeName}`
+    session.branch = `${session.projectName}/${session.worktreeName}`
   }
   if (session.issueNumber === undefined) {
     session.issueNumber = parseIssueNumber(session.worktreeName, session.branch)


### PR DESCRIPTION
## Summary
- New session branches use `<project>/<session>` instead of the hardcoded `cc-pewpew/<session>` prefix, so branches identify the project they belong to.
- Applies to local sessions (basename of projectPath), remote sessions (remoteProject.name), and the fallbacks in `resolveBranchFromWorktree` / `backfillDerivedFields`.
- For the cc-pewpew repo itself, branch names are unchanged. Existing sessions/branches keep their persisted names — `resolveBranchFromWorktree` always reads the live git branch when the worktree exists.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/main/session-manager.ts`
- [x] `npx vitest run` (206 passed)
- [ ] Manually create a new session in a non-cc-pewpew project and confirm the branch is `<project>/<session>`