### PR TITLE
fix: clarify host alias placeholder in Manage hosts dialog

### DIFF
--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -63,7 +63,7 @@ function HostForm({
         autoFocus
         type="text"
         className="create-input"
-        placeholder="ssh alias (e.g. devbox)"
+        placeholder="Host from ~/.ssh/config (e.g. devbox)"
         value={alias}
         onChange={(e) => setAlias(e.target.value)}
         onKeyDown={handleKey}


### PR DESCRIPTION
## Summary
- The Add/Edit host form's first field placeholder read `ssh alias (e.g. devbox)`, which made it look like the field accepted a full ssh command. Users would type `ssh -p 4436 user@host` and run into the cryptic "Alias must not contain whitespace" validation error.
- Updated the placeholder to `Host from ~/.ssh/config (e.g. devbox)` so it's clear the field expects a Host entry from the user's SSH config.

## Test plan
- [ ] Open Manage hosts dialog and confirm the new placeholder text on the alias input