### PR TITLE
fix: treat ControlPersist daemonization as success, not failure

### DIFF
--- a/src/main/host-connection.test.ts
+++ b/src/main/host-connection.test.ts
@@ -9,10 +9,18 @@ interface FakeResult {
   exitCode: number | null
 }
 
+interface FakeChild extends EventEmitter {
+  stderr: EventEmitter
+  exitCode: number | null
+  kill: () => boolean
+}
+
 let nextResult: FakeResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
+let resultResolver: ((args: string[]) => FakeResult) | null = null
 const execFileCalls: { file: string; args: string[] }[] = []
 const recordedEntries: SshLogEntry[] = []
 const emittedToasts: Omit<ToastEvent, 'id'>[] = []
+let pendingSpawn: { child: FakeChild; args: string[] } | null = null
 
 vi.mock('child_process', () => ({
   execFile: (
@@ -26,12 +34,29 @@ vi.mock('child_process', () => ({
     ) => void
   ) => {
     execFileCalls.push({ file, args })
+    const result = resultResolver ? resultResolver(args) : nextResult
     const child = new EventEmitter() as EventEmitter & { exitCode: number | null }
-    child.exitCode = nextResult.exitCode
-    setImmediate(() => cb(nextResult.error, nextResult.stdout, nextResult.stderr))
+    child.exitCode = result.exitCode
+    setImmediate(() => cb(result.error, result.stdout, result.stderr))
+    return child
+  },
+  spawn: (_file: string, args: string[]) => {
+    const child = new EventEmitter() as FakeChild
+    child.stderr = new EventEmitter()
+    child.exitCode = null
+    child.kill = () => true
+    pendingSpawn = { child, args }
     return child
   },
 }))
+
+vi.mock('./config', async () => {
+  const { tmpdir: getTmpDir } = await import('os')
+  const { join: pathJoin } = await import('path')
+  return {
+    CONFIG_DIR: pathJoin(getTmpDir(), `cc-pewpew-host-connection-test-${process.pid}`),
+  }
+})
 
 vi.mock('./ssh-log-buffer', () => ({
   recordSshInvocation: (entry: SshLogEntry) => {
@@ -52,15 +77,23 @@ vi.mock('./host-registry', () => ({
     hostId === 'h1' ? { hostId: 'h1', alias: 'dev', label: 'Devbox' } : undefined,
 }))
 
-import { exec, validateRemoteRepo } from './host-connection'
+import {
+  exec,
+  validateRemoteRepo,
+  ensureHostConnection,
+  stopHostConnection,
+  runtimeStateFor,
+} from './host-connection'
 
 const HOST: Host = { hostId: 'h1', alias: 'dev', label: 'Devbox' }
 
 beforeEach(() => {
   nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
+  resultResolver = null
   execFileCalls.length = 0
   recordedEntries.length = 0
   emittedToasts.length = 0
+  pendingSpawn = null
 })
 
 describe('validateRemoteRepo', () => {
@@ -241,5 +274,101 @@ describe('exec ring-buffer + toast wiring', () => {
     expect(recordedEntries).toHaveLength(1)
     expect(recordedEntries[0].kind).toBe('exec')
     expect(recordedEntries[0].exitCode).toBe(1)
+  })
+})
+
+describe('ensureHostConnection / startRuntime', () => {
+  // ControlPersist=10m forks the foreground ssh into the background once the
+  // master is up; the parent then exits with code 0. The master daemon owns
+  // the control socket and serves subsequent ssh invocations. These tests pin
+  // that the runtime treats code-0 parent exit as success rather than a
+  // misleading "ssh control connection exited: 0" failure.
+
+  beforeEach(async () => {
+    await stopHostConnection(HOST.hostId).catch(() => undefined)
+  })
+
+  it('reaches live state when the parent ssh exits 0 after daemonization', async () => {
+    // controlCheck always succeeds — the daemon is serving the socket.
+    nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
+    const promise = ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    expect(pendingSpawn).not.toBeNull()
+    // Simulate the foreground parent forking to the background and exiting 0.
+    pendingSpawn!.child.exitCode = 0
+    pendingSpawn!.child.emit('exit', 0)
+    const result = await promise
+    expect(result.controlPath).toContain(HOST.hostId)
+    expect(runtimeStateFor(HOST.hostId)).toBe('live')
+    await stopHostConnection(HOST.hostId)
+  })
+
+  it('still reaches live state when parent exits 0 between poll attempts', async () => {
+    // Race scenario: controlCheck fails the first time (socket not yet
+    // ready), parent ssh then daemonizes (exit 0) before the next poll, and
+    // controlCheck succeeds afterwards. The runtime must NOT bail out just
+    // because the foreground child has exited — the daemon owns the socket.
+    let checkCalls = 0
+    resultResolver = (args) => {
+      const isControlCheck = args.includes('-O') && args.includes('check')
+      if (isControlCheck) {
+        checkCalls += 1
+        if (checkCalls === 1) {
+          return {
+            stdout: '',
+            stderr: 'Control socket connect: No such file or directory',
+            error: { name: 'Error', message: 'x', code: 1 } as unknown as NodeJS.ErrnoException,
+            exitCode: 1,
+          }
+        }
+        return { stdout: '', stderr: '', error: null, exitCode: 0 }
+      }
+      return { stdout: '', stderr: '', error: null, exitCode: 0 }
+    }
+
+    const promise = ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    expect(pendingSpawn).not.toBeNull()
+    // Wait for the first failed controlCheck to resolve, then simulate the
+    // parent ssh forking to background and exiting cleanly. The next poll
+    // attempt must still proceed and succeed.
+    await new Promise((r) => setImmediate(r))
+    pendingSpawn!.child.exitCode = 0
+    pendingSpawn!.child.emit('exit', 0)
+    const result = await promise
+    expect(result.controlPath).toContain(HOST.hostId)
+    expect(runtimeStateFor(HOST.hostId)).toBe('live')
+    expect(checkCalls).toBeGreaterThanOrEqual(2)
+    await stopHostConnection(HOST.hostId)
+  })
+
+  it('returns immediately on subsequent calls once the runtime is live', async () => {
+    nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
+    const first = ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    pendingSpawn!.child.exitCode = 0
+    pendingSpawn!.child.emit('exit', 0)
+    await first
+    expect(runtimeStateFor(HOST.hostId)).toBe('live')
+    // Second call must not spawn another ssh master — it should reuse the
+    // daemonized control socket. After daemonization the parent process
+    // handle has already exited, so the live fast-path cannot rely on a
+    // running parent process to detect liveness.
+    pendingSpawn = null
+    const second = await ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    expect(pendingSpawn).toBeNull()
+    expect(second.controlPath).toContain(HOST.hostId)
+    await stopHostConnection(HOST.hostId)
+  })
+
+  it('rejects with a real failure when the parent ssh exits non-zero', async () => {
+    // controlCheck would succeed — but the parent exits with auth failure
+    // before the live socket gets used. exitPromise must win the race.
+    nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
+    const promise = ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    expect(pendingSpawn).not.toBeNull()
+    pendingSpawn!.child.stderr.emit('data', Buffer.from('Permission denied (publickey).\n'))
+    pendingSpawn!.child.exitCode = 255
+    pendingSpawn!.child.emit('exit', 255)
+    await expect(promise).rejects.toThrow(/Permission denied/)
+    expect(runtimeStateFor(HOST.hostId)).toBe('auth-failed')
+    await stopHostConnection(HOST.hostId)
   })
 })

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -307,8 +307,11 @@ async function controlCheck(runtime: HostRuntime): Promise<boolean> {
 
 async function waitForControl(runtime: HostRuntime): Promise<void> {
   const deadline = Date.now() + 5000
+  // Don't bail on child.exitCode being set: ControlPersist daemonizes the
+  // foreground ssh, so exitCode flips to 0 once setup completes while the
+  // control socket lives on in the daemon. A non-zero exit is signaled by
+  // exitPromise in startRuntime, which wins the Promise.race.
   while (Date.now() < deadline) {
-    if (!runtime.child || runtime.child.exitCode !== null) break
     if (await controlCheck(runtime)) return
     await new Promise((resolve) => setTimeout(resolve, 100))
   }
@@ -344,9 +347,12 @@ async function startRuntime(runtime: HostRuntime): Promise<void> {
     stderr += data.toString()
   })
 
+  // ControlPersist=10m + ControlMaster=yes forks the foreground ssh into the
+  // background once the master socket is set up; the parent then exits 0 while
+  // the daemon keeps the control socket alive. Treat code 0 as successful
+  // daemonization and let waitForControl detect the live socket.
   const exitPromise = new Promise<never>((_, reject) => {
     child.once('exit', (code) => {
-      runtime.child = null
       logSshInvocation(
         { hostId: runtime.host.hostId, kind: 'control' },
         argv,
@@ -354,6 +360,8 @@ async function startRuntime(runtime: HostRuntime): Promise<void> {
         stderr,
         Date.now() - t0
       )
+      if (code === 0) return
+      runtime.child = null
       runtime.state = classifyConnectionFailure(code, stderr)
       reject(new Error(stderr.trim() || `ssh control connection exited: ${code ?? 'signal'}`))
     })
@@ -409,7 +417,10 @@ export async function ensureHostConnection(
   localSocketPath: string
 ): Promise<{ remoteSocketPath: string; controlPath: string }> {
   const runtime = runtimeFor(host, localSocketPath)
-  if (runtime.state === 'live' && runtime.child) {
+  // After ControlPersist daemonization the foreground child has exited but the
+  // master daemon owns the control socket, so 'live' alone is the source of
+  // truth for liveness here.
+  if (runtime.state === 'live') {
     return { remoteSocketPath: runtime.remoteSocketPath, controlPath: runtime.controlPath }
   }
   if (!runtime.ready) {
@@ -438,21 +449,24 @@ export async function stopHostConnection(hostId: HostId): Promise<void> {
   const runtime = runtimes.get(hostId)
   if (!runtime) return
 
+  // Always send `-O exit`: after ControlPersist daemonization the master is
+  // owned by a forked child we no longer track, so the control socket is the
+  // only handle on it. Falls through harmlessly if the socket is already gone.
+  await runSsh(
+    [
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      `ControlPath=${runtime.controlPath}`,
+      '-O',
+      'exit',
+      '--',
+      runtime.host.alias,
+    ],
+    2000,
+    { hostId: runtime.host.hostId, kind: 'control-exit' }
+  ).catch(() => undefined)
   if (runtime.child) {
-    await runSsh(
-      [
-        '-o',
-        'BatchMode=yes',
-        '-o',
-        `ControlPath=${runtime.controlPath}`,
-        '-O',
-        'exit',
-        '--',
-        runtime.host.alias,
-      ],
-      2000,
-      { hostId: runtime.host.hostId, kind: 'control-exit' }
-    ).catch(() => undefined)
     try {
       runtime.child.kill()
     } catch {


### PR DESCRIPTION
## Summary
- Creating a session on an SSH project failed with `Error: ssh control connection exited: 0`. Root cause: the ssh master is launched with `ControlPersist=10m` + `ControlMaster=yes`, so OpenSSH forks the foreground process to the background once authentication completes — the parent exits cleanly (code 0) while the daemon keeps the control socket alive. cc-pewpew interpreted every parent exit as failure.
- Reproduced directly: `ssh -N -M -o ControlPersist=10m … x86-igalia-box </dev/null` exits 0 with empty stderr while the control socket persists.

## Changes
- Exit handler: skip rejection when `code === 0`; the daemon owns the socket.
- `waitForControl`: drop the `runtime.child.exitCode !== null` early-bail. A non-zero exit is still surfaced via `exitPromise` and wins `Promise.race`; the deadline still bounds the wait.
- `ensureHostConnection`: live fast-path keys off `state === 'live'` only — the parent handle is misleading after daemonization.
- `stopHostConnection`: always send `-O exit` since the daemon may be alive without us holding a parent reference.

## Tests (TDD)
Two new tests in `src/main/host-connection.test.ts`:
- "reaches live state when the parent ssh exits 0 after daemonization" — pins the basic daemonization case (failed before fix with the original error message).
- "still reaches live state when parent exits 0 between poll attempts" — pins the race scenario where exit fires during a `controlCheck` interval (failed before fix with "did not become ready").
- Plus regression coverage for non-zero exit and the live fast-path.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .`
- [x] `npx vitest run` — 309 passing
- [ ] Smoke test: create a new session on an SSH project end-to-end