### PR TITLE
refactor: extract handleHookEvent into pure session state-machine reducer

### DIFF
--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -40,6 +40,7 @@ import { getHost, setHostAgentPaths } from './host-registry'
 import { listRemoteProjects } from './remote-project-registry'
 import { listenHookServerForHost } from './hook-server'
 import { classifySshExit } from './ssh-exit-parser'
+import { applyHookEvent, type SideEffectIntent } from './session-state-machine'
 import {
   ensureHostConnection,
   exec as execRemote,
@@ -1023,76 +1024,45 @@ export async function createSession(
   return createSessionForWorktree(projectPath, worktreePath, worktreeName, options.tool)
 }
 
+function realizeIntent(intent: SideEffectIntent): void {
+  switch (intent.kind) {
+    case 'notifyNeedsInput': {
+      const e = sessions.get(intent.sessionId)
+      if (e) notifyNeedsInput(e.session)
+      return
+    }
+    case 'promptCleanup':
+      // Fire-and-forget, but attach a catch so a remote removeSession failure
+      // doesn't become an unhandled rejection in the main process.
+      promptCleanup(intent.sessionId).catch((err) => {
+        console.error(`promptCleanup(${intent.sessionId}) failed:`, err)
+      })
+      return
+  }
+}
+
 export function handleHookEvent(
   method: string,
   params: Record<string, unknown>,
   originHostId: string | null = null
 ): boolean {
-  // Match hook event to our session. CC's session_id differs from our internal id,
-  // so match by cwd (worktree path) which is unique per session.
-  const cwd = params.cwd as string | undefined
-  const ccSessionId = (params.session_id ?? params.sessionId) as string | undefined
+  const currentState = new Map<string, Session>()
+  for (const e of sessions.values()) currentState.set(e.session.id, e.session)
 
-  // Filter by origin first so local and remote sessions with the same worktree
-  // path don't shadow each other — picking the wrong one would drop the event.
-  let entry: SessionEntry | undefined
-  for (const e of sessions.values()) {
-    if ((e.session.hostId ?? null) !== originHostId) continue
-    // Primary match: cwd matches our worktreePath
-    if (cwd && e.session.worktreePath && cwd.startsWith(e.session.worktreePath)) {
-      entry = e
-      break
-    }
-    // Fallback: exact id match (in case we somehow share IDs)
-    if (ccSessionId && e.session.id === ccSessionId) {
-      entry = e
-      break
+  const result = applyHookEvent(currentState, { method, params, originHostId }, Date.now())
+  if (!result.matched) return false
+
+  let mutated = false
+  for (const [id, nextSession] of result.state) {
+    const entry = sessions.get(id)
+    if (entry && entry.session !== nextSession) {
+      entry.session = nextSession
+      mutated = true
     }
   }
-  if (!entry) return false
+  for (const intent of result.intents) realizeIntent(intent)
 
-  switch (method) {
-    case 'session.start':
-      entry.session.status = 'running'
-      entry.session.connectionState = originHostId ? 'live' : entry.session.connectionState
-      // Capture codex's session_id so `codex resume <id>` can recover the same
-      // conversation after restart. Claude resumes via `--continue` and doesn't
-      // need this.
-      if (entry.session.tool === 'codex' && ccSessionId && !entry.session.agentSessionId) {
-        entry.session.agentSessionId = ccSessionId
-      }
-      break
-    case 'session.stop':
-      entry.session.status = 'needs_input'
-      entry.session.connectionState = originHostId ? 'live' : entry.session.connectionState
-      notifyNeedsInput(entry.session)
-      break
-    case 'session.activity':
-      entry.session.status = 'running'
-      entry.session.connectionState = originHostId ? 'live' : entry.session.connectionState
-      break
-    case 'session.end':
-      // Fire-and-forget, but attach a catch so a remote removeSession failure
-      // doesn't become an unhandled rejection in the main process.
-      promptCleanup(entry.session.id).catch((err) => {
-        console.error(`promptCleanup(${entry.session.id}) failed:`, err)
-      })
-      return true
-    case 'session.notification':
-      entry.session.hookEvents.push({
-        method,
-        sessionId: ccSessionId || entry.session.id,
-        timestamp: Date.now(),
-        originHostId,
-        data: params,
-      })
-      break
-    default:
-      return false
-  }
-
-  entry.session.lastActivity = Date.now()
-  onSessionsChanged()
+  if (mutated) onSessionsChanged()
   return true
 }
 

--- a/src/main/session-state-machine.test.ts
+++ b/src/main/session-state-machine.test.ts
@@ -93,6 +93,20 @@ describe('applyHookEvent — session.start', () => {
     )
     expect(result.state.get('cx2')?.agentSessionId).toBe('first')
   })
+
+  it('captures camelCase sessionId alias as agentSessionId for codex sessions', () => {
+    const session = makeSession({ id: 'cx3', worktreePath: '/cx/wt', tool: 'codex' })
+    const result = applyHookEvent(
+      stateOf(session),
+      {
+        method: 'session.start',
+        params: { cwd: '/cx/wt', sessionId: 'codex-uuid-camel' },
+        originHostId: null,
+      },
+      1
+    )
+    expect(result.state.get('cx3')?.agentSessionId).toBe('codex-uuid-camel')
+  })
 })
 
 describe('applyHookEvent — session.activity', () => {
@@ -157,6 +171,20 @@ describe('applyHookEvent — session.notification', () => {
       1
     )
     expect(result.state.get('s2')!.hookEvents[0].sessionId).toBe('s2')
+  })
+
+  it('uses camelCase sessionId alias for the appended hook-event sessionId', () => {
+    const session = makeSession({ id: 's3', hookEvents: [] })
+    const result = applyHookEvent(
+      stateOf(session),
+      {
+        method: 'session.notification',
+        params: { cwd: '/p/w', sessionId: 'cc-uuid-camel' },
+        originHostId: null,
+      },
+      1
+    )
+    expect(result.state.get('s3')!.hookEvents[0].sessionId).toBe('cc-uuid-camel')
   })
 })
 

--- a/src/main/session-state-machine.test.ts
+++ b/src/main/session-state-machine.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from 'vitest'
+import type { Session } from '../shared/types'
+import { applyHookEvent } from './session-state-machine'
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 's1',
+    hostId: null,
+    projectPath: '/p',
+    projectName: 'p',
+    worktreeName: 'w',
+    worktreePath: '/p/w',
+    branch: 'main',
+    pid: 0,
+    tmuxSession: 'cc-pewpew-s1',
+    status: 'idle',
+    lastActivity: 0,
+    hookEvents: [],
+    tool: 'claude',
+    ...overrides,
+  }
+}
+
+function stateOf(...sessions: Session[]): Map<string, Session> {
+  return new Map(sessions.map((s) => [s.id, s]))
+}
+
+describe('applyHookEvent — session.stop', () => {
+  it('sets status to needs_input and emits a notifyNeedsInput intent for a matching local session', () => {
+    const session = makeSession({ id: 's1', worktreePath: '/p/w', status: 'running' })
+    const state = stateOf(session)
+    const now = 1_700_000_000_000
+
+    const result = applyHookEvent(
+      state,
+      { method: 'session.stop', params: { cwd: '/p/w' }, originHostId: null },
+      now
+    )
+
+    expect(result.matched).toBe(true)
+    expect(result.state.get('s1')?.status).toBe('needs_input')
+    expect(result.state.get('s1')?.lastActivity).toBe(now)
+    expect(result.intents).toContainEqual({ kind: 'notifyNeedsInput', sessionId: 's1' })
+  })
+})
+
+describe('applyHookEvent — session.start', () => {
+  it('captures session_id as agentSessionId for codex sessions', () => {
+    const session = makeSession({ id: 'cx1', worktreePath: '/cx/wt', tool: 'codex' })
+    const result = applyHookEvent(
+      stateOf(session),
+      {
+        method: 'session.start',
+        params: { cwd: '/cx/wt', session_id: 'codex-uuid-9' },
+        originHostId: null,
+      },
+      1
+    )
+    expect(result.matched).toBe(true)
+    expect(result.state.get('cx1')?.agentSessionId).toBe('codex-uuid-9')
+    expect(result.state.get('cx1')?.status).toBe('running')
+  })
+
+  it('does not capture agentSessionId for claude sessions', () => {
+    const session = makeSession({ id: 'cl1', worktreePath: '/cl/wt', tool: 'claude' })
+    const result = applyHookEvent(
+      stateOf(session),
+      {
+        method: 'session.start',
+        params: { cwd: '/cl/wt', session_id: 'should-not-store' },
+        originHostId: null,
+      },
+      1
+    )
+    expect(result.state.get('cl1')?.agentSessionId).toBeUndefined()
+  })
+
+  it('does not overwrite an existing agentSessionId', () => {
+    const session = makeSession({
+      id: 'cx2',
+      worktreePath: '/cx/wt',
+      tool: 'codex',
+      agentSessionId: 'first',
+    })
+    const result = applyHookEvent(
+      stateOf(session),
+      {
+        method: 'session.start',
+        params: { cwd: '/cx/wt', session_id: 'second' },
+        originHostId: null,
+      },
+      1
+    )
+    expect(result.state.get('cx2')?.agentSessionId).toBe('first')
+  })
+})
+
+describe('applyHookEvent — session.activity', () => {
+  it('flips status to running and emits no intents', () => {
+    const session = makeSession({ id: 's1', status: 'idle' })
+    const result = applyHookEvent(
+      stateOf(session),
+      { method: 'session.activity', params: { cwd: '/p/w' }, originHostId: null },
+      42
+    )
+    expect(result.matched).toBe(true)
+    expect(result.state.get('s1')?.status).toBe('running')
+    expect(result.state.get('s1')?.lastActivity).toBe(42)
+    expect(result.intents).toEqual([])
+  })
+})
+
+describe('applyHookEvent — session.end', () => {
+  it('emits promptCleanup intent and returns state unchanged', () => {
+    const session = makeSession({ id: 's1', status: 'running', lastActivity: 0 })
+    const original = stateOf(session)
+    const result = applyHookEvent(
+      original,
+      { method: 'session.end', params: { cwd: '/p/w' }, originHostId: null },
+      99
+    )
+    expect(result.matched).toBe(true)
+    expect(result.intents).toContainEqual({ kind: 'promptCleanup', sessionId: 's1' })
+    // State must be unchanged — promptCleanup runs async and removeSession will
+    // reduce state separately. The reducer must not pre-emptively mutate.
+    expect(result.state.get('s1')).toEqual(session)
+  })
+})
+
+describe('applyHookEvent — session.notification', () => {
+  it('appends a HookEvent and bumps lastActivity', () => {
+    const session = makeSession({ id: 's1', hookEvents: [] })
+    const params = { cwd: '/p/w', session_id: 'cc-uuid', message: 'hi' }
+    const result = applyHookEvent(
+      stateOf(session),
+      { method: 'session.notification', params, originHostId: null },
+      77
+    )
+    expect(result.matched).toBe(true)
+    const updated = result.state.get('s1')!
+    expect(updated.lastActivity).toBe(77)
+    expect(updated.hookEvents).toHaveLength(1)
+    expect(updated.hookEvents[0]).toMatchObject({
+      method: 'session.notification',
+      sessionId: 'cc-uuid',
+      timestamp: 77,
+      originHostId: null,
+      data: params,
+    })
+  })
+
+  it('falls back to internal id when session_id is absent', () => {
+    const session = makeSession({ id: 's2', hookEvents: [] })
+    const result = applyHookEvent(
+      stateOf(session),
+      { method: 'session.notification', params: { cwd: '/p/w' }, originHostId: null },
+      1
+    )
+    expect(result.state.get('s2')!.hookEvents[0].sessionId).toBe('s2')
+  })
+})
+
+describe('applyHookEvent — origin host filtering', () => {
+  it('does not match a local session when event originHostId is set', () => {
+    const local = makeSession({ id: 'local', hostId: null, worktreePath: '/shared/wt' })
+    const result = applyHookEvent(
+      stateOf(local),
+      { method: 'session.stop', params: { cwd: '/shared/wt' }, originHostId: 'h1' },
+      1
+    )
+    expect(result.matched).toBe(false)
+    expect(result.state.get('local')?.status).toBe('idle')
+  })
+
+  it('does not match a remote session when event originHostId is null', () => {
+    const remote = makeSession({ id: 'remote', hostId: 'h1', worktreePath: '/shared/wt' })
+    const result = applyHookEvent(
+      stateOf(remote),
+      { method: 'session.stop', params: { cwd: '/shared/wt' }, originHostId: null },
+      1
+    )
+    expect(result.matched).toBe(false)
+  })
+
+  it('picks the remote session over a same-cwd local one when origin matches', () => {
+    const local = makeSession({ id: 'local', hostId: null, worktreePath: '/shared/wt' })
+    const remote = makeSession({ id: 'remote', hostId: 'h1', worktreePath: '/shared/wt' })
+    const result = applyHookEvent(
+      new Map([
+        ['local', local],
+        ['remote', remote],
+      ]),
+      { method: 'session.stop', params: { cwd: '/shared/wt' }, originHostId: 'h1' },
+      1
+    )
+    expect(result.matched).toBe(true)
+    expect(result.state.get('remote')?.status).toBe('needs_input')
+    expect(result.state.get('local')?.status).toBe('idle')
+  })
+})
+
+describe('applyHookEvent — match precedence', () => {
+  it('matches when cwd is a subdirectory of worktreePath (startsWith, not equality)', () => {
+    const session = makeSession({ id: 's1', worktreePath: '/p/w', status: 'running' })
+    const result = applyHookEvent(
+      stateOf(session),
+      { method: 'session.stop', params: { cwd: '/p/w/sub/dir' }, originHostId: null },
+      1
+    )
+    expect(result.matched).toBe(true)
+    expect(result.state.get('s1')?.status).toBe('needs_input')
+  })
+
+  it('falls back to internal id when no session matches by cwd', () => {
+    const session = makeSession({ id: 'abc12345', worktreePath: '/p/w', status: 'running' })
+    const result = applyHookEvent(
+      stateOf(session),
+      {
+        method: 'session.stop',
+        params: { cwd: '/elsewhere', session_id: 'abc12345' },
+        originHostId: null,
+      },
+      1
+    )
+    expect(result.matched).toBe(true)
+    expect(result.state.get('abc12345')?.status).toBe('needs_input')
+  })
+
+  it('also accepts sessionId (camelCase) as a session_id alias', () => {
+    const session = makeSession({ id: 'abc12345', worktreePath: '/p/w' })
+    const result = applyHookEvent(
+      stateOf(session),
+      { method: 'session.stop', params: { sessionId: 'abc12345' }, originHostId: null },
+      1
+    )
+    expect(result.matched).toBe(true)
+  })
+})
+
+describe('applyHookEvent — remote connectionState', () => {
+  it.each(['session.start', 'session.stop', 'session.activity'])(
+    '%s on a remote session sets connectionState to live',
+    (method) => {
+      const session = makeSession({
+        id: 'r1',
+        hostId: 'h1',
+        worktreePath: '/p/w',
+        connectionState: 'pending',
+      })
+      const result = applyHookEvent(
+        stateOf(session),
+        { method, params: { cwd: '/p/w' }, originHostId: 'h1' },
+        1
+      )
+      expect(result.state.get('r1')?.connectionState).toBe('live')
+    }
+  )
+
+  it('preserves connectionState on local session.start (no originHostId)', () => {
+    const session = makeSession({ id: 'l1', hostId: null, connectionState: undefined })
+    const result = applyHookEvent(
+      stateOf(session),
+      { method: 'session.start', params: { cwd: '/p/w' }, originHostId: null },
+      1
+    )
+    expect(result.state.get('l1')?.connectionState).toBeUndefined()
+  })
+})
+
+describe('applyHookEvent — unknown method', () => {
+  it('returns state unchanged with no intents and matched=false even when a session matches by cwd', () => {
+    const session = makeSession({ id: 's1', worktreePath: '/p/w', status: 'running' })
+    const original = stateOf(session)
+    const result = applyHookEvent(
+      original,
+      { method: 'session.fnord', params: { cwd: '/p/w' }, originHostId: null },
+      1
+    )
+    expect(result.matched).toBe(false)
+    expect(result.intents).toEqual([])
+    expect(result.state).toBe(original)
+  })
+
+  it('returns matched=false when no session matches at all', () => {
+    const session = makeSession({ id: 's1', worktreePath: '/p/w' })
+    const result = applyHookEvent(
+      stateOf(session),
+      { method: 'session.stop', params: { cwd: '/elsewhere' }, originHostId: null },
+      1
+    )
+    expect(result.matched).toBe(false)
+    expect(result.intents).toEqual([])
+  })
+})

--- a/src/main/session-state-machine.ts
+++ b/src/main/session-state-machine.ts
@@ -45,7 +45,7 @@ export function applyHookEvent(
       next.status = 'running'
       next.lastActivity = now
       if (event.originHostId) next.connectionState = 'live'
-      const incoming = event.params.session_id as string | undefined
+      const incoming = (event.params.session_id ?? event.params.sessionId) as string | undefined
       if (next.tool === 'codex' && incoming && !next.agentSessionId) {
         next.agentSessionId = incoming
       }
@@ -69,7 +69,7 @@ export function applyHookEvent(
         matched: true,
       }
     case 'session.notification': {
-      const incoming = event.params.session_id as string | undefined
+      const incoming = (event.params.session_id ?? event.params.sessionId) as string | undefined
       next.hookEvents = [
         ...next.hookEvents,
         {

--- a/src/main/session-state-machine.ts
+++ b/src/main/session-state-machine.ts
@@ -1,0 +1,93 @@
+import type { Session } from '../shared/types'
+
+export type SessionsState = ReadonlyMap<string, Session>
+
+export interface HookEventInput {
+  method: string
+  params: Record<string, unknown>
+  originHostId: string | null
+}
+
+export type SideEffectIntent =
+  | { kind: 'notifyNeedsInput'; sessionId: string }
+  | { kind: 'promptCleanup'; sessionId: string }
+
+export interface ApplyResult {
+  state: SessionsState
+  intents: SideEffectIntent[]
+  matched: boolean
+}
+
+function findSession(state: SessionsState, event: HookEventInput): Session | undefined {
+  const cwd = event.params.cwd as string | undefined
+  const ccSessionId = (event.params.session_id ?? event.params.sessionId) as string | undefined
+  for (const s of state.values()) {
+    if ((s.hostId ?? null) !== event.originHostId) continue
+    if (cwd && s.worktreePath && cwd.startsWith(s.worktreePath)) return s
+    if (ccSessionId && s.id === ccSessionId) return s
+  }
+  return undefined
+}
+
+export function applyHookEvent(
+  state: SessionsState,
+  event: HookEventInput,
+  now: number
+): ApplyResult {
+  const target = findSession(state, event)
+  if (!target) return { state, intents: [], matched: false }
+
+  const intents: SideEffectIntent[] = []
+  const next: Session = { ...target }
+
+  switch (event.method) {
+    case 'session.start': {
+      next.status = 'running'
+      next.lastActivity = now
+      if (event.originHostId) next.connectionState = 'live'
+      const incoming = event.params.session_id as string | undefined
+      if (next.tool === 'codex' && incoming && !next.agentSessionId) {
+        next.agentSessionId = incoming
+      }
+      break
+    }
+    case 'session.stop':
+      next.status = 'needs_input'
+      next.lastActivity = now
+      if (event.originHostId) next.connectionState = 'live'
+      intents.push({ kind: 'notifyNeedsInput', sessionId: target.id })
+      break
+    case 'session.activity':
+      next.status = 'running'
+      next.lastActivity = now
+      if (event.originHostId) next.connectionState = 'live'
+      break
+    case 'session.end':
+      return {
+        state,
+        intents: [{ kind: 'promptCleanup', sessionId: target.id }],
+        matched: true,
+      }
+    case 'session.notification': {
+      const incoming = event.params.session_id as string | undefined
+      next.hookEvents = [
+        ...next.hookEvents,
+        {
+          method: event.method,
+          sessionId: incoming || target.id,
+          timestamp: now,
+          originHostId: event.originHostId,
+          data: event.params,
+        },
+      ]
+      next.lastActivity = now
+      break
+    }
+    default:
+      return { state, intents: [], matched: false }
+  }
+
+  const nextState = new Map(state)
+  nextState.set(target.id, next)
+  return { state: nextState, intents, matched: true }
+}


### PR DESCRIPTION
## Summary

First slice of the SessionManager split surfaced by the architecture audit (audit candidate #1). Pulls the `handleHookEvent` reducer out of `session-manager.ts` into a new `session-state-machine.ts` module as a **pure reducer** behind a small interface:

```ts
applyHookEvent(state, event, now) → { state, intents, matched }
```

State is a `ReadonlyMap<string, Session>`. Side effects (`notifyNeedsInput`, `promptCleanup`) become discriminated `SideEffectIntent` values that `session-manager` realizes after applying the returned state.

`handleHookEvent` is now a thin adapter:

1. Snapshot the `SessionEntry` map → `Map<string, Session>`.
2. Call `applyHookEvent`.
3. Write back any sessions whose reference changed.
4. Realize each intent.
5. `onSessionsChanged()` iff at least one session mutated (preserves the original `session.end` no-broadcast behaviour).

## Why

`session-manager.ts` is 2283 lines and owns: session lifecycle, worktree/git resolution, hook-event dispatch, remote bootstrap, host-connection lifecycle, and PTY orchestration. The reducer was the smallest piece where TDD genuinely shifts the test surface — from "mock the side effects" to "assert on the intents". This slice unblocks future work on a typed `HookEvent` union (audit candidate #2) since the reducer's input is now a clear chokepoint.

## What changed

- **New** `src/main/session-state-machine.ts` — pure reducer + intent types
- **New** `src/main/session-state-machine.test.ts` — 20 cases driven via TDD red→green, covers all five hook methods, host-origin filtering, cwd/sessionId match precedence, codex `agentSessionId` capture + idempotency, and the connectionState='live' flip on remote events
- **Modified** `src/main/session-manager.ts` — `handleHookEvent` body collapses from ~70 lines to ~20; net file size −30 lines
- Existing `codex agent integration` cases in `session-manager.test.ts` still pass — they now exercise the wire-in path

## Behaviour preserved

- cwd match wins, internal-id fallback (also accepts camelCase `sessionId`)
- origin-host filter prevents local/remote sessions at the same path from shadowing each other
- `connectionState='live'` set on `session.start/stop/activity` when `originHostId` is present
- codex `agentSessionId` captured once; never overwritten
- `session.end` does not mutate state or broadcast — only emits a `promptCleanup` intent
- Unknown methods return `matched=false` with empty intents

## Out of scope (next slices)

- Lift `HookEventInput` into a discriminated union in `src/shared/types.ts`
- Extract worktree/git resolver
- Extract remote bootstrap orchestrator
- Fold `updateLastKnownState` into the same reducer

## Test plan

- [x] `npx vitest run` — 356/356 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] `npx prettier --write` — formatted
- [ ] Manual smoke: launch the app, start a session, verify hook events still flip status (`running` → `needs_input` → `running`) and the cleanup dialog still appears on `session.end`