### PR TITLE
feat: support PR sessions on remote projects

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -284,9 +284,12 @@ app.whenReady().then(async () => {
     }
   )
 
-  ipcMain.handle('sessions:create-pr', async (_event, projectPath: string, prNumber: number) => {
-    return createPrSession(projectPath, prNumber)
-  })
+  ipcMain.handle(
+    'sessions:create-pr',
+    async (_event, projectPath: string, prNumber: number, hostId?: string | null) => {
+      return createPrSession(projectPath, prNumber, hostId ?? null)
+    }
+  )
 
   async function gitignoreWarning(
     projectPath: string,

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -821,6 +821,147 @@ async function createRemoteSession(
   return session
 }
 
+async function createRemotePrSession(
+  hostId: string,
+  projectPath: string,
+  prNumber: number
+): Promise<Session | string> {
+  const host = getRequiredHost(hostId)
+  const remoteProject = getRemoteProject(hostId, projectPath)
+
+  const worktreeName = `pr-${prNumber}`
+  const worktreePath = posix.join(projectPath, '.claude', 'worktrees', worktreeName)
+
+  for (const e of sessions.values()) {
+    if (e.session.hostId === hostId && e.session.worktreePath === worktreePath) {
+      return e.session
+    }
+  }
+
+  const { notifyScriptPath, availableAgents } = await prepareRemoteHost(host)
+
+  if (!(await probeRemoteGh(host))) {
+    await releaseHostConnection(hostId).catch(() => undefined)
+    return `gh CLI is not installed on host ${host.label || host.alias}.`
+  }
+
+  let prInfo: { headRefName: string; state: string; title: string }
+  try {
+    const stdout = await expectRemoteOk(
+      host,
+      [
+        'sh',
+        '-c',
+        'cd "$1" && gh pr view "$2" --json headRefName,state,title',
+        '_',
+        projectPath,
+        String(prNumber),
+      ],
+      'gh failed'
+    )
+    try {
+      prInfo = JSON.parse(stdout)
+    } catch {
+      await releaseHostConnection(hostId).catch(() => undefined)
+      return `Failed to parse PR metadata for #${prNumber}.`
+    }
+  } catch {
+    await releaseHostConnection(hostId).catch(() => undefined)
+    return `PR #${prNumber} not found in this repository.`
+  }
+
+  if (prInfo.state !== 'OPEN') {
+    await releaseHostConnection(hostId).catch(() => undefined)
+    return `PR #${prNumber} is ${prInfo.state.toLowerCase()}, not open.`
+  }
+
+  const effectiveTool: AgentTool = getConfig().defaultTool
+  if (!availableAgents[effectiveTool]) {
+    await releaseHostConnection(hostId).catch(() => undefined)
+    return `${effectiveTool} is not installed on host ${host.label || host.alias}.`
+  }
+
+  const branch = prInfo.headRefName
+  const id = randomUUID().slice(0, 8)
+  const tmuxSession = `cc-pewpew-${id}`
+
+  let resolvedBranch: string
+  try {
+    await execRemote(host, ['git', '-C', projectPath, 'fetch', 'origin', branch]).catch(
+      () => undefined
+    )
+
+    try {
+      await expectRemoteOk(
+        host,
+        ['git', '-C', projectPath, 'worktree', 'add', worktreePath, branch],
+        'Failed to create remote worktree'
+      )
+    } catch {
+      try {
+        await expectRemoteOk(
+          host,
+          [
+            'git',
+            '-C',
+            projectPath,
+            'worktree',
+            'add',
+            worktreePath,
+            '-b',
+            branch,
+            `origin/${branch}`,
+          ],
+          'Failed to create remote worktree'
+        )
+      } catch (err) {
+        await releaseHostConnection(hostId).catch(() => undefined)
+        return `Failed to create worktree for branch "${branch}": ${(err as Error).message}`
+      }
+    }
+
+    resolvedBranch =
+      (
+        await expectRemoteOk(
+          host,
+          ['git', '-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'],
+          'Failed to resolve remote branch'
+        )
+      ).trim() || branch
+
+    await installRemoteAgentHooks(effectiveTool, host, worktreePath, notifyScriptPath)
+    await createRemotePty(id, worktreePath, host, { tool: effectiveTool })
+  } catch (err) {
+    await releaseHostConnection(hostId).catch(() => undefined)
+    throw err
+  }
+  await releaseHostConnection(hostId).catch(() => undefined)
+
+  const session: Session = {
+    id,
+    hostId,
+    projectPath,
+    projectName: remoteProject.name,
+    worktreeName,
+    worktreePath,
+    branch: resolvedBranch,
+    prNumber,
+    issueNumber: parseIssueNumber(worktreeName, resolvedBranch, prInfo.title),
+    pid: 0,
+    tmuxSession,
+    status: 'running',
+    connectionState: 'live',
+    lastActivity: Date.now(),
+    hookEvents: [],
+    tool: effectiveTool,
+    ...(remoteProject.repoFingerprint ? { repoFingerprint: remoteProject.repoFingerprint } : {}),
+  }
+
+  sessions.set(id, { session })
+  onSessionsChanged()
+  return session
+}
+
 export async function createSession(
   projectPath: string,
   name?: string,
@@ -1381,10 +1522,18 @@ async function promptCleanup(id: string): Promise<void> {
   }
 }
 
+async function probeRemoteGh(host: Host): Promise<boolean> {
+  const result = await execRemote(host, ['sh', '-c', 'command -v gh >/dev/null 2>&1'])
+  return result.code === 0 && !result.timedOut
+}
+
 export async function createPrSession(
   projectPath: string,
-  prNumber: number
+  prNumber: number,
+  hostId: string | null = null
 ): Promise<Session | string> {
+  if (hostId !== null) return createRemotePrSession(hostId, projectPath, prNumber)
+
   // Look up PR via gh CLI
   let prInfo: { headRefName: string; state: string; title: string }
   try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,8 +20,8 @@ contextBridge.exposeInMainWorld('api', {
     hostId?: string | null,
     options?: CreateSessionOptions
   ) => ipcRenderer.invoke('sessions:create', projectPath, name, hostId ?? null, options),
-  createPrSession: (projectPath: string, prNumber: number) =>
-    ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber),
+  createPrSession: (projectPath: string, prNumber: number, hostId?: string | null) =>
+    ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber, hostId ?? null),
   mirrorWorktree: (projectPath: string, worktreePath: string) =>
     ipcRenderer.invoke('sessions:mirror', projectPath, worktreePath),
   mirrorAllWorktrees: (projectPath: string) =>

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -33,6 +33,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const [baseFromOrigin, setBaseFromOrigin] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const [pendingPrPath, setPendingPrPath] = useState<string | null>(null)
+  const [pendingPrHostId, setPendingPrHostId] = useState<string | null>(null)
   const [prNumberInput, setPrNumberInput] = useState('')
   const [prError, setPrError] = useState<string | null>(null)
   const [toast, setToast] = useState<string | null>(null)
@@ -119,6 +120,15 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
           await openNewSessionDialog(menu.projectPath, hostId)
         },
       })
+      items.push({
+        label: 'New PR session...',
+        onClick: () => {
+          setPendingPrPath(menu.projectPath)
+          setPendingPrHostId(hostId)
+          setPrNumberInput('')
+          setPrError(null)
+        },
+      })
       items.push({ label: '', separator: true, onClick: () => {} })
       items.push({
         label: 'Remove remote project',
@@ -148,6 +158,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
         label: 'New PR session...',
         onClick: () => {
           setPendingPrPath(menu.projectPath)
+          setPendingPrHostId(null)
           setPrNumberInput('')
           setPrError(null)
         },
@@ -248,11 +259,12 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
     setCreating(true)
     setPrError(null)
     try {
-      const result = await window.api.createPrSession(pendingPrPath, num)
+      const result = await window.api.createPrSession(pendingPrPath, num, pendingPrHostId)
       if (typeof result === 'string') {
         setPrError(result)
       } else {
         setPendingPrPath(null)
+        setPendingPrHostId(null)
         setPrNumberInput('')
       }
     } finally {
@@ -346,6 +358,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
               if (e.key === 'Enter') handleCreatePrSession()
               if (e.key === 'Escape') {
                 setPendingPrPath(null)
+                setPendingPrHostId(null)
                 setPrError(null)
               }
             }}
@@ -360,6 +373,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
               className="create-btn cancel"
               onClick={() => {
                 setPendingPrPath(null)
+                setPendingPrHostId(null)
                 setPrError(null)
               }}
             >

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -30,7 +30,11 @@ declare global {
         hostId?: string | null,
         options?: CreateSessionOptions
       ) => Promise<Session>
-      createPrSession: (projectPath: string, prNumber: number) => Promise<Session | string>
+      createPrSession: (
+        projectPath: string,
+        prNumber: number,
+        hostId?: string | null
+      ) => Promise<Session | string>
       mirrorWorktree: (
         projectPath: string,
         worktreePath: string


### PR DESCRIPTION
## Summary
- Adds **"New PR session..."** to the right-click menu for projects on remote SSH hosts, removing the local-only restriction.
- Implements `createRemotePrSession` in `session-manager.ts`, mirroring `createRemoteSession`'s SSH execution and connection-refcount discipline. Resolves the PR via `gh pr view` over SSH, then runs `git fetch` + `git worktree add` (with branch-tracking fallback) on the remote.
- `gh` is probed lazily on demand inside the remote PR-session path, so regular remote sessions are not gated on `gh` being installed.
- Threads `hostId` through `sessions:create-pr` (preload bridge, IPC handler, renderer type, dialog state).

## Implementation notes
- Same-PR dedup runs before any SSH work and returns the existing session if one is found at the target worktree path.
- All user-facing error conditions (missing `gh`, PR not found, PR not open, malformed `gh` output, missing tool, worktree-add failure) return string errors that the renderer surfaces in the dialog. Unexpected mid-flight errors (PTY, hooks) still throw.
- Every error path before `createRemotePty` succeeds calls `releaseHostConnection` so the SSH ref retained by `prepareRemoteHost` doesn't leak.
- `sanitizeBranchPrefix` is intentionally not used — the PR path checks out an upstream-named ref (`headRefName`), not a constructed branch.

## Test plan
- [ ] Right-click a remote project on a host with `gh` installed and authed → "New PR session..." → enter a real open PR number → confirm a remote session appears with correct branch and `prNumber`, and that `.claude/worktrees/pr-<n>` exists on the remote host.
- [ ] Right-click a remote project on a host *without* `gh` → "New PR session..." → confirm the "gh CLI is not installed on host..." string is shown in the dialog.
- [ ] Try a closed/merged PR → confirm the matching state error string.
- [ ] Try an invalid PR number → confirm "PR #X not found...".
- [ ] Try with an unreachable host → confirm host-connection error surfaces (same path as regular remote session creation).
- [ ] Regression: local "New PR session..." still works.
- [ ] Regression: regular remote session creation still works on a host without `gh` installed (no new gating).