### PR TITLE
feat: accept multi-PR specs in New PR session

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,6 +30,7 @@ import {
   createSessionForWorktree,
   mirrorAllWorktrees,
   createPrSession,
+  createPrSessions,
   openSessionsForOpenPrs,
   openSessionsForOpenIssues,
   getSession,
@@ -290,6 +291,13 @@ app.whenReady().then(async () => {
     'sessions:create-pr',
     async (_event, projectPath: string, prNumber: number, hostId?: string | null) => {
       return createPrSession(projectPath, prNumber, hostId ?? null)
+    }
+  )
+
+  ipcMain.handle(
+    'sessions:create-prs',
+    async (_event, projectPath: string, prNumbers: number[], hostId?: string | null) => {
+      return createPrSessions(projectPath, prNumbers, hostId ?? null)
     }
   )
 

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1501,3 +1501,82 @@ describe('openSessionsForOpenIssues', () => {
     expect(result.failed).toEqual([{ number: 5, error: 'boom' }])
   })
 })
+
+describe('createPrSessions', () => {
+  it('skips numbers that already have a session and creates the rest', async () => {
+    const sm = await loadSessionManager()
+    writeSessionsJson([baseLocalSession({ id: 's-existing', prNumber: 7, projectPath: '/proj' })])
+    sm.restoreSessions()
+
+    const createPrSession = vi.fn(
+      async (_projectPath: string, prNumber: number, _hostId: string | null) =>
+        baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session | string
+    )
+
+    const result = await sm.createPrSessions('/proj', [7, 8, 9], null, { createPrSession })
+    expect(typeof result).not.toBe('string')
+    if (typeof result === 'string') throw new Error(result)
+
+    expect(result.skipped).toEqual([7])
+    expect(result.created.map((s) => s.prNumber).sort()).toEqual([8, 9])
+    expect(result.failed).toEqual([])
+    expect(createPrSession).toHaveBeenCalledTimes(2)
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 8, null)
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 9, null)
+  })
+
+  it('aggregates per-number failures into the summary', async () => {
+    const sm = await loadSessionManager()
+    const createPrSession = vi.fn(
+      async (_projectPath: string, prNumber: number, _hostId: string | null) =>
+        prNumber === 5
+          ? `PR #${prNumber} not found.`
+          : (baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session)
+    )
+    const result = await sm.createPrSessions('/proj', [4, 5, 6], null, { createPrSession })
+    if (typeof result === 'string') throw new Error(result)
+    expect(result.created.map((s) => s.prNumber).sort()).toEqual([4, 6])
+    expect(result.failed).toEqual([{ number: 5, error: 'PR #5 not found.' }])
+    expect(result.skipped).toEqual([])
+  })
+
+  it('dedupes duplicate inputs before invoking createPrSession', async () => {
+    const sm = await loadSessionManager()
+    const createPrSession = vi.fn(
+      async (_projectPath: string, prNumber: number, _hostId: string | null) =>
+        baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session | string
+    )
+    const result = await sm.createPrSessions('/proj', [3, 3, 3], null, { createPrSession })
+    if (typeof result === 'string') throw new Error(result)
+    expect(createPrSession).toHaveBeenCalledTimes(1)
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 3, null)
+    expect(result.created.map((s) => s.prNumber)).toEqual([3])
+  })
+
+  it('does not skip numbers from sessions belonging to a different project', async () => {
+    const sm = await loadSessionManager()
+    writeSessionsJson([
+      baseLocalSession({ id: 's-other', prNumber: 5, projectPath: '/other-proj' }),
+    ])
+    sm.restoreSessions()
+
+    const createPrSession = vi.fn(
+      async (_projectPath: string, prNumber: number, _hostId: string | null) =>
+        baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session | string
+    )
+    const result = await sm.createPrSessions('/proj', [5], null, { createPrSession })
+    if (typeof result === 'string') throw new Error(result)
+    expect(result.skipped).toEqual([])
+    expect(result.created.map((s) => s.prNumber)).toEqual([5])
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 5, null)
+  })
+
+  it('returns an empty summary for an empty number list', async () => {
+    const sm = await loadSessionManager()
+    const createPrSession = vi.fn()
+    const result = await sm.createPrSessions('/proj', [], null, { createPrSession })
+    if (typeof result === 'string') throw new Error(result)
+    expect(result).toEqual({ created: [], skipped: [], failed: [] })
+    expect(createPrSession).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1689,21 +1689,13 @@ async function listOpenIssues(
     : listRemoteOpenGhItems(projectPath, hostId, 'issue')
 }
 
-async function openSessionsForNumberedItems(
+async function createSessionsForNumbers(
   projectPath: string,
   hostId: string | null,
   field: 'prNumber' | 'issueNumber',
-  listItems: ListNumberedItems,
+  numbers: number[],
   createSession: CreateNumberedSession
-): Promise<OpenSessionsSummary | string> {
-  let items: NumberedGhItem[] | string
-  try {
-    items = await listItems(projectPath, hostId)
-  } catch (err) {
-    return describeGhError(err)
-  }
-  if (typeof items === 'string') return items
-
+): Promise<OpenSessionsSummary> {
   const existing = new Set<number>()
   for (const entry of sessions.values()) {
     if (entry.session.hostId !== hostId || entry.session.projectPath !== projectPath) continue
@@ -1711,7 +1703,10 @@ async function openSessionsForNumberedItems(
     if (number !== undefined) existing.add(number)
   }
 
-  const { toCreate, toSkip } = selectNumbersToOpen(items, existing)
+  const { toCreate, toSkip } = selectNumbersToOpen(
+    numbers.map((n) => ({ number: n })),
+    existing
+  )
   const created: Session[] = []
   const failed: { number: number; error: string }[] = []
 
@@ -1729,6 +1724,30 @@ async function openSessionsForNumberedItems(
   }
 
   return { created, skipped: toSkip, failed }
+}
+
+async function openSessionsForNumberedItems(
+  projectPath: string,
+  hostId: string | null,
+  field: 'prNumber' | 'issueNumber',
+  listItems: ListNumberedItems,
+  createSession: CreateNumberedSession
+): Promise<OpenSessionsSummary | string> {
+  let items: NumberedGhItem[] | string
+  try {
+    items = await listItems(projectPath, hostId)
+  } catch (err) {
+    return describeGhError(err)
+  }
+  if (typeof items === 'string') return items
+
+  return createSessionsForNumbers(
+    projectPath,
+    hostId,
+    field,
+    items.map((i) => i.number),
+    createSession
+  )
 }
 
 function describeRemoteGhProbeFailure(
@@ -1821,6 +1840,22 @@ export async function createPrSession(
   }
   onSessionsChanged()
   return session
+}
+
+export async function createPrSessions(
+  projectPath: string,
+  prNumbers: number[],
+  hostId: string | null = null,
+  deps: { createPrSession?: CreateNumberedSession } = {}
+): Promise<OpenSessionsSummary | string> {
+  const deduped = Array.from(new Set(prNumbers)).sort((a, b) => a - b)
+  return createSessionsForNumbers(
+    projectPath,
+    hostId,
+    'prNumber',
+    deduped,
+    deps.createPrSession ?? createPrSession
+  )
 }
 
 export async function createIssueSession(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,6 +22,8 @@ contextBridge.exposeInMainWorld('api', {
   ) => ipcRenderer.invoke('sessions:create', projectPath, name, hostId ?? null, options),
   createPrSession: (projectPath: string, prNumber: number, hostId?: string | null) =>
     ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber, hostId ?? null),
+  createPrSessions: (projectPath: string, prNumbers: number[], hostId?: string | null) =>
+    ipcRenderer.invoke('sessions:create-prs', projectPath, prNumbers, hostId ?? null),
   openSessionsForOpenPrs: (projectPath: string, hostId?: string | null) =>
     ipcRenderer.invoke('sessions:open-all-prs', projectPath, hostId ?? null),
   openSessionsForOpenIssues: (projectPath: string, hostId?: string | null) =>

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -4,6 +4,7 @@ import { useSessionsStore } from '../stores/sessions'
 import { useHostsStore } from '../stores/hosts'
 import ContextMenu, { type MenuItem } from './ContextMenu'
 import type { AgentTool, OpenSessionsSummary } from '../../shared/types'
+import { parsePrSpec } from '../utils/pr-spec-parser'
 
 interface MenuState {
   x: number
@@ -106,6 +107,18 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
       return "Could not determine origin's default branch."
     }
     return message.replace(/^Error:\s*/, '') || 'Failed to create session.'
+  }
+
+  const formatPrSpecSummary = (result: OpenSessionsSummary): string => {
+    const parts: string[] = []
+    if (result.created.length > 0) {
+      parts.push(
+        `Opened ${result.created.length} PR session${result.created.length === 1 ? '' : 's'}`
+      )
+    }
+    if (result.skipped.length > 0) parts.push(`skipped ${result.skipped.length}`)
+    if (result.failed.length > 0) parts.push(`${result.failed.length} failed`)
+    return parts.length > 0 ? parts.join(', ') : 'No PR sessions created'
   }
 
   const formatOpenAllSummary = (result: OpenSessionsSummary, label: 'PR' | 'issue'): string => {
@@ -313,22 +326,41 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
 
   const handleCreatePrSession = async () => {
     if (!pendingPrPath || creating) return
-    const num = parseInt(prNumberInput.trim(), 10)
-    if (isNaN(num) || num <= 0) {
-      setPrError('Enter a valid PR number.')
+    const parsed = parsePrSpec(prNumberInput)
+    if ('error' in parsed) {
+      setPrError(parsed.error)
       return
     }
     setCreating(true)
     setPrError(null)
     try {
-      const result = await window.api.createPrSession(pendingPrPath, num, pendingPrHostId)
+      const result = await window.api.createPrSessions(
+        pendingPrPath,
+        parsed.numbers,
+        pendingPrHostId
+      )
       if (typeof result === 'string') {
         setPrError(result)
-      } else {
+        return
+      }
+      if (parsed.numbers.length === 1) {
+        if (result.failed.length === 1) {
+          setPrError(result.failed[0].error)
+          return
+        }
+        if (result.skipped.length === 1) {
+          setPrError(`PR #${result.skipped[0]} already has a session.`)
+          return
+        }
         setPendingPrPath(null)
         setPendingPrHostId(null)
         setPrNumberInput('')
+        return
       }
+      showToast(formatPrSpecSummary(result))
+      setPendingPrPath(null)
+      setPendingPrHostId(null)
+      setPrNumberInput('')
     } finally {
       setCreating(false)
     }
@@ -409,11 +441,11 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
       )}
       {pendingPrPath && (
         <div className="session-name-dialog">
-          <div className="session-name-label">PR number:</div>
+          <div className="session-name-label">PR number(s):</div>
           <input
             type="text"
             className="create-input"
-            placeholder="e.g. 42"
+            placeholder="e.g. 42 or 1,2,22-28"
             value={prNumberInput}
             onChange={(e) => setPrNumberInput(e.target.value)}
             onKeyDown={(e) => {

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -36,6 +36,11 @@ declare global {
         prNumber: number,
         hostId?: string | null
       ) => Promise<Session | string>
+      createPrSessions: (
+        projectPath: string,
+        prNumbers: number[],
+        hostId?: string | null
+      ) => Promise<OpenSessionsSummary | string>
       openSessionsForOpenPrs: (
         projectPath: string,
         hostId?: string | null

--- a/src/renderer/utils/pr-spec-parser.test.ts
+++ b/src/renderer/utils/pr-spec-parser.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { parsePrSpec, MAX_PR_SPEC_NUMBERS } from './pr-spec-parser'
+
+describe('parsePrSpec', () => {
+  describe('valid input', () => {
+    it('parses a single PR number', () => {
+      expect(parsePrSpec('42')).toEqual({ numbers: [42] })
+    })
+
+    it('parses a comma-separated list', () => {
+      expect(parsePrSpec('1,2,3')).toEqual({ numbers: [1, 2, 3] })
+    })
+
+    it('parses an inclusive range', () => {
+      expect(parsePrSpec('1-3')).toEqual({ numbers: [1, 2, 3] })
+    })
+
+    it('parses a mixed list of numbers and ranges', () => {
+      expect(parsePrSpec('1,2,22-25')).toEqual({ numbers: [1, 2, 22, 23, 24, 25] })
+    })
+
+    it('matches the example from the feature spec', () => {
+      expect(parsePrSpec('1,2,22-28')).toEqual({
+        numbers: [1, 2, 22, 23, 24, 25, 26, 27, 28],
+      })
+    })
+
+    it('tolerates whitespace inside and around tokens', () => {
+      expect(parsePrSpec(' 1 ,  2 - 4 , 5 ')).toEqual({ numbers: [1, 2, 3, 4, 5] })
+    })
+
+    it('treats a single-element range as one number', () => {
+      expect(parsePrSpec('5-5')).toEqual({ numbers: [5] })
+    })
+
+    it('dedupes overlapping numbers', () => {
+      expect(parsePrSpec('1,1,2-3,3')).toEqual({ numbers: [1, 2, 3] })
+    })
+
+    it('returns numbers sorted ascending even when input is not', () => {
+      expect(parsePrSpec('5,1,3')).toEqual({ numbers: [1, 3, 5] })
+    })
+
+    it('skips empty tokens between commas', () => {
+      expect(parsePrSpec('1,,2,')).toEqual({ numbers: [1, 2] })
+    })
+  })
+
+  describe('input errors', () => {
+    it('rejects empty input', () => {
+      expect(parsePrSpec('')).toEqual({ error: 'Enter at least one PR number.' })
+    })
+
+    it('rejects whitespace-only input', () => {
+      expect(parsePrSpec('   ')).toEqual({ error: 'Enter at least one PR number.' })
+    })
+
+    it('rejects input that is only commas', () => {
+      expect(parsePrSpec(',,,')).toEqual({ error: 'Enter at least one PR number.' })
+    })
+
+    it('rejects non-numeric tokens', () => {
+      const r = parsePrSpec('abc')
+      expect(r).toEqual({ error: 'Invalid PR spec: "abc".' })
+    })
+
+    it('rejects malformed range tokens', () => {
+      expect(parsePrSpec('1-')).toEqual({ error: 'Invalid PR spec: "1-".' })
+      expect(parsePrSpec('-3')).toEqual({ error: 'Invalid PR spec: "-3".' })
+      expect(parsePrSpec('1--3')).toEqual({ error: 'Invalid PR spec: "1--3".' })
+    })
+
+    it('rejects floats', () => {
+      expect(parsePrSpec('1.5')).toEqual({ error: 'Invalid PR spec: "1.5".' })
+    })
+
+    it('rejects whitespace inside numeric tokens', () => {
+      expect(parsePrSpec('1 2')).toEqual({ error: 'Invalid PR spec: "1 2".' })
+    })
+
+    it('rejects zero', () => {
+      expect(parsePrSpec('0')).toEqual({ error: 'PR numbers must be 1 or greater.' })
+    })
+
+    it('rejects ranges with start > end', () => {
+      expect(parsePrSpec('5-3')).toEqual({ error: 'Invalid range "5-3": start > end.' })
+    })
+
+    it('rejects ranges that exceed the size cap', () => {
+      const result = parsePrSpec(`1-${MAX_PR_SPEC_NUMBERS + 1}`)
+      expect(result).toEqual({
+        error: `Range "1-${MAX_PR_SPEC_NUMBERS + 1}" is too large (max ${MAX_PR_SPEC_NUMBERS}).`,
+      })
+    })
+
+    it('rejects total numbers exceeding the cap across multiple tokens', () => {
+      // Two tokens within their own cap but combined exceed it.
+      const half = Math.floor(MAX_PR_SPEC_NUMBERS / 2)
+      const a = `1-${half + 1}` // half+1 numbers
+      const b = `1000-${1000 + half + 1}` // half+2 numbers
+      const result = parsePrSpec(`${a},${b}`)
+      expect(result).toEqual({
+        error: `Too many PR numbers (max ${MAX_PR_SPEC_NUMBERS}).`,
+      })
+    })
+
+    it('rejects values exceeding safe integer range', () => {
+      expect(parsePrSpec('99999999999999999')).toEqual({
+        error: 'PR numbers must be 1 or greater.',
+      })
+    })
+  })
+})

--- a/src/renderer/utils/pr-spec-parser.ts
+++ b/src/renderer/utils/pr-spec-parser.ts
@@ -1,0 +1,42 @@
+export const MAX_PR_SPEC_NUMBERS = 200
+
+export type PrSpecResult = { numbers: number[] } | { error: string }
+
+const TOKEN_RE = /^(\d+)(?:\s*-\s*(\d+))?$/
+
+export function parsePrSpec(input: string): PrSpecResult {
+  const trimmed = input.trim()
+  if (trimmed.length === 0) return { error: 'Enter at least one PR number.' }
+
+  const tokens = trimmed
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+  if (tokens.length === 0) return { error: 'Enter at least one PR number.' }
+
+  const result = new Set<number>()
+  for (const token of tokens) {
+    const match = TOKEN_RE.exec(token)
+    if (!match) return { error: `Invalid PR spec: "${token}".` }
+
+    const lo = Number.parseInt(match[1], 10)
+    const hi = match[2] === undefined ? lo : Number.parseInt(match[2], 10)
+
+    if (!Number.isSafeInteger(lo) || !Number.isSafeInteger(hi) || lo < 1 || hi < 1) {
+      return { error: 'PR numbers must be 1 or greater.' }
+    }
+    if (hi < lo) return { error: `Invalid range "${token}": start > end.` }
+    if (hi - lo + 1 > MAX_PR_SPEC_NUMBERS) {
+      return { error: `Range "${token}" is too large (max ${MAX_PR_SPEC_NUMBERS}).` }
+    }
+
+    for (let n = lo; n <= hi; n++) {
+      result.add(n)
+      if (result.size > MAX_PR_SPEC_NUMBERS) {
+        return { error: `Too many PR numbers (max ${MAX_PR_SPEC_NUMBERS}).` }
+      }
+    }
+  }
+
+  return { numbers: Array.from(result).sort((a, b) => a - b) }
+}


### PR DESCRIPTION
## Summary
- Accept comma lists, inclusive ranges, and mixed specs (e.g. `1,2,22-28`) in the **New PR session** dialog. PRs already with a session are skipped silently.
- New pure parser `parsePrSpec` (renderer/utils) with safe-int + range cap (200), covering 22 cases.
- Backend extracts `createSessionsForNumbers` from `openSessionsForNumberedItems` (skip-existing + per-number create loop) and reuses it in a new `createPrSessions(projectPath, prNumbers, hostId)` exposed via IPC.
- UI preserves single-number UX: silent close on success, inline error on failure or "already has a session". Multi-number submits show a toast summary.

## Test plan
- [x] `npx vitest run src/renderer/utils/pr-spec-parser.test.ts` — 22 parser tests
- [x] `npx vitest run src/main/session-manager.test.ts` — 5 new `createPrSessions` tests + existing `openSessionsForOpenPrs` still passing after refactor
- [x] `npx vitest run` — 336/336 pass
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [ ] Manual: local project — `42`, `1,2,3`, `1-3` (one already opened), `5-3` (parse error), `1-1000` (cap)
- [ ] Manual: remote project — same scenarios over SSH