### PR TITLE
[codex] Branch sessions from origin default

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import type { AgentTool, Host, RemoteProject } from '../shared/types'
+import type { AgentTool, Host, RemoteProject, WorktreeBase } from '../shared/types'
 
 export interface CanvasState {
   zoom: number
@@ -31,6 +31,7 @@ export interface AppConfig {
   gitignoreWarned: string[]
   remoteProjects: RemoteProject[]
   defaultTool: AgentTool
+  worktreeBase: WorktreeBase
 }
 
 export const CONFIG_DIR = join(
@@ -52,6 +53,7 @@ const DEFAULT_CONFIG: AppConfig = {
   gitignoreWarned: [],
   remoteProjects: [],
   defaultTool: 'claude',
+  worktreeBase: 'local',
 }
 
 export function shouldWarnGitignore(projectPath: string): boolean {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,7 +63,7 @@ import {
   validateRemotePath,
 } from './remote-project-registry'
 import type {
-  AgentTool,
+  CreateSessionOptions,
   DiffMode,
   ReviewBranchesResult,
   ReviewDefaultBranchResult,
@@ -270,9 +270,9 @@ app.whenReady().then(async () => {
       projectPath: string,
       name?: string,
       hostId?: string | null,
-      tool?: AgentTool
+      options?: CreateSessionOptions
     ) => {
-      return createSession(projectPath, name, hostId ?? null, tool)
+      return createSession(projectPath, name, hostId ?? null, options ?? {})
     }
   )
 
@@ -562,6 +562,10 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('config:get-default-tool', () => {
     return getConfig().defaultTool
+  })
+
+  ipcMain.handle('config:get-worktree-base', () => {
+    return getConfig().worktreeBase
   })
 
   ipcMain.handle('swim-lanes:open', (_event, sessionIds: string[]) => {

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -299,11 +299,29 @@ describe('resolveOriginDefaultBase', () => {
         fakeGitRunner({
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
+          'ls-remote --symref origin HEAD': new Error('unavailable'),
           'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
           'rev-parse --verify origin/main': 'abc123\n',
         })
       )
     ).resolves.toBe('origin/main')
+  })
+
+  it('prefers ls-remote default branch over stale local origin/HEAD', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': 'git@example.com:org/repo.git\n',
+          'fetch origin --quiet': '',
+          'ls-remote --symref origin HEAD': 'ref: refs/heads/develop\tHEAD\nabc123\tHEAD\n',
+          'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
+          'rev-parse --verify origin/develop': 'abc123\n',
+          'rev-parse --verify origin/main': 'def456\n',
+        })
+      )
+    ).resolves.toBe('origin/develop')
   })
 
   it('throws no-origin-remote when origin is missing', async () => {
@@ -339,8 +357,8 @@ describe('resolveOriginDefaultBase', () => {
         fakeGitRunner({
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
-          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
           'ls-remote --symref origin HEAD': new Error('unset'),
+          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
           'rev-parse --verify origin/main': 'abc123\n',
         })
       )
@@ -355,8 +373,8 @@ describe('resolveOriginDefaultBase', () => {
         fakeGitRunner({
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
-          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
           'ls-remote --symref origin HEAD': 'ref: refs/heads/develop\tHEAD\nabc123\tHEAD\n',
+          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
           'rev-parse --verify origin/develop': 'abc123\n',
         })
       )
@@ -371,8 +389,8 @@ describe('resolveOriginDefaultBase', () => {
         fakeGitRunner({
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
-          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
           'ls-remote --symref origin HEAD': new Error('unset'),
+          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
           'rev-parse --verify origin/main': new Error('missing'),
           'rev-parse --verify origin/master': 'abc123\n',
         })
@@ -388,8 +406,8 @@ describe('resolveOriginDefaultBase', () => {
         fakeGitRunner({
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
-          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
           'ls-remote --symref origin HEAD': new Error('unset'),
+          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
           'rev-parse --verify origin/main': new Error('missing'),
           'rev-parse --verify origin/master': new Error('missing'),
         })
@@ -405,8 +423,8 @@ describe('resolveOriginDefaultBase', () => {
         fakeGitRunner({
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
-          'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
           'ls-remote --symref origin HEAD': new Error('unset'),
+          'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
           'rev-parse --verify origin/main': new Error('stale'),
           'rev-parse --verify origin/master': 'abc123\n',
         })

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Host, Session, WorktreeBase } from '../shared/types'
+import type { Host, RemoteProject, Session, WorktreeBase } from '../shared/types'
 
 // Hoisted state so vi.mock factories can reach mutable per-test values before
 // the SUT imports run.
@@ -13,6 +13,7 @@ const state = vi.hoisted(() => ({
   tmuxAvailable: true,
   repoFingerprint: undefined as string | undefined,
   hosts: [] as Host[],
+  remoteProjects: [] as RemoteProject[],
   worktreeBase: 'local' as WorktreeBase,
   runtimeStates: new Map<string, string>(),
   // Call logs for assertion.
@@ -31,6 +32,10 @@ const state = vi.hoisted(() => ({
   runtimeRefs: new Map<string, number>(),
   sessionsUpdatedBroadcasts: 0,
   execRemoteCalls: [] as { hostId: string; argv: string[] }[],
+  execRemoteResults: new Map<
+    string,
+    { stdout: string; stderr: string; code: number; timedOut: boolean }
+  >(),
   // Toggle to simulate ensureHostConnection throwing.
   ensureHostConnectionThrows: null as null | { message: string; runtimeStateAfter: string },
   // When set, delays next ensureHostConnection resolution (used for idempotency
@@ -89,7 +94,7 @@ vi.mock('./host-registry', () => ({
 }))
 
 vi.mock('./remote-project-registry', () => ({
-  listRemoteProjects: () => [],
+  listRemoteProjects: () => state.remoteProjects,
 }))
 
 vi.mock('./hook-server', () => ({
@@ -97,7 +102,10 @@ vi.mock('./hook-server', () => ({
 }))
 
 vi.mock('./host-bootstrap', () => ({
-  bootstrapHost: vi.fn(async () => ({ notifyScriptPath: '/tmp/notify-v1.sh' })),
+  bootstrapHost: vi.fn(async () => ({
+    notifyScriptPath: '/tmp/notify-v1.sh',
+    availableAgents: { claude: true, codex: true },
+  })),
 }))
 
 vi.mock('./pty-manager', () => ({
@@ -156,6 +164,8 @@ vi.mock('./host-connection', () => ({
   exec: async (hostOrAlias: Host | string, argv: string[]) => {
     const hostId = typeof hostOrAlias === 'string' ? hostOrAlias : hostOrAlias.hostId
     state.execRemoteCalls.push({ hostId, argv })
+    const configured = state.execRemoteResults.get(argv.join(' '))
+    if (configured) return configured
     return { stdout: '', stderr: '', code: 0, timedOut: false }
   },
   retainHostConnection: vi.fn((hostId: string) => {
@@ -246,6 +256,7 @@ beforeEach(() => {
   state.tmuxAvailable = true
   state.repoFingerprint = undefined
   state.hosts = [{ hostId: 'h1', alias: 'devbox', label: 'Dev' }]
+  state.remoteProjects = []
   state.worktreeBase = 'local'
   state.runtimeStates = new Map()
   state.ensureHostConnectionCalls = []
@@ -260,6 +271,7 @@ beforeEach(() => {
   state.sessionsUpdatedBroadcasts = 0
   state.probeSideEffect = new Map()
   state.execRemoteCalls = []
+  state.execRemoteResults = new Map()
   state.ensureHostConnectionThrows = null
   state.ensureHostConnectionGate = null
 })
@@ -328,10 +340,27 @@ describe('resolveOriginDefaultBase', () => {
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
           'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
+          'ls-remote --symref origin HEAD': new Error('unset'),
           'rev-parse --verify origin/main': 'abc123\n',
         })
       )
     ).resolves.toBe('origin/main')
+  })
+
+  it('uses ls-remote default branch when origin/HEAD is unset', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': 'git@example.com:org/repo.git\n',
+          'fetch origin --quiet': '',
+          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
+          'ls-remote --symref origin HEAD': 'ref: refs/heads/develop\tHEAD\nabc123\tHEAD\n',
+          'rev-parse --verify origin/develop': 'abc123\n',
+        })
+      )
+    ).resolves.toBe('origin/develop')
   })
 
   it('falls back to origin/master when origin/main is absent', async () => {
@@ -343,6 +372,7 @@ describe('resolveOriginDefaultBase', () => {
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
           'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
+          'ls-remote --symref origin HEAD': new Error('unset'),
           'rev-parse --verify origin/main': new Error('missing'),
           'rev-parse --verify origin/master': 'abc123\n',
         })
@@ -359,6 +389,7 @@ describe('resolveOriginDefaultBase', () => {
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
           'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
+          'ls-remote --symref origin HEAD': new Error('unset'),
           'rev-parse --verify origin/main': new Error('missing'),
           'rev-parse --verify origin/master': new Error('missing'),
         })
@@ -375,6 +406,7 @@ describe('resolveOriginDefaultBase', () => {
           'remote get-url origin': 'git@example.com:org/repo.git\n',
           'fetch origin --quiet': '',
           'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
+          'ls-remote --symref origin HEAD': new Error('unset'),
           'rev-parse --verify origin/main': new Error('stale'),
           'rev-parse --verify origin/master': 'abc123\n',
         })
@@ -390,30 +422,35 @@ describe('createSession origin-default base', () => {
     return execFileSync('git', args, { cwd, encoding: 'utf-8' })
   }
 
+  function createProjectWithUpdatedOrigin(root: string): string {
+    const source = join(root, 'source')
+    const remote = join(root, 'remote.git')
+    const project = join(root, 'project')
+    mkdirSync(source)
+
+    git(source, ['init'])
+    git(source, ['config', 'user.email', 'test@example.com'])
+    git(source, ['config', 'user.name', 'Test User'])
+    writeFileSync(join(source, 'file.txt'), 'one\n')
+    git(source, ['add', 'file.txt'])
+    git(source, ['commit', '-m', 'one'])
+    git(source, ['branch', '-M', 'main'])
+    execFileSync('git', ['clone', '--bare', source, remote], { stdio: 'ignore' })
+    execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
+
+    git(source, ['remote', 'add', 'origin', remote])
+    writeFileSync(join(source, 'file.txt'), 'two\n')
+    git(source, ['commit', '-am', 'two'])
+    git(source, ['push', 'origin', 'main'])
+    mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
+
+    return project
+  }
+
   gitIt('branches the new worktree from the fetched origin default branch', async () => {
     const root = mkdtempSync(join(tmpdir(), 'origin-base-'))
     try {
-      const source = join(root, 'source')
-      const remote = join(root, 'remote.git')
-      const project = join(root, 'project')
-      mkdirSync(source)
-
-      git(source, ['init'])
-      git(source, ['config', 'user.email', 'test@example.com'])
-      git(source, ['config', 'user.name', 'Test User'])
-      writeFileSync(join(source, 'file.txt'), 'one\n')
-      git(source, ['add', 'file.txt'])
-      git(source, ['commit', '-m', 'one'])
-      git(source, ['branch', '-M', 'main'])
-      execFileSync('git', ['clone', '--bare', source, remote], { stdio: 'ignore' })
-      execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
-
-      git(source, ['remote', 'add', 'origin', remote])
-      writeFileSync(join(source, 'file.txt'), 'two\n')
-      git(source, ['commit', '-am', 'two'])
-      git(source, ['push', 'origin', 'main'])
-      mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
-
+      const project = createProjectWithUpdatedOrigin(root)
       const sm = await loadSessionManager()
       const session = await sm.createSession(project, 'from-origin', null, {
         baseRef: 'origin-default',
@@ -425,6 +462,75 @@ describe('createSession origin-default base', () => {
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
+  })
+
+  gitIt('reuses an existing branch when origin-default session name is recreated', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'origin-base-existing-'))
+    try {
+      const project = createProjectWithUpdatedOrigin(root)
+      const branchName = 'project/from-origin'
+      git(project, ['branch', branchName, 'origin/main'])
+
+      const sm = await loadSessionManager()
+      const session = await sm.createSession(project, 'from-origin', null, {
+        baseRef: 'origin-default',
+      })
+
+      const branch = git(session.worktreePath, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()
+      expect(branch).toBe(branchName)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('retries remote origin-default worktree creation when the branch already exists', async () => {
+    state.remoteProjects = [{ hostId: 'h1', path: '/remote/proj', name: 'proj' }]
+    const branchName = 'proj/feat'
+    const worktreePath = '/remote/proj/.claude/worktrees/feat'
+    state.execRemoteResults.set(
+      [
+        'git',
+        '-C',
+        '/remote/proj',
+        'worktree',
+        'add',
+        worktreePath,
+        '-b',
+        branchName,
+        'origin/main',
+      ].join(' '),
+      { stdout: '', stderr: 'fatal: a branch named already exists', code: 128, timedOut: false }
+    )
+    state.execRemoteResults.set(
+      ['git', '-C', '/remote/proj', 'symbolic-ref', '--short', 'refs/remotes/origin/HEAD'].join(
+        ' '
+      ),
+      { stdout: 'origin/main\n', stderr: '', code: 0, timedOut: false }
+    )
+    state.execRemoteResults.set(
+      ['git', '-C', '/remote/proj', 'rev-parse', '--verify', 'refs/heads/proj/feat'].join(' '),
+      { stdout: 'abc123\n', stderr: '', code: 0, timedOut: false }
+    )
+    state.execRemoteResults.set(
+      ['git', '-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'].join(' '),
+      { stdout: `${branchName}\n`, stderr: '', code: 0, timedOut: false }
+    )
+    const sm = await loadSessionManager()
+
+    const session = await sm.createSession('/remote/proj', 'feat', 'h1', {
+      baseRef: 'origin-default',
+    })
+
+    expect(session.branch).toBe(branchName)
+    expect(state.execRemoteCalls.map((c) => c.argv)).toContainEqual([
+      'git',
+      '-C',
+      '/remote/proj',
+      'worktree',
+      'add',
+      worktreePath,
+      branchName,
+    ])
   })
 })
 

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1,8 +1,9 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { execFileSync } from 'child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Host, Session } from '../shared/types'
+import type { Host, Session, WorktreeBase } from '../shared/types'
 
 // Hoisted state so vi.mock factories can reach mutable per-test values before
 // the SUT imports run.
@@ -12,6 +13,7 @@ const state = vi.hoisted(() => ({
   tmuxAvailable: true,
   repoFingerprint: undefined as string | undefined,
   hosts: [] as Host[],
+  worktreeBase: 'local' as WorktreeBase,
   runtimeStates: new Map<string, string>(),
   // Call logs for assertion.
   ensureHostConnectionCalls: [] as string[],
@@ -50,6 +52,8 @@ vi.mock('./config', () => ({
     uiScale: 1,
     hosts: state.hosts,
     remoteProjects: [],
+    defaultTool: 'claude',
+    worktreeBase: state.worktreeBase,
   }),
   saveConfig: vi.fn(),
 }))
@@ -227,12 +231,22 @@ function baseLocalSession(overrides: Partial<Session>): Session {
   }
 }
 
+const canRunGit = (() => {
+  try {
+    execFileSync('git', ['--version'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+})()
+
 beforeEach(() => {
   state.configDir = mkdtempSync(join(tmpdir(), 'sess-mgr-'))
   state.liveTmuxIds = []
   state.tmuxAvailable = true
   state.repoFingerprint = undefined
   state.hosts = [{ hostId: 'h1', alias: 'devbox', label: 'Dev' }]
+  state.worktreeBase = 'local'
   state.runtimeStates = new Map()
   state.ensureHostConnectionCalls = []
   state.createRemotePtyCalls = []
@@ -252,6 +266,166 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(state.configDir, { recursive: true, force: true })
+})
+
+describe('resolveOriginDefaultBase', () => {
+  function fakeGitRunner(script: Record<string, string | Error>) {
+    return async (argv: string[]) => {
+      const key = argv.join(' ')
+      const result = script[key]
+      if (result === undefined) throw new Error(`unexpected git ${key}`)
+      if (result instanceof Error) throw result
+      return { stdout: result }
+    }
+  }
+
+  it('returns origin/HEAD when symbolic-ref resolves and validates', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': 'git@example.com:org/repo.git\n',
+          'fetch origin --quiet': '',
+          'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
+          'rev-parse --verify origin/main': 'abc123\n',
+        })
+      )
+    ).resolves.toBe('origin/main')
+  })
+
+  it('throws no-origin-remote when origin is missing', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': new Error('No such remote'),
+        })
+      )
+    ).rejects.toThrow(/^no-origin-remote$/)
+  })
+
+  it('adds context when fetch fails', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': 'git@example.com:org/repo.git\n',
+          'fetch origin --quiet': new Error('network down'),
+        })
+      )
+    ).rejects.toThrow(/Failed to fetch origin: network down/)
+  })
+
+  it('falls back to origin/main when origin/HEAD is unset', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': 'git@example.com:org/repo.git\n',
+          'fetch origin --quiet': '',
+          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
+          'rev-parse --verify origin/main': 'abc123\n',
+        })
+      )
+    ).resolves.toBe('origin/main')
+  })
+
+  it('falls back to origin/master when origin/main is absent', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': 'git@example.com:org/repo.git\n',
+          'fetch origin --quiet': '',
+          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
+          'rev-parse --verify origin/main': new Error('missing'),
+          'rev-parse --verify origin/master': 'abc123\n',
+        })
+      )
+    ).resolves.toBe('origin/master')
+  })
+
+  it('throws no-origin-default-branch when no candidate resolves', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': 'git@example.com:org/repo.git\n',
+          'fetch origin --quiet': '',
+          'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
+          'rev-parse --verify origin/main': new Error('missing'),
+          'rev-parse --verify origin/master': new Error('missing'),
+        })
+      )
+    ).rejects.toThrow(/^no-origin-default-branch$/)
+  })
+
+  it('falls through when origin/HEAD points at a stale ref', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': 'git@example.com:org/repo.git\n',
+          'fetch origin --quiet': '',
+          'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
+          'rev-parse --verify origin/main': new Error('stale'),
+          'rev-parse --verify origin/master': 'abc123\n',
+        })
+      )
+    ).resolves.toBe('origin/master')
+  })
+})
+
+describe('createSession origin-default base', () => {
+  const gitIt = canRunGit ? it : it.skip
+
+  function git(cwd: string, args: string[]): string {
+    return execFileSync('git', args, { cwd, encoding: 'utf-8' })
+  }
+
+  gitIt('branches the new worktree from the fetched origin default branch', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'origin-base-'))
+    try {
+      const source = join(root, 'source')
+      const remote = join(root, 'remote.git')
+      const project = join(root, 'project')
+      mkdirSync(source)
+
+      git(source, ['init'])
+      git(source, ['config', 'user.email', 'test@example.com'])
+      git(source, ['config', 'user.name', 'Test User'])
+      writeFileSync(join(source, 'file.txt'), 'one\n')
+      git(source, ['add', 'file.txt'])
+      git(source, ['commit', '-m', 'one'])
+      git(source, ['branch', '-M', 'main'])
+      execFileSync('git', ['clone', '--bare', source, remote], { stdio: 'ignore' })
+      execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
+
+      git(source, ['remote', 'add', 'origin', remote])
+      writeFileSync(join(source, 'file.txt'), 'two\n')
+      git(source, ['commit', '-am', 'two'])
+      git(source, ['push', 'origin', 'main'])
+      mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
+
+      const sm = await loadSessionManager()
+      const session = await sm.createSession(project, 'from-origin', null, {
+        baseRef: 'origin-default',
+      })
+
+      const originTip = git(project, ['rev-parse', 'origin/main']).trim()
+      const worktreeTip = git(session.worktreePath, ['rev-parse', 'HEAD']).trim()
+      expect(worktreeTip).toBe(originTip)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('restoreSessions — remote lazy materialization', () => {

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -301,10 +301,10 @@ describe('resolveOriginDefaultBase', () => {
           'fetch origin --quiet': '',
           'ls-remote --symref origin HEAD': new Error('unavailable'),
           'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
-          'rev-parse --verify origin/main': 'abc123\n',
+          'rev-parse --verify refs/remotes/origin/main': 'abc123\n',
         })
       )
-    ).resolves.toBe('origin/main')
+    ).resolves.toBe('refs/remotes/origin/main')
   })
 
   it('prefers ls-remote default branch over stale local origin/HEAD', async () => {
@@ -317,11 +317,27 @@ describe('resolveOriginDefaultBase', () => {
           'fetch origin --quiet': '',
           'ls-remote --symref origin HEAD': 'ref: refs/heads/develop\tHEAD\nabc123\tHEAD\n',
           'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
-          'rev-parse --verify origin/develop': 'abc123\n',
-          'rev-parse --verify origin/main': 'def456\n',
+          'rev-parse --verify refs/remotes/origin/develop': 'abc123\n',
+          'rev-parse --verify refs/remotes/origin/main': 'def456\n',
         })
       )
-    ).resolves.toBe('origin/develop')
+    ).resolves.toBe('refs/remotes/origin/develop')
+  })
+
+  it('validates fully qualified remote-tracking refs to avoid local branch ambiguity', async () => {
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.resolveOriginDefaultBase(
+        fakeGitRunner({
+          'remote get-url origin': 'git@example.com:org/repo.git\n',
+          'fetch origin --quiet': '',
+          'ls-remote --symref origin HEAD': 'ref: refs/heads/main\tHEAD\nabc123\tHEAD\n',
+          'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
+          'rev-parse --verify refs/remotes/origin/main': 'abc123\n',
+        })
+      )
+    ).resolves.toBe('refs/remotes/origin/main')
   })
 
   it('throws no-origin-remote when origin is missing', async () => {
@@ -359,10 +375,10 @@ describe('resolveOriginDefaultBase', () => {
           'fetch origin --quiet': '',
           'ls-remote --symref origin HEAD': new Error('unset'),
           'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
-          'rev-parse --verify origin/main': 'abc123\n',
+          'rev-parse --verify refs/remotes/origin/main': 'abc123\n',
         })
       )
-    ).resolves.toBe('origin/main')
+    ).resolves.toBe('refs/remotes/origin/main')
   })
 
   it('uses ls-remote default branch when origin/HEAD is unset', async () => {
@@ -375,10 +391,10 @@ describe('resolveOriginDefaultBase', () => {
           'fetch origin --quiet': '',
           'ls-remote --symref origin HEAD': 'ref: refs/heads/develop\tHEAD\nabc123\tHEAD\n',
           'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
-          'rev-parse --verify origin/develop': 'abc123\n',
+          'rev-parse --verify refs/remotes/origin/develop': 'abc123\n',
         })
       )
-    ).resolves.toBe('origin/develop')
+    ).resolves.toBe('refs/remotes/origin/develop')
   })
 
   it('falls back to origin/master when origin/main is absent', async () => {
@@ -391,11 +407,11 @@ describe('resolveOriginDefaultBase', () => {
           'fetch origin --quiet': '',
           'ls-remote --symref origin HEAD': new Error('unset'),
           'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
-          'rev-parse --verify origin/main': new Error('missing'),
-          'rev-parse --verify origin/master': 'abc123\n',
+          'rev-parse --verify refs/remotes/origin/main': new Error('missing'),
+          'rev-parse --verify refs/remotes/origin/master': 'abc123\n',
         })
       )
-    ).resolves.toBe('origin/master')
+    ).resolves.toBe('refs/remotes/origin/master')
   })
 
   it('throws no-origin-default-branch when no candidate resolves', async () => {
@@ -408,8 +424,8 @@ describe('resolveOriginDefaultBase', () => {
           'fetch origin --quiet': '',
           'ls-remote --symref origin HEAD': new Error('unset'),
           'symbolic-ref --short refs/remotes/origin/HEAD': new Error('unset'),
-          'rev-parse --verify origin/main': new Error('missing'),
-          'rev-parse --verify origin/master': new Error('missing'),
+          'rev-parse --verify refs/remotes/origin/main': new Error('missing'),
+          'rev-parse --verify refs/remotes/origin/master': new Error('missing'),
         })
       )
     ).rejects.toThrow(/^no-origin-default-branch$/)
@@ -425,11 +441,11 @@ describe('resolveOriginDefaultBase', () => {
           'fetch origin --quiet': '',
           'ls-remote --symref origin HEAD': new Error('unset'),
           'symbolic-ref --short refs/remotes/origin/HEAD': 'origin/main\n',
-          'rev-parse --verify origin/main': new Error('stale'),
-          'rev-parse --verify origin/master': 'abc123\n',
+          'rev-parse --verify refs/remotes/origin/main': new Error('stale'),
+          'rev-parse --verify refs/remotes/origin/master': 'abc123\n',
         })
       )
-    ).resolves.toBe('origin/master')
+    ).resolves.toBe('refs/remotes/origin/master')
   })
 })
 
@@ -515,7 +531,7 @@ describe('createSession origin-default base', () => {
         worktreePath,
         '-b',
         branchName,
-        'origin/main',
+        'refs/remotes/origin/main',
       ].join(' '),
       { stdout: '', stderr: 'fatal: a branch named already exists', code: 128, timedOut: false }
     )

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -115,10 +115,18 @@ function resolveBranchFromWorktree(
 
 type GitRunner = (argv: string[]) => Promise<{ stdout: string }>
 
+function remoteTrackingRef(ref: string): string | undefined {
+  const trimmed = ref.trim()
+  if (!trimmed) return undefined
+  if (trimmed.startsWith('refs/remotes/origin/')) return trimmed
+  if (trimmed.startsWith('origin/')) return `refs/remotes/${trimmed}`
+  return undefined
+}
+
 function parseOriginHeadSymref(stdout: string): string | undefined {
   for (const line of stdout.split('\n')) {
     const match = line.match(/^ref:\s+refs\/heads\/(.+)\s+HEAD$/)
-    if (match) return `origin/${match[1]}`
+    if (match) return `refs/remotes/origin/${match[1]}`
   }
   return undefined
 }
@@ -148,13 +156,13 @@ export async function resolveOriginDefaultBase(run: GitRunner): Promise<string> 
 
   try {
     const { stdout } = await run(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])
-    const ref = stdout.trim()
+    const ref = remoteTrackingRef(stdout)
     if (ref && !candidates.includes(ref)) candidates.push(ref)
   } catch {
     // fall through to conventional branch names
   }
 
-  for (const ref of ['origin/main', 'origin/master']) {
+  for (const ref of ['refs/remotes/origin/main', 'refs/remotes/origin/master']) {
     if (!candidates.includes(ref)) candidates.push(ref)
   }
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -139,16 +139,16 @@ export async function resolveOriginDefaultBase(run: GitRunner): Promise<string> 
 
   const candidates: string[] = []
   try {
-    const { stdout } = await run(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])
-    const ref = stdout.trim()
+    const { stdout } = await run(['ls-remote', '--symref', 'origin', 'HEAD'])
+    const ref = parseOriginHeadSymref(stdout)
     if (ref) candidates.push(ref)
   } catch {
-    // fall through to conventional branch names
+    // fall through to local origin/HEAD
   }
 
   try {
-    const { stdout } = await run(['ls-remote', '--symref', 'origin', 'HEAD'])
-    const ref = parseOriginHeadSymref(stdout)
+    const { stdout } = await run(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])
+    const ref = stdout.trim()
     if (ref && !candidates.includes(ref)) candidates.push(ref)
   } catch {
     // fall through to conventional branch names

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -115,6 +115,14 @@ function resolveBranchFromWorktree(
 
 type GitRunner = (argv: string[]) => Promise<{ stdout: string }>
 
+function parseOriginHeadSymref(stdout: string): string | undefined {
+  for (const line of stdout.split('\n')) {
+    const match = line.match(/^ref:\s+refs\/heads\/(.+)\s+HEAD$/)
+    if (match) return `origin/${match[1]}`
+  }
+  return undefined
+}
+
 export async function resolveOriginDefaultBase(run: GitRunner): Promise<string> {
   try {
     await run(['remote', 'get-url', 'origin'])
@@ -134,6 +142,14 @@ export async function resolveOriginDefaultBase(run: GitRunner): Promise<string> 
     const { stdout } = await run(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])
     const ref = stdout.trim()
     if (ref) candidates.push(ref)
+  } catch {
+    // fall through to conventional branch names
+  }
+
+  try {
+    const { stdout } = await run(['ls-remote', '--symref', 'origin', 'HEAD'])
+    const ref = parseOriginHeadSymref(stdout)
+    if (ref && !candidates.includes(ref)) candidates.push(ref)
   } catch {
     // fall through to conventional branch names
   }
@@ -290,6 +306,36 @@ async function expectRemoteOk(host: Host, argv: string[], message: string): Prom
 
 function effectiveWorktreeBase(options: CreateSessionOptions): WorktreeBase {
   return options.baseRef ?? getConfig().worktreeBase
+}
+
+async function branchExists(projectPath: string, branchName: string): Promise<boolean> {
+  try {
+    await execFileAsync(
+      'git',
+      ['-C', projectPath, 'rev-parse', '--verify', `refs/heads/${branchName}`],
+      { timeout: 5000 }
+    )
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function remoteBranchExists(
+  host: Host,
+  projectPath: string,
+  branchName: string
+): Promise<boolean> {
+  try {
+    await expectRemoteOk(
+      host,
+      ['git', '-C', projectPath, 'rev-parse', '--verify', `refs/heads/${branchName}`],
+      'git failed'
+    )
+    return true
+  } catch {
+    return false
+  }
 }
 
 // Positive hits are cached forever; negative hits (no PR yet / gh transient
@@ -692,11 +738,20 @@ async function createRemoteSession(
           stdout,
         }))
       )
-      await expectRemoteOk(
-        host,
-        ['git', '-C', projectPath, 'worktree', 'add', worktreePath, '-b', branchName, originRef],
-        'Failed to create remote worktree'
-      )
+      try {
+        await expectRemoteOk(
+          host,
+          ['git', '-C', projectPath, 'worktree', 'add', worktreePath, '-b', branchName, originRef],
+          'Failed to create remote worktree'
+        )
+      } catch (err) {
+        if (!(await remoteBranchExists(host, projectPath, branchName))) throw err
+        await expectRemoteOk(
+          host,
+          ['git', '-C', projectPath, 'worktree', 'add', worktreePath, branchName],
+          'Failed to create remote worktree'
+        )
+      }
     } else {
       const addWithBranch = await execRemote(host, [
         'git',
@@ -778,16 +833,21 @@ export async function createSession(
       })
       return { stdout: String(stdout) }
     })
-    await execFileAsync('git', [
-      '-C',
-      projectPath,
-      'worktree',
-      'add',
-      worktreePath,
-      '-b',
-      branchName,
-      originRef,
-    ])
+    try {
+      await execFileAsync('git', [
+        '-C',
+        projectPath,
+        'worktree',
+        'add',
+        worktreePath,
+        '-b',
+        branchName,
+        originRef,
+      ])
+    } catch (err) {
+      if (!(await branchExists(projectPath, branchName))) throw err
+      await execFileAsync('git', ['-C', projectPath, 'worktree', 'add', worktreePath, branchName])
+    }
   } else {
     try {
       await execFileAsync('git', [

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -51,7 +51,15 @@ import {
 } from './host-connection'
 import { bootstrapHost, HostBootstrapError } from './host-bootstrap'
 import { emitToast } from './notifications'
-import type { AgentTool, Host, RemoteProject, Session, SessionStatus } from '../shared/types'
+import type {
+  AgentTool,
+  CreateSessionOptions,
+  Host,
+  RemoteProject,
+  Session,
+  SessionStatus,
+  WorktreeBase,
+} from '../shared/types'
 
 const execFileAsync = promisify(execFile)
 const SESSIONS_PATH = join(CONFIG_DIR, 'sessions.json')
@@ -103,6 +111,47 @@ function resolveBranchFromWorktree(
     }
   }
   return `${sanitizeBranchPrefix(projectName)}/${worktreeName}`
+}
+
+type GitRunner = (argv: string[]) => Promise<{ stdout: string }>
+
+export async function resolveOriginDefaultBase(run: GitRunner): Promise<string> {
+  try {
+    await run(['remote', 'get-url', 'origin'])
+  } catch {
+    throw new Error('no-origin-remote')
+  }
+
+  try {
+    await run(['fetch', 'origin', '--quiet'])
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to fetch origin: ${detail}`, { cause: err })
+  }
+
+  const candidates: string[] = []
+  try {
+    const { stdout } = await run(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])
+    const ref = stdout.trim()
+    if (ref) candidates.push(ref)
+  } catch {
+    // fall through to conventional branch names
+  }
+
+  for (const ref of ['origin/main', 'origin/master']) {
+    if (!candidates.includes(ref)) candidates.push(ref)
+  }
+
+  for (const ref of candidates) {
+    try {
+      await run(['rev-parse', '--verify', ref])
+      return ref
+    } catch {
+      // try next candidate
+    }
+  }
+
+  throw new Error('no-origin-default-branch')
 }
 
 // Extract the owner segment from a GitHub `origin` remote URL. Used to
@@ -237,6 +286,10 @@ async function expectRemoteOk(host: Host, argv: string[], message: string): Prom
     throw new Error(`${message}: ${detail}`)
   }
   return result.stdout
+}
+
+function effectiveWorktreeBase(options: CreateSessionOptions): WorktreeBase {
+  return options.baseRef ?? getConfig().worktreeBase
 }
 
 // Positive hits are cached forever; negative hits (no PR yet / gh transient
@@ -598,9 +651,9 @@ async function createRemoteSession(
   hostId: string,
   projectPath: string,
   name?: string,
-  tool?: AgentTool
+  options: CreateSessionOptions = {}
 ): Promise<Session> {
-  const effectiveTool: AgentTool = tool ?? getConfig().defaultTool
+  const effectiveTool: AgentTool = options.tool ?? getConfig().defaultTool
   const host = getRequiredHost(hostId)
   const remoteProject = getRemoteProject(hostId, projectPath)
   const worktreeName = name || `session-${randomUUID().slice(0, 8)}`
@@ -621,6 +674,7 @@ async function createRemoteSession(
   const id = randomUUID().slice(0, 8)
   const tmuxSession = `cc-pewpew-${id}`
   const branchName = `${sanitizeBranchPrefix(remoteProject.name)}/${worktreeName}`
+  const baseRef = effectiveWorktreeBase(options)
 
   // prepareRemoteHost retains the SSH runtime on success; we own the ref and
   // release it at the end (or in catch). createRemotePty takes its own retain
@@ -632,22 +686,35 @@ async function createRemoteSession(
   }
   let branch: string
   try {
-    const addWithBranch = await execRemote(host, [
-      'git',
-      '-C',
-      projectPath,
-      'worktree',
-      'add',
-      worktreePath,
-      '-b',
-      branchName,
-    ])
-    if (addWithBranch.timedOut || addWithBranch.code !== 0) {
+    if (baseRef === 'origin-default') {
+      const originRef = await resolveOriginDefaultBase((argv) =>
+        expectRemoteOk(host, ['git', '-C', projectPath, ...argv], 'git failed').then((stdout) => ({
+          stdout,
+        }))
+      )
       await expectRemoteOk(
         host,
-        ['git', '-C', projectPath, 'worktree', 'add', worktreePath],
+        ['git', '-C', projectPath, 'worktree', 'add', worktreePath, '-b', branchName, originRef],
         'Failed to create remote worktree'
       )
+    } else {
+      const addWithBranch = await execRemote(host, [
+        'git',
+        '-C',
+        projectPath,
+        'worktree',
+        'add',
+        worktreePath,
+        '-b',
+        branchName,
+      ])
+      if (addWithBranch.timedOut || addWithBranch.code !== 0) {
+        await expectRemoteOk(
+          host,
+          ['git', '-C', projectPath, 'worktree', 'add', worktreePath],
+          'Failed to create remote worktree'
+        )
+      }
     }
 
     branch =
@@ -695,14 +762,22 @@ export async function createSession(
   projectPath: string,
   name?: string,
   hostId: string | null = null,
-  tool?: AgentTool
+  options: CreateSessionOptions = {}
 ): Promise<Session> {
-  if (hostId) return createRemoteSession(hostId, projectPath, name, tool)
+  if (hostId) return createRemoteSession(hostId, projectPath, name, options)
 
   const worktreeName = name || `session-${randomUUID().slice(0, 8)}`
   const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
+  const branchName = `${sanitizeBranchPrefix(basename(projectPath))}/${worktreeName}`
+  const baseRef = effectiveWorktreeBase(options)
 
-  try {
+  if (baseRef === 'origin-default') {
+    const originRef = await resolveOriginDefaultBase(async (argv) => {
+      const { stdout } = await execFileAsync('git', ['-C', projectPath, ...argv], {
+        timeout: 30000,
+      })
+      return { stdout: String(stdout) }
+    })
     await execFileAsync('git', [
       '-C',
       projectPath,
@@ -710,14 +785,27 @@ export async function createSession(
       'add',
       worktreePath,
       '-b',
-      `${sanitizeBranchPrefix(basename(projectPath))}/${worktreeName}`,
+      branchName,
+      originRef,
     ])
-  } catch {
-    // Branch may already exist — try without -b
-    await execFileAsync('git', ['-C', projectPath, 'worktree', 'add', worktreePath])
+  } else {
+    try {
+      await execFileAsync('git', [
+        '-C',
+        projectPath,
+        'worktree',
+        'add',
+        worktreePath,
+        '-b',
+        branchName,
+      ])
+    } catch {
+      // Branch may already exist — try without -b
+      await execFileAsync('git', ['-C', projectPath, 'worktree', 'add', worktreePath])
+    }
   }
 
-  return createSessionForWorktree(projectPath, worktreePath, worktreeName, tool)
+  return createSessionForWorktree(projectPath, worktreePath, worktreeName, options.tool)
 }
 
 export function handleHookEvent(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { AgentTool, ToastEvent } from '../shared/types'
+import type { AgentTool, CreateSessionOptions, ToastEvent } from '../shared/types'
 
 contextBridge.exposeInMainWorld('api', {
   scanProjects: () => ipcRenderer.invoke('projects:scan'),
@@ -14,8 +14,12 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.on('hook:event', handler)
     return () => ipcRenderer.removeListener('hook:event', handler)
   },
-  createSession: (projectPath: string, name?: string, hostId?: string | null, tool?: AgentTool) =>
-    ipcRenderer.invoke('sessions:create', projectPath, name, hostId ?? null, tool),
+  createSession: (
+    projectPath: string,
+    name?: string,
+    hostId?: string | null,
+    options?: CreateSessionOptions
+  ) => ipcRenderer.invoke('sessions:create', projectPath, name, hostId ?? null, options),
   createPrSession: (projectPath: string, prNumber: number) =>
     ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber),
   mirrorWorktree: (projectPath: string, worktreePath: string) =>
@@ -52,6 +56,7 @@ contextBridge.exposeInMainWorld('api', {
   saveSidebarWidth: (width: number) => ipcRenderer.invoke('config:save-sidebar-width', width),
   getUiScale: () => ipcRenderer.invoke('config:get-ui-scale'),
   getDefaultTool: () => ipcRenderer.invoke('config:get-default-tool') as Promise<AgentTool>,
+  getWorktreeBase: () => ipcRenderer.invoke('config:get-worktree-base'),
   onTextThumbnails: (callback: (data: Record<string, string>) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: Record<string, string>) =>
       callback(data)

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -30,6 +30,8 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const [defaultTool, setDefaultTool] = useState<AgentTool>('claude')
   const [pendingTool, setPendingTool] = useState<AgentTool>('claude')
   const [creating, setCreating] = useState(false)
+  const [baseFromOrigin, setBaseFromOrigin] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
   const [pendingPrPath, setPendingPrPath] = useState<string | null>(null)
   const [prNumberInput, setPrNumberInput] = useState('')
   const [prError, setPrError] = useState<string | null>(null)
@@ -82,6 +84,29 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
     setMenu({ x: e.clientX, y: e.clientY, projectPath, setupState, hostId })
   }
 
+  const openNewSessionDialog = async (projectPath: string, hostId: string | null) => {
+    setCreateError(null)
+    setSessionNameInput('')
+    setPendingTool(defaultTool)
+    try {
+      const worktreeBase = await window.api.getWorktreeBase()
+      setBaseFromOrigin(worktreeBase === 'origin-default')
+    } catch {
+      setBaseFromOrigin(false)
+    }
+    setPendingSessionPath(projectPath)
+    setPendingSessionHostId(hostId)
+  }
+
+  const describeCreateError = (err: unknown): string => {
+    const message = err instanceof Error ? err.message : String(err)
+    if (message.includes('no-origin-remote')) return 'This project has no origin remote.'
+    if (message.includes('no-origin-default-branch')) {
+      return "Could not determine origin's default branch."
+    }
+    return message.replace(/^Error:\s*/, '') || 'Failed to create session.'
+  }
+
   const getMenuItems = (): MenuItem[] => {
     if (!menu) return []
     const items: MenuItem[] = []
@@ -90,11 +115,8 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
       const hostId = menu.hostId
       items.push({
         label: 'New session...',
-        onClick: () => {
-          setPendingSessionPath(menu.projectPath)
-          setPendingSessionHostId(hostId)
-          setSessionNameInput('')
-          setPendingTool(defaultTool)
+        onClick: async () => {
+          await openNewSessionDialog(menu.projectPath, hostId)
         },
       })
       items.push({ label: '', separator: true, onClick: () => {} })
@@ -118,11 +140,8 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
     } else {
       items.push({
         label: 'New session...',
-        onClick: () => {
-          setPendingSessionPath(menu.projectPath)
-          setPendingSessionHostId(null)
-          setSessionNameInput('')
-          setPendingTool(defaultTool)
+        onClick: async () => {
+          await openNewSessionDialog(menu.projectPath, null)
         },
       })
       items.push({
@@ -202,12 +221,18 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const handleCreateSession = async () => {
     if (!pendingSessionPath || creating) return
     setCreating(true)
+    setCreateError(null)
     try {
       const name = sessionNameInput.trim() || undefined
-      await window.api.createSession(pendingSessionPath, name, pendingSessionHostId, pendingTool)
+      await window.api.createSession(pendingSessionPath, name, pendingSessionHostId, {
+        tool: pendingTool,
+        baseRef: baseFromOrigin ? 'origin-default' : 'local',
+      })
       setPendingSessionPath(null)
       setPendingSessionHostId(null)
       setSessionNameInput('')
+    } catch (err) {
+      setCreateError(describeCreateError(err))
     } finally {
       setCreating(false)
     }
@@ -251,6 +276,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
               if (e.key === 'Escape') {
                 setPendingSessionPath(null)
                 setPendingSessionHostId(null)
+                setCreateError(null)
               }
             }}
             autoFocus
@@ -278,6 +304,18 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
               Codex
             </label>
           </div>
+          <label className="session-base-checkbox">
+            <input
+              type="checkbox"
+              checked={baseFromOrigin}
+              onChange={(e) => {
+                setBaseFromOrigin(e.target.checked)
+                setCreateError(null)
+              }}
+            />
+            <span>Branch from origin/&lt;default&gt;</span>
+          </label>
+          {createError && <div className="pr-error">{createError}</div>}
           <div className="create-actions">
             <button className="create-btn" onClick={handleCreateSession} disabled={creating}>
               {creating ? 'Creating...' : 'Create'}
@@ -287,6 +325,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
               onClick={() => {
                 setPendingSessionPath(null)
                 setPendingSessionHostId(null)
+                setCreateError(null)
               }}
             >
               Cancel

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -2,6 +2,7 @@
 
 import type {
   AgentTool,
+  CreateSessionOptions,
   DiffMode,
   Host,
   Project,
@@ -12,6 +13,7 @@ import type {
   Session,
   TestConnectionResult,
   ToastEvent,
+  WorktreeBase,
 } from '../shared/types'
 
 declare global {
@@ -26,7 +28,7 @@ declare global {
         projectPath: string,
         name?: string,
         hostId?: string | null,
-        tool?: AgentTool
+        options?: CreateSessionOptions
       ) => Promise<Session>
       createPrSession: (projectPath: string, prNumber: number) => Promise<Session | string>
       mirrorWorktree: (
@@ -57,6 +59,7 @@ declare global {
       saveSidebarWidth: (width: number) => Promise<void>
       getUiScale: () => Promise<number>
       getDefaultTool: () => Promise<AgentTool>
+      getWorktreeBase: () => Promise<WorktreeBase>
       onTextThumbnails: (callback: (data: Record<string, string>) => void) => () => void
       pickDirectory: () => Promise<string | null>
       relocateProject: (oldPath: string, newPath: string) => Promise<{ migratedCount: number }>

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -852,6 +852,19 @@ body,
   border-color: var(--accent-green);
 }
 
+.session-base-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.session-base-checkbox input {
+  margin: 0;
+}
+
 .create-actions {
   display: flex;
   gap: 4px;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -141,6 +141,13 @@ export interface ValidateRemoteRepoResult {
   message?: string
 }
 
+export type WorktreeBase = 'local' | 'origin-default'
+
+export interface CreateSessionOptions {
+  baseRef?: WorktreeBase
+  tool?: AgentTool
+}
+
 export interface ReviewDiffResult {
   ok: boolean
   files?: DiffFile[]


### PR DESCRIPTION
## Summary

Adds an opt-in worktree base mode for new sessions so users can branch from the fetched `origin` default branch instead of the local project HEAD.

## Changes

- Adds `worktreeBase` config and shared `CreateSessionOptions`/`WorktreeBase` types.
- Resolves `origin/HEAD` with `origin/main` and `origin/master` fallbacks after `git fetch origin --quiet`.
- Applies the origin-default path to both local and SSH-backed session creation while preserving the existing local fallback behavior for the default mode.
- Adds the New Session dialog checkbox and inline error messages for missing origin/default-branch failures.
- Covers resolver behavior and a real-git local session integration case in `session-manager.test.ts`.

## Validation

- `npx vitest run src/main/session-manager.test.ts`
- `npx tsc --noEmit`
- `npx eslint .`
- `npx electron-vite build`
- CDP smoke check confirmed the New Session checkbox renders.