### PR TITLE
fix: stop "Branch from" worktrees auto-tracking origin/<default>

### DIFF
--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -505,6 +505,21 @@ describe('createSession origin-default base', () => {
       const originTip = git(project, ['rev-parse', 'origin/main']).trim()
       const worktreeTip = git(session.worktreePath, ['rev-parse', 'HEAD']).trim()
       expect(worktreeTip).toBe(originTip)
+
+      // The new branch must NOT track origin/main — pushes from this worktree
+      // would otherwise overwrite origin/main instead of creating origin/<branch>.
+      // `git rev-parse @{u}` exits non-zero when no upstream is configured.
+      let upstreamRef = ''
+      try {
+        upstreamRef = execFileSync(
+          'git',
+          ['-C', session.worktreePath, 'rev-parse', '--abbrev-ref', '@{u}'],
+          { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }
+        ).trim()
+      } catch {
+        upstreamRef = ''
+      }
+      expect(upstreamRef).toBe('')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -541,6 +556,7 @@ describe('createSession origin-default base', () => {
         'worktree',
         'add',
         worktreePath,
+        '--no-track',
         '-b',
         branchName,
         'refs/remotes/origin/main',
@@ -1301,7 +1317,8 @@ describe('createIssueSession', () => {
         return { stdout: 'abc123\n' }
       }
       if (
-        key === 'worktree add /proj/.claude/worktrees/issue-42 -b issue-42 refs/remotes/origin/main'
+        key ===
+        'worktree add /proj/.claude/worktrees/issue-42 --no-track -b issue-42 refs/remotes/origin/main'
       ) {
         return { stdout: '' }
       }
@@ -1335,6 +1352,7 @@ describe('createIssueSession', () => {
       'worktree',
       'add',
       '/proj/.claude/worktrees/issue-42',
+      '--no-track',
       '-b',
       'issue-42',
       'refs/remotes/origin/main',

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -657,6 +657,7 @@ async function createRemoteSession(
               'worktree',
               'add',
               worktreePath,
+              '--no-track',
               '-b',
               branchName,
               originRef,
@@ -883,6 +884,7 @@ export async function createSession(
         'worktree',
         'add',
         worktreePath,
+        '--no-track',
         '-b',
         branchName,
         originRef,
@@ -1721,7 +1723,7 @@ export async function createIssueSession(
   }
 
   try {
-    await runGit(['worktree', 'add', worktreePath, '-b', branch, originRef])
+    await runGit(['worktree', 'add', worktreePath, '--no-track', '-b', branch, originRef])
   } catch (err) {
     if (!(await hasBranch(projectPath, branch))) {
       return `Failed to create worktree for branch "${branch}": ${(err as Error).message}`
@@ -1783,7 +1785,18 @@ async function createRemoteIssueSession(
     try {
       await expectRemoteOk(
         host,
-        ['git', '-C', projectPath, 'worktree', 'add', worktreePath, '-b', branch, originRef],
+        [
+          'git',
+          '-C',
+          projectPath,
+          'worktree',
+          'add',
+          worktreePath,
+          '--no-track',
+          '-b',
+          branch,
+          originRef,
+        ],
         'Failed to create remote worktree'
       )
     } catch (err) {


### PR DESCRIPTION
## Summary
- The "Branch from origin/<default>" checkbox created branches that silently tracked `origin/<default>`, so a plain `git push` from inside the worktree would push to `origin/main` instead of creating `origin/<branch>`.
- Fix by passing `--no-track` to `git worktree add` in both local and remote session-creation paths (`src/main/session-manager.ts:760`, `src/main/session-manager.ts:1006`). The new branch is still based on `origin/<default>`'s tip but has no upstream; the first push needs `-u origin <branch>` (or `push.autoSetupRemote=true`).
- Added a test asserting the new branch has no `@{u}` after creation, and updated the remote-path stub argv expectation to include `--no-track`.

## Test plan
- [x] `npx vitest run src/main/session-manager.test.ts` (74 passed)
- [x] `npx tsc --noEmit` (clean)
- [ ] Manually: enable "Branch from origin/<default>" in New session dialog, verify `git rev-parse --abbrev-ref @{u}` errors with "no upstream" inside the new worktree, and that `git push -u origin <branch>` creates `origin/<branch>` (not a push to `origin/main`).