### PR TITLE
[codex] Open sessions for GitHub work

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,6 +30,8 @@ import {
   createSessionForWorktree,
   mirrorAllWorktrees,
   createPrSession,
+  openSessionsForOpenPrs,
+  openSessionsForOpenIssues,
   getSession,
   getSessions,
   restoreSessions,
@@ -288,6 +290,20 @@ app.whenReady().then(async () => {
     'sessions:create-pr',
     async (_event, projectPath: string, prNumber: number, hostId?: string | null) => {
       return createPrSession(projectPath, prNumber, hostId ?? null)
+    }
+  )
+
+  ipcMain.handle(
+    'sessions:open-all-prs',
+    async (_event, projectPath: string, hostId?: string | null) => {
+      return openSessionsForOpenPrs(projectPath, hostId ?? null)
+    }
+  )
+
+  ipcMain.handle(
+    'sessions:open-all-issues',
+    async (_event, projectPath: string, hostId?: string | null) => {
+      return openSessionsForOpenIssues(projectPath, hostId ?? null)
     }
   )
 

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1272,3 +1272,182 @@ describe('sanitizeBranchPrefix', () => {
     expect(sm.sanitizeBranchPrefix('')).toBe('cc-pewpew')
   })
 })
+
+describe('createIssueSession', () => {
+  it('creates a worktree on branch issue-<n> from origin default and sets issueNumber', async () => {
+    const sm = await loadSessionManager()
+    const runGit = vi.fn(async (argv: string[]) => {
+      const key = argv.join(' ')
+      if (key === 'remote get-url origin') return { stdout: 'git@example.com:org/repo.git\n' }
+      if (key === 'fetch origin --quiet') return { stdout: '' }
+      if (key === 'ls-remote --symref origin HEAD') {
+        return { stdout: 'ref: refs/heads/main\tHEAD\nabc123\tHEAD\n' }
+      }
+      if (key === 'symbolic-ref --short refs/remotes/origin/HEAD') {
+        return { stdout: 'origin/main\n' }
+      }
+      if (key === 'rev-parse --verify refs/remotes/origin/main') {
+        return { stdout: 'abc123\n' }
+      }
+      if (
+        key === 'worktree add /proj/.claude/worktrees/issue-42 -b issue-42 refs/remotes/origin/main'
+      ) {
+        return { stdout: '' }
+      }
+      throw new Error(`unexpected git ${key}`)
+    })
+    const createSessionForWorktree = vi.fn(async () =>
+      baseLocalSession({
+        id: 'issue-42',
+        projectPath: '/proj',
+        worktreeName: 'issue-42',
+        worktreePath: '/proj/.claude/worktrees/issue-42',
+        branch: 'issue-42',
+      })
+    )
+
+    const result = await sm.createIssueSession('/proj', 42, null, {
+      runGit,
+      createSessionForWorktree,
+    })
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result === 'string') throw new Error(result)
+    expect(result.issueNumber).toBe(42)
+    expect(result.worktreeName).toBe('issue-42')
+    expect(createSessionForWorktree).toHaveBeenCalledWith(
+      '/proj',
+      '/proj/.claude/worktrees/issue-42',
+      'issue-42'
+    )
+    expect(runGit).toHaveBeenCalledWith([
+      'worktree',
+      'add',
+      '/proj/.claude/worktrees/issue-42',
+      '-b',
+      'issue-42',
+      'refs/remotes/origin/main',
+    ])
+  })
+
+  it('returns a user-facing error string when origin default is missing', async () => {
+    const sm = await loadSessionManager()
+    const runGit = vi.fn(async (argv: string[]) => {
+      const key = argv.join(' ')
+      if (key === 'remote get-url origin') return { stdout: 'git@example.com:org/repo.git\n' }
+      if (key === 'fetch origin --quiet') return { stdout: '' }
+      throw new Error(`missing ${key}`)
+    })
+
+    const result = await sm.createIssueSession('/proj', 99, null, { runGit })
+    expect(result).toBe("Could not determine origin's default branch.")
+  })
+})
+
+describe('selectNumbersToOpen', () => {
+  it('partitions items into toCreate (new) and toSkip (already present)', async () => {
+    const sm = await loadSessionManager()
+    const items = [{ number: 1 }, { number: 2 }, { number: 3 }]
+    const existing = new Set([2])
+    const result = sm.selectNumbersToOpen(items, existing)
+    expect(result.toCreate).toEqual([{ number: 1 }, { number: 3 }])
+    expect(result.toSkip).toEqual([2])
+  })
+
+  it('dedupes repeated items in the same list', async () => {
+    const sm = await loadSessionManager()
+    const result = sm.selectNumbersToOpen([{ number: 7 }, { number: 7 }], new Set())
+    expect(result.toCreate).toEqual([{ number: 7 }])
+    expect(result.toSkip).toEqual([7])
+  })
+
+  it('returns empty toCreate when everything matches', async () => {
+    const sm = await loadSessionManager()
+    const result = sm.selectNumbersToOpen([{ number: 1 }, { number: 2 }], new Set([1, 2]))
+    expect(result.toCreate).toEqual([])
+    expect(result.toSkip).toEqual([1, 2])
+  })
+})
+
+describe('openSessionsForOpenPrs', () => {
+  it('lists open PRs, skips ones that already have a session, creates the rest', async () => {
+    const sm = await loadSessionManager()
+    writeSessionsJson([baseLocalSession({ id: 's-existing', prNumber: 7, projectPath: '/proj' })])
+    sm.restoreSessions()
+
+    const listPrs = vi.fn(async () => [
+      { number: 7, title: 'old', headRefName: 'a' },
+      { number: 8, title: 'new', headRefName: 'b' },
+      { number: 9, title: 'newer', headRefName: 'c' },
+    ])
+    const createPrSession = vi.fn(
+      async (_projectPath: string, prNumber: number, _hostId: string | null) =>
+        baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session | string
+    )
+
+    const result = await sm.openSessionsForOpenPrs('/proj', null, { listPrs, createPrSession })
+    expect(typeof result).not.toBe('string')
+    if (typeof result === 'string') throw new Error(result)
+
+    expect(result.skipped).toEqual([7])
+    expect(result.created.map((s) => s.prNumber).sort()).toEqual([8, 9])
+    expect(result.failed).toEqual([])
+    expect(listPrs).toHaveBeenCalledWith('/proj', null)
+    expect(createPrSession).toHaveBeenCalledTimes(2)
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 8, null)
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 9, null)
+  })
+
+  it('surfaces gh list errors as a string', async () => {
+    const sm = await loadSessionManager()
+    const result = await sm.openSessionsForOpenPrs('/proj', null, {
+      listPrs: async () => 'Failed to list open PRs: gh auth failed',
+      createPrSession: vi.fn(),
+    })
+
+    expect(result).toBe('Failed to list open PRs: gh auth failed')
+  })
+})
+
+describe('openSessionsForOpenIssues', () => {
+  it('lists open issues, skips ones that already have a session, creates the rest', async () => {
+    const sm = await loadSessionManager()
+    writeSessionsJson([
+      baseLocalSession({ id: 's-existing', issueNumber: 3, projectPath: '/proj' }),
+    ])
+    sm.restoreSessions()
+
+    const listIssues = vi.fn(async () => [{ number: 3 }, { number: 4 }])
+    const createIssueSession = vi.fn(
+      async (_projectPath: string, issueNumber: number, _hostId: string | null) =>
+        baseLocalSession({ id: `s-${issueNumber}`, issueNumber }) as Session | string
+    )
+
+    const result = await sm.openSessionsForOpenIssues('/proj', null, {
+      listIssues,
+      createIssueSession,
+    })
+    expect(typeof result).not.toBe('string')
+    if (typeof result === 'string') throw new Error(result)
+
+    expect(result.skipped).toEqual([3])
+    expect(result.created.map((s) => s.issueNumber)).toEqual([4])
+    expect(result.failed).toEqual([])
+    expect(listIssues).toHaveBeenCalledWith('/proj', null)
+    expect(createIssueSession).toHaveBeenCalledTimes(1)
+    expect(createIssueSession).toHaveBeenCalledWith('/proj', 4, null)
+  })
+
+  it('records per-issue create failures in the summary', async () => {
+    const sm = await loadSessionManager()
+    const result = await sm.openSessionsForOpenIssues('/proj', null, {
+      listIssues: async () => [{ number: 5 }],
+      createIssueSession: async () => 'boom',
+    })
+    expect(typeof result).not.toBe('string')
+    if (typeof result === 'string') throw new Error(result)
+    expect(result.created).toEqual([])
+    expect(result.skipped).toEqual([])
+    expect(result.failed).toEqual([{ number: 5, error: 'boom' }])
+  })
+})

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1369,6 +1369,30 @@ describe('selectNumbersToOpen', () => {
   })
 })
 
+describe('ghApiOpenItemsArgs', () => {
+  it('uses paginated REST calls for PR numbers', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.ghApiOpenItemsArgs('pr', 'owner/repo')).toEqual([
+      'api',
+      '--paginate',
+      'repos/owner/repo/pulls?state=open&per_page=100',
+      '--jq',
+      '.[].number',
+    ])
+  })
+
+  it('uses paginated REST calls for issue numbers without including PRs', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.ghApiOpenItemsArgs('issue', 'owner/repo')).toEqual([
+      'api',
+      '--paginate',
+      'repos/owner/repo/issues?state=open&per_page=100',
+      '--jq',
+      '.[] | select(.pull_request | not) | .number',
+    ])
+  })
+})
+
 describe('openSessionsForOpenPrs', () => {
   it('lists open PRs, skips ones that already have a session, creates the rest', async () => {
     const sm = await loadSessionManager()

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1431,6 +1431,32 @@ describe('openSessionsForOpenPrs', () => {
 
     expect(result).toBe('Failed to list open PRs: gh auth failed')
   })
+
+  it('surfaces remote SSH auth failures separately from missing gh', async () => {
+    const sm = await loadSessionManager()
+    state.execRemoteResults.set('sh -c command -v gh >/dev/null 2>&1', {
+      stdout: '',
+      stderr: 'Permission denied (publickey).\n',
+      code: 255,
+      timedOut: false,
+    })
+
+    const result = await sm.openSessionsForOpenPrs('/remote/proj', 'h1')
+    expect(result).toBe('SSH authentication failed on Dev: Permission denied (publickey).')
+  })
+
+  it('still reports missing gh when the remote probe runs and gh is absent', async () => {
+    const sm = await loadSessionManager()
+    state.execRemoteResults.set('sh -c command -v gh >/dev/null 2>&1', {
+      stdout: '',
+      stderr: '',
+      code: 1,
+      timedOut: false,
+    })
+
+    const result = await sm.openSessionsForOpenPrs('/remote/proj', 'h1')
+    expect(result).toBe('gh CLI is not installed on host Dev.')
+  })
 })
 
 describe('openSessionsForOpenIssues', () => {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -39,6 +39,7 @@ import {
 import { getHost, setHostAgentPaths } from './host-registry'
 import { listRemoteProjects } from './remote-project-registry'
 import { listenHookServerForHost } from './hook-server'
+import { classifySshExit } from './ssh-exit-parser'
 import {
   ensureHostConnection,
   exec as execRemote,
@@ -847,9 +848,10 @@ async function createRemotePrSession(
 
   const { notifyScriptPath, agentPaths } = await prepareRemoteHost(host)
 
-  if (!(await probeRemoteGh(host))) {
+  const ghProbe = await probeRemoteGh(host)
+  if (!ghProbe.ok) {
     await releaseHostConnection(hostId).catch(() => undefined)
-    return `gh CLI is not installed on host ${host.label || host.alias}.`
+    return ghProbe.error
   }
 
   let prInfo: { headRefName: string; state: string; title: string }
@@ -1559,6 +1561,7 @@ type CreateNumberedSession = (
   number: number,
   hostId: string | null
 ) => Promise<Session | string>
+type RemoteGhProbe = { ok: true } | { ok: false; error: string }
 
 interface OpenSessionsDeps {
   listPrs?: ListNumberedItems
@@ -1637,9 +1640,8 @@ async function listRemoteOpenGhItems(
   kind: 'pr' | 'issue'
 ): Promise<NumberedGhItem[] | string> {
   const host = getRequiredHost(hostId)
-  if (!(await probeRemoteGh(host))) {
-    return `gh CLI is not installed on host ${host.label || host.alias}.`
-  }
+  const ghProbe = await probeRemoteGh(host)
+  if (!ghProbe.ok) return ghProbe.error
 
   try {
     const stdout = await expectRemoteOk(
@@ -1729,9 +1731,28 @@ async function openSessionsForNumberedItems(
   return { created, skipped: toSkip, failed }
 }
 
-async function probeRemoteGh(host: Host): Promise<boolean> {
+function describeRemoteGhProbeFailure(
+  host: Host,
+  result: { code: number; stderr: string; timedOut: boolean }
+): string {
+  const label = host.label || host.alias
+  if (result.timedOut) return `Cannot reach ${label}: ssh timed out while checking for gh.`
+
+  const { reason, message } = classifySshExit({ exitCode: result.code, stderr: result.stderr })
+  if (reason === 'auth-failed') return `SSH authentication failed on ${label}: ${message}`
+  if (reason === 'network') return `Cannot reach ${label}: ${message}`
+  if (reason === 'bind-unlink') {
+    return `${label}: remote sshd needs StreamLocalBindUnlink yes: ${message}`
+  }
+  if (reason === 'dep-missing') return `${label}: remote shell dependency missing: ${message}`
+
+  return `gh CLI is not installed on host ${label}.`
+}
+
+async function probeRemoteGh(host: Host): Promise<RemoteGhProbe> {
   const result = await execRemote(host, ['sh', '-c', 'command -v gh >/dev/null 2>&1'])
-  return result.code === 0 && !result.timedOut
+  if (result.code === 0 && !result.timedOut) return { ok: true }
+  return { ok: false, error: describeRemoteGhProbeFailure(host, result) }
 }
 
 export async function createPrSession(

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -55,6 +55,7 @@ import type {
   AgentTool,
   CreateSessionOptions,
   Host,
+  OpenSessionsSummary,
   RemoteProject,
   Session,
   SessionStatus,
@@ -1530,6 +1531,181 @@ async function promptCleanup(id: string): Promise<void> {
   }
 }
 
+export function selectNumbersToOpen<T extends { number: number }>(
+  items: T[],
+  existing: Set<number>
+): { toCreate: T[]; toSkip: number[] } {
+  const toCreate: T[] = []
+  const toSkip: number[] = []
+  const seen = new Set(existing)
+  for (const item of items) {
+    if (seen.has(item.number)) {
+      toSkip.push(item.number)
+    } else {
+      seen.add(item.number)
+      toCreate.push(item)
+    }
+  }
+  return { toCreate, toSkip }
+}
+
+type NumberedGhItem = { number: number }
+type ListNumberedItems = (
+  projectPath: string,
+  hostId: string | null
+) => Promise<NumberedGhItem[] | string>
+type CreateNumberedSession = (
+  projectPath: string,
+  number: number,
+  hostId: string | null
+) => Promise<Session | string>
+
+interface OpenSessionsDeps {
+  listPrs?: ListNumberedItems
+  listIssues?: ListNumberedItems
+  createPrSession?: CreateNumberedSession
+  createIssueSession?: CreateNumberedSession
+}
+
+interface CreateIssueSessionDeps {
+  runGit?: GitRunner
+  branchExists?: (projectPath: string, branchName: string) => Promise<boolean>
+  createSessionForWorktree?: (
+    projectPath: string,
+    worktreePath: string,
+    label?: string
+  ) => Promise<Session>
+}
+
+function describeGhError(err: unknown): string {
+  const detail =
+    typeof err === 'object' && err !== null && 'stderr' in err
+      ? String((err as { stderr?: unknown }).stderr ?? '').trim()
+      : ''
+  if (detail) return detail
+  if (err instanceof Error) return err.message.replace(/^Error:\s*/, '')
+  return String(err)
+}
+
+function parseNumberedGhItems(stdout: string, label: string): NumberedGhItem[] {
+  const parsed = JSON.parse(stdout) as unknown
+  if (!Array.isArray(parsed)) throw new Error(`Expected ${label} list JSON array.`)
+  return parsed
+    .map((item) => {
+      if (typeof item !== 'object' || item === null) return undefined
+      const number = (item as { number?: unknown }).number
+      return typeof number === 'number' && Number.isInteger(number) && number > 0
+        ? { number }
+        : undefined
+    })
+    .filter((item): item is NumberedGhItem => item !== undefined)
+}
+
+async function listLocalOpenGhItems(
+  projectPath: string,
+  kind: 'pr' | 'issue'
+): Promise<NumberedGhItem[] | string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      [kind, 'list', '--state', 'open', '--json', 'number', '--limit', '100'],
+      { cwd: projectPath, timeout: 30000 }
+    )
+    return parseNumberedGhItems(String(stdout), kind === 'pr' ? 'PR' : 'issue')
+  } catch (err) {
+    return `Failed to list open ${kind === 'pr' ? 'PRs' : 'issues'}: ${describeGhError(err)}`
+  }
+}
+
+async function listRemoteOpenGhItems(
+  projectPath: string,
+  hostId: string,
+  kind: 'pr' | 'issue'
+): Promise<NumberedGhItem[] | string> {
+  const host = getRequiredHost(hostId)
+  if (!(await probeRemoteGh(host))) {
+    return `gh CLI is not installed on host ${host.label || host.alias}.`
+  }
+
+  try {
+    const stdout = await expectRemoteOk(
+      host,
+      [
+        'sh',
+        '-c',
+        'cd "$1" && gh "$2" list --state open --json number --limit 100',
+        '_',
+        projectPath,
+        kind,
+      ],
+      'gh failed'
+    )
+    return parseNumberedGhItems(stdout, kind === 'pr' ? 'PR' : 'issue')
+  } catch (err) {
+    return `Failed to list open ${kind === 'pr' ? 'PRs' : 'issues'}: ${describeGhError(err)}`
+  }
+}
+
+async function listOpenPrs(
+  projectPath: string,
+  hostId: string | null
+): Promise<NumberedGhItem[] | string> {
+  return hostId === null
+    ? listLocalOpenGhItems(projectPath, 'pr')
+    : listRemoteOpenGhItems(projectPath, hostId, 'pr')
+}
+
+async function listOpenIssues(
+  projectPath: string,
+  hostId: string | null
+): Promise<NumberedGhItem[] | string> {
+  return hostId === null
+    ? listLocalOpenGhItems(projectPath, 'issue')
+    : listRemoteOpenGhItems(projectPath, hostId, 'issue')
+}
+
+async function openSessionsForNumberedItems(
+  projectPath: string,
+  hostId: string | null,
+  field: 'prNumber' | 'issueNumber',
+  listItems: ListNumberedItems,
+  createSession: CreateNumberedSession
+): Promise<OpenSessionsSummary | string> {
+  let items: NumberedGhItem[] | string
+  try {
+    items = await listItems(projectPath, hostId)
+  } catch (err) {
+    return describeGhError(err)
+  }
+  if (typeof items === 'string') return items
+
+  const existing = new Set<number>()
+  for (const entry of sessions.values()) {
+    if (entry.session.hostId !== hostId || entry.session.projectPath !== projectPath) continue
+    const number = entry.session[field]
+    if (number !== undefined) existing.add(number)
+  }
+
+  const { toCreate, toSkip } = selectNumbersToOpen(items, existing)
+  const created: Session[] = []
+  const failed: { number: number; error: string }[] = []
+
+  for (const item of toCreate) {
+    try {
+      const result = await createSession(projectPath, item.number, hostId)
+      if (typeof result === 'string') {
+        failed.push({ number: item.number, error: result })
+      } else {
+        created.push(result)
+      }
+    } catch (err) {
+      failed.push({ number: item.number, error: describeGhError(err) })
+    }
+  }
+
+  return { created, skipped: toSkip, failed }
+}
+
 async function probeRemoteGh(host: Host): Promise<boolean> {
   const result = await execRemote(host, ['sh', '-c', 'command -v gh >/dev/null 2>&1'])
   return result.code === 0 && !result.timedOut
@@ -1601,6 +1777,202 @@ export async function createPrSession(
   }
   onSessionsChanged()
   return session
+}
+
+export async function createIssueSession(
+  projectPath: string,
+  issueNumber: number,
+  hostId: string | null = null,
+  deps: CreateIssueSessionDeps = {}
+): Promise<Session | string> {
+  if (hostId !== null) return createRemoteIssueSession(hostId, projectPath, issueNumber)
+
+  const branch = `issue-${issueNumber}`
+  const worktreeName = `issue-${issueNumber}`
+  const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
+
+  for (const e of sessions.values()) {
+    if (e.session.hostId === null && e.session.worktreePath === worktreePath) {
+      return e.session
+    }
+  }
+
+  const runGit =
+    deps.runGit ??
+    (async (argv: string[]) => {
+      const { stdout } = await execFileAsync('git', ['-C', projectPath, ...argv], {
+        timeout: 30000,
+      })
+      return { stdout: String(stdout) }
+    })
+  const hasBranch =
+    deps.branchExists ?? ((root: string, branchName: string) => branchExists(root, branchName))
+  const adopt = deps.createSessionForWorktree ?? createSessionForWorktree
+
+  let originRef: string
+  try {
+    originRef = await resolveOriginDefaultBase(runGit)
+  } catch (err) {
+    const msg = (err as Error).message
+    if (msg === 'no-origin-remote') return 'This project has no origin remote.'
+    if (msg === 'no-origin-default-branch') return "Could not determine origin's default branch."
+    return `Failed to resolve origin default: ${msg}`
+  }
+
+  try {
+    await runGit(['worktree', 'add', worktreePath, '-b', branch, originRef])
+  } catch (err) {
+    if (!(await hasBranch(projectPath, branch))) {
+      return `Failed to create worktree for branch "${branch}": ${(err as Error).message}`
+    }
+    try {
+      await runGit(['worktree', 'add', worktreePath, branch])
+    } catch (fallbackErr) {
+      return `Failed to create worktree for branch "${branch}": ${(fallbackErr as Error).message}`
+    }
+  }
+
+  const session = await adopt(projectPath, worktreePath, worktreeName)
+  session.issueNumber = issueNumber
+  onSessionsChanged()
+  return session
+}
+
+async function createRemoteIssueSession(
+  hostId: string,
+  projectPath: string,
+  issueNumber: number
+): Promise<Session | string> {
+  const host = getRequiredHost(hostId)
+  const remoteProject = getRemoteProject(hostId, projectPath)
+
+  const branch = `issue-${issueNumber}`
+  const worktreeName = `issue-${issueNumber}`
+  const worktreePath = posix.join(projectPath, '.claude', 'worktrees', worktreeName)
+
+  for (const e of sessions.values()) {
+    if (e.session.hostId === hostId && e.session.worktreePath === worktreePath) {
+      return e.session
+    }
+  }
+
+  const { notifyScriptPath, agentPaths } = await prepareRemoteHost(host)
+  const effectiveTool: AgentTool = getConfig().defaultTool
+  const agentPath = agentPaths[effectiveTool]
+  if (!agentPath) {
+    await releaseHostConnection(hostId).catch(() => undefined)
+    return `${effectiveTool} is not installed on host ${host.label || host.alias}.`
+  }
+
+  const id = randomUUID().slice(0, 8)
+  const tmuxSession = `cc-pewpew-${id}`
+  let resolvedBranch: string
+  try {
+    let originRef: string
+    try {
+      originRef = await resolveOriginDefaultBase((argv) =>
+        expectRemoteOk(host, ['git', '-C', projectPath, ...argv], 'git failed').then((stdout) => ({
+          stdout,
+        }))
+      )
+    } catch (err) {
+      const msg = (err as Error).message
+      await releaseHostConnection(hostId).catch(() => undefined)
+      if (msg === 'no-origin-remote') return 'This project has no origin remote.'
+      if (msg === 'no-origin-default-branch') return "Could not determine origin's default branch."
+      return `Failed to resolve origin default: ${msg}`
+    }
+
+    try {
+      await expectRemoteOk(
+        host,
+        ['git', '-C', projectPath, 'worktree', 'add', worktreePath, '-b', branch, originRef],
+        'Failed to create remote worktree'
+      )
+    } catch (err) {
+      if (!(await remoteBranchExists(host, projectPath, branch))) {
+        await releaseHostConnection(hostId).catch(() => undefined)
+        return `Failed to create worktree for branch "${branch}": ${(err as Error).message}`
+      }
+      try {
+        await expectRemoteOk(
+          host,
+          ['git', '-C', projectPath, 'worktree', 'add', worktreePath, branch],
+          'Failed to create remote worktree'
+        )
+      } catch (fallbackErr) {
+        await releaseHostConnection(hostId).catch(() => undefined)
+        return `Failed to create worktree for branch "${branch}": ${(fallbackErr as Error).message}`
+      }
+    }
+
+    resolvedBranch =
+      (
+        await expectRemoteOk(
+          host,
+          ['git', '-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'],
+          'Failed to resolve remote branch'
+        )
+      ).trim() || branch
+
+    await installRemoteAgentHooks(effectiveTool, host, worktreePath, notifyScriptPath)
+    await createRemotePty(id, worktreePath, host, { tool: effectiveTool, agentPath })
+  } catch (err) {
+    await releaseHostConnection(hostId).catch(() => undefined)
+    throw err
+  }
+  await releaseHostConnection(hostId).catch(() => undefined)
+
+  const session: Session = {
+    id,
+    hostId,
+    projectPath,
+    projectName: remoteProject.name,
+    worktreeName,
+    worktreePath,
+    branch: resolvedBranch,
+    issueNumber,
+    pid: 0,
+    tmuxSession,
+    status: 'running',
+    connectionState: 'live',
+    lastActivity: Date.now(),
+    hookEvents: [],
+    tool: effectiveTool,
+    ...(remoteProject.repoFingerprint ? { repoFingerprint: remoteProject.repoFingerprint } : {}),
+  }
+
+  sessions.set(id, { session })
+  onSessionsChanged()
+  return session
+}
+
+export async function openSessionsForOpenPrs(
+  projectPath: string,
+  hostId: string | null = null,
+  deps: OpenSessionsDeps = {}
+): Promise<OpenSessionsSummary | string> {
+  return openSessionsForNumberedItems(
+    projectPath,
+    hostId,
+    'prNumber',
+    deps.listPrs ?? listOpenPrs,
+    deps.createPrSession ?? createPrSession
+  )
+}
+
+export async function openSessionsForOpenIssues(
+  projectPath: string,
+  hostId: string | null = null,
+  deps: OpenSessionsDeps = {}
+): Promise<OpenSessionsSummary | string> {
+  return openSessionsForNumberedItems(
+    projectPath,
+    hostId,
+    'issueNumber',
+    deps.listIssues ?? listOpenIssues,
+    deps.createIssueSession ?? createIssueSession
+  )
 }
 
 export function getSession(id: string): Session | undefined {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1587,18 +1587,27 @@ function describeGhError(err: unknown): string {
   return String(err)
 }
 
-function parseNumberedGhItems(stdout: string, label: string): NumberedGhItem[] {
-  const parsed = JSON.parse(stdout) as unknown
-  if (!Array.isArray(parsed)) throw new Error(`Expected ${label} list JSON array.`)
-  return parsed
-    .map((item) => {
-      if (typeof item !== 'object' || item === null) return undefined
-      const number = (item as { number?: unknown }).number
-      return typeof number === 'number' && Number.isInteger(number) && number > 0
-        ? { number }
-        : undefined
-    })
-    .filter((item): item is NumberedGhItem => item !== undefined)
+export function ghApiOpenItemsArgs(kind: 'pr' | 'issue', repo: string): string[] {
+  const endpoint =
+    kind === 'pr'
+      ? `repos/${repo}/pulls?state=open&per_page=100`
+      : `repos/${repo}/issues?state=open&per_page=100`
+  const jq = kind === 'pr' ? '.[].number' : '.[] | select(.pull_request | not) | .number'
+  return ['api', '--paginate', endpoint, '--jq', jq]
+}
+
+function parseNumberedGhLines(stdout: string, label: string): NumberedGhItem[] {
+  const items: NumberedGhItem[] = []
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line) continue
+    const number = Number(line)
+    if (!Number.isInteger(number) || number <= 0) {
+      throw new Error(`Expected ${label} number, got ${JSON.stringify(line)}.`)
+    }
+    items.push({ number })
+  }
+  return items
 }
 
 async function listLocalOpenGhItems(
@@ -1606,12 +1615,17 @@ async function listLocalOpenGhItems(
   kind: 'pr' | 'issue'
 ): Promise<NumberedGhItem[] | string> {
   try {
-    const { stdout } = await execFileAsync(
+    const { stdout: repoStdout } = await execFileAsync(
       'gh',
-      [kind, 'list', '--state', 'open', '--json', 'number', '--limit', '100'],
+      ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
       { cwd: projectPath, timeout: 30000 }
     )
-    return parseNumberedGhItems(String(stdout), kind === 'pr' ? 'PR' : 'issue')
+    const repo = String(repoStdout).trim()
+    const { stdout } = await execFileAsync('gh', ghApiOpenItemsArgs(kind, repo), {
+      cwd: projectPath,
+      timeout: 30000,
+    })
+    return parseNumberedGhLines(String(stdout), kind === 'pr' ? 'PR' : 'issue')
   } catch (err) {
     return `Failed to list open ${kind === 'pr' ? 'PRs' : 'issues'}: ${describeGhError(err)}`
   }
@@ -1633,14 +1647,23 @@ async function listRemoteOpenGhItems(
       [
         'sh',
         '-c',
-        'cd "$1" && gh "$2" list --state open --json number --limit 100',
+        [
+          'set -e',
+          'cd "$1"',
+          'repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)',
+          'if [ "$2" = pr ]; then',
+          '  gh api --paginate "repos/$repo/pulls?state=open&per_page=100" --jq ".[].number"',
+          'else',
+          '  gh api --paginate "repos/$repo/issues?state=open&per_page=100" --jq ".[] | select(.pull_request | not) | .number"',
+          'fi',
+        ].join('\n'),
         '_',
         projectPath,
         kind,
       ],
       'gh failed'
     )
-    return parseNumberedGhItems(stdout, kind === 'pr' ? 'PR' : 'issue')
+    return parseNumberedGhLines(stdout, kind === 'pr' ? 'PR' : 'issue')
   } catch (err) {
     return `Failed to list open ${kind === 'pr' ? 'PRs' : 'issues'}: ${describeGhError(err)}`
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,6 +22,10 @@ contextBridge.exposeInMainWorld('api', {
   ) => ipcRenderer.invoke('sessions:create', projectPath, name, hostId ?? null, options),
   createPrSession: (projectPath: string, prNumber: number, hostId?: string | null) =>
     ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber, hostId ?? null),
+  openSessionsForOpenPrs: (projectPath: string, hostId?: string | null) =>
+    ipcRenderer.invoke('sessions:open-all-prs', projectPath, hostId ?? null),
+  openSessionsForOpenIssues: (projectPath: string, hostId?: string | null) =>
+    ipcRenderer.invoke('sessions:open-all-issues', projectPath, hostId ?? null),
   mirrorWorktree: (projectPath: string, worktreePath: string) =>
     ipcRenderer.invoke('sessions:mirror', projectPath, worktreePath),
   mirrorAllWorktrees: (projectPath: string) =>

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -3,7 +3,7 @@ import { useProjectsStore } from '../stores/projects'
 import { useSessionsStore } from '../stores/sessions'
 import { useHostsStore } from '../stores/hosts'
 import ContextMenu, { type MenuItem } from './ContextMenu'
-import type { AgentTool } from '../../shared/types'
+import type { AgentTool, OpenSessionsSummary } from '../../shared/types'
 
 interface MenuState {
   x: number
@@ -108,6 +108,48 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
     return message.replace(/^Error:\s*/, '') || 'Failed to create session.'
   }
 
+  const formatOpenAllSummary = (result: OpenSessionsSummary, label: 'PR' | 'issue'): string => {
+    const parts: string[] = []
+    const sessionLabel = label === 'PR' ? 'PR session' : 'issue session'
+    const itemLabel = label === 'PR' ? 'PR' : 'issue'
+    if (result.created.length > 0) {
+      parts.push(
+        `Opened ${result.created.length} ${sessionLabel}${result.created.length === 1 ? '' : 's'}`
+      )
+    }
+    if (result.skipped.length > 0) parts.push(`skipped ${result.skipped.length}`)
+    if (result.failed.length > 0) parts.push(`${result.failed.length} failed`)
+    return parts.length > 0
+      ? parts.join(', ')
+      : `No open ${itemLabel === 'PR' ? 'PRs' : 'issues'} to open`
+  }
+
+  const handleOpenAllPrs = async (projectPath: string, hostId: string | null) => {
+    if (creating) return
+    setCreating(true)
+    try {
+      const result = await window.api.openSessionsForOpenPrs(projectPath, hostId)
+      showToast(typeof result === 'string' ? result : formatOpenAllSummary(result, 'PR'))
+    } catch (err) {
+      showToast(`Failed to open PR sessions: ${String(err)}`)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleOpenAllIssues = async (projectPath: string, hostId: string | null) => {
+    if (creating) return
+    setCreating(true)
+    try {
+      const result = await window.api.openSessionsForOpenIssues(projectPath, hostId)
+      showToast(typeof result === 'string' ? result : formatOpenAllSummary(result, 'issue'))
+    } catch (err) {
+      showToast(`Failed to open issue sessions: ${String(err)}`)
+    } finally {
+      setCreating(false)
+    }
+  }
+
   const getMenuItems = (): MenuItem[] => {
     if (!menu) return []
     const items: MenuItem[] = []
@@ -128,6 +170,16 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
           setPrNumberInput('')
           setPrError(null)
         },
+      })
+      items.push({
+        label: 'Open sessions for all open PRs',
+        disabled: creating,
+        onClick: () => void handleOpenAllPrs(menu.projectPath, hostId),
+      })
+      items.push({
+        label: 'Open sessions for all open issues',
+        disabled: creating,
+        onClick: () => void handleOpenAllIssues(menu.projectPath, hostId),
       })
       items.push({ label: '', separator: true, onClick: () => {} })
       items.push({
@@ -162,6 +214,16 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
           setPrNumberInput('')
           setPrError(null)
         },
+      })
+      items.push({
+        label: 'Open sessions for all open PRs',
+        disabled: creating,
+        onClick: () => void handleOpenAllPrs(menu.projectPath, null),
+      })
+      items.push({
+        label: 'Open sessions for all open issues',
+        disabled: creating,
+        onClick: () => void handleOpenAllIssues(menu.projectPath, null),
       })
 
       const project = projects.find((p) => p.path === menu.projectPath)

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -5,6 +5,7 @@ import type {
   CreateSessionOptions,
   DiffMode,
   Host,
+  OpenSessionsSummary,
   Project,
   RemoteProject,
   ReviewBranchesResult,
@@ -35,6 +36,14 @@ declare global {
         prNumber: number,
         hostId?: string | null
       ) => Promise<Session | string>
+      openSessionsForOpenPrs: (
+        projectPath: string,
+        hostId?: string | null
+      ) => Promise<OpenSessionsSummary | string>
+      openSessionsForOpenIssues: (
+        projectPath: string,
+        hostId?: string | null
+      ) => Promise<OpenSessionsSummary | string>
       mirrorWorktree: (
         projectPath: string,
         worktreePath: string

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,6 +52,12 @@ export interface Session {
   agentSessionId?: string
 }
 
+export interface OpenSessionsSummary {
+  created: Session[]
+  skipped: number[]
+  failed: { number: number; error: string }[]
+}
+
 export interface HookEvent {
   method: string
   sessionId: string


### PR DESCRIPTION
## Summary

- Add session-manager APIs to open sessions for all open PRs or issues, including dedupe, per-item failure reporting, and local/remote gh listing.
- Add issue session creation from the origin default branch with issue metadata set immediately.
- Wire IPC, preload, renderer types, and project context-menu actions with toast summaries.

## Validation

- `npx vitest run src/main/session-manager.test.ts`
- `npx vitest run`
- `npx tsc --noEmit`
- `npx eslint .`
- `npm run build`
- `git diff --check`