### PR TITLE
feat: select tool when creating a PR session

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -289,15 +289,27 @@ app.whenReady().then(async () => {
 
   ipcMain.handle(
     'sessions:create-pr',
-    async (_event, projectPath: string, prNumber: number, hostId?: string | null) => {
-      return createPrSession(projectPath, prNumber, hostId ?? null)
+    async (
+      _event,
+      projectPath: string,
+      prNumber: number,
+      hostId?: string | null,
+      options?: CreateSessionOptions
+    ) => {
+      return createPrSession(projectPath, prNumber, hostId ?? null, options ?? {})
     }
   )
 
   ipcMain.handle(
     'sessions:create-prs',
-    async (_event, projectPath: string, prNumbers: number[], hostId?: string | null) => {
-      return createPrSessions(projectPath, prNumbers, hostId ?? null)
+    async (
+      _event,
+      projectPath: string,
+      prNumbers: number[],
+      hostId?: string | null,
+      options?: CreateSessionOptions
+    ) => {
+      return createPrSessions(projectPath, prNumbers, hostId ?? null, options ?? {})
     }
   )
 

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1317,10 +1317,13 @@ describe('createIssueSession', () => {
       })
     )
 
-    const result = await sm.createIssueSession('/proj', 42, null, {
-      runGit,
-      createSessionForWorktree,
-    })
+    const result = await sm.createIssueSession(
+      '/proj',
+      42,
+      null,
+      {},
+      { runGit, createSessionForWorktree }
+    )
 
     expect(typeof result).not.toBe('string')
     if (typeof result === 'string') throw new Error(result)
@@ -1329,7 +1332,8 @@ describe('createIssueSession', () => {
     expect(createSessionForWorktree).toHaveBeenCalledWith(
       '/proj',
       '/proj/.claude/worktrees/issue-42',
-      'issue-42'
+      'issue-42',
+      undefined
     )
     expect(runGit).toHaveBeenCalledWith([
       'worktree',
@@ -1350,7 +1354,7 @@ describe('createIssueSession', () => {
       throw new Error(`missing ${key}`)
     })
 
-    const result = await sm.createIssueSession('/proj', 99, null, { runGit })
+    const result = await sm.createIssueSession('/proj', 99, null, {}, { runGit })
     expect(result).toBe("Could not determine origin's default branch.")
   })
 })
@@ -1429,8 +1433,8 @@ describe('openSessionsForOpenPrs', () => {
     expect(result.failed).toEqual([])
     expect(listPrs).toHaveBeenCalledWith('/proj', null)
     expect(createPrSession).toHaveBeenCalledTimes(2)
-    expect(createPrSession).toHaveBeenCalledWith('/proj', 8, null)
-    expect(createPrSession).toHaveBeenCalledWith('/proj', 9, null)
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 8, null, {})
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 9, null, {})
   })
 
   it('surfaces gh list errors as a string', async () => {
@@ -1496,7 +1500,7 @@ describe('openSessionsForOpenIssues', () => {
     expect(result.failed).toEqual([])
     expect(listIssues).toHaveBeenCalledWith('/proj', null)
     expect(createIssueSession).toHaveBeenCalledTimes(1)
-    expect(createIssueSession).toHaveBeenCalledWith('/proj', 4, null)
+    expect(createIssueSession).toHaveBeenCalledWith('/proj', 4, null, {})
   })
 
   it('records per-issue create failures in the summary', async () => {
@@ -1524,7 +1528,7 @@ describe('createPrSessions', () => {
         baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session | string
     )
 
-    const result = await sm.createPrSessions('/proj', [7, 8, 9], null, { createPrSession })
+    const result = await sm.createPrSessions('/proj', [7, 8, 9], null, {}, { createPrSession })
     expect(typeof result).not.toBe('string')
     if (typeof result === 'string') throw new Error(result)
 
@@ -1532,8 +1536,8 @@ describe('createPrSessions', () => {
     expect(result.created.map((s) => s.prNumber).sort()).toEqual([8, 9])
     expect(result.failed).toEqual([])
     expect(createPrSession).toHaveBeenCalledTimes(2)
-    expect(createPrSession).toHaveBeenCalledWith('/proj', 8, null)
-    expect(createPrSession).toHaveBeenCalledWith('/proj', 9, null)
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 8, null, {})
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 9, null, {})
   })
 
   it('aggregates per-number failures into the summary', async () => {
@@ -1544,7 +1548,7 @@ describe('createPrSessions', () => {
           ? `PR #${prNumber} not found.`
           : (baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session)
     )
-    const result = await sm.createPrSessions('/proj', [4, 5, 6], null, { createPrSession })
+    const result = await sm.createPrSessions('/proj', [4, 5, 6], null, {}, { createPrSession })
     if (typeof result === 'string') throw new Error(result)
     expect(result.created.map((s) => s.prNumber).sort()).toEqual([4, 6])
     expect(result.failed).toEqual([{ number: 5, error: 'PR #5 not found.' }])
@@ -1557,10 +1561,10 @@ describe('createPrSessions', () => {
       async (_projectPath: string, prNumber: number, _hostId: string | null) =>
         baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session | string
     )
-    const result = await sm.createPrSessions('/proj', [3, 3, 3], null, { createPrSession })
+    const result = await sm.createPrSessions('/proj', [3, 3, 3], null, {}, { createPrSession })
     if (typeof result === 'string') throw new Error(result)
     expect(createPrSession).toHaveBeenCalledTimes(1)
-    expect(createPrSession).toHaveBeenCalledWith('/proj', 3, null)
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 3, null, {})
     expect(result.created.map((s) => s.prNumber)).toEqual([3])
   })
 
@@ -1575,19 +1579,29 @@ describe('createPrSessions', () => {
       async (_projectPath: string, prNumber: number, _hostId: string | null) =>
         baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session | string
     )
-    const result = await sm.createPrSessions('/proj', [5], null, { createPrSession })
+    const result = await sm.createPrSessions('/proj', [5], null, {}, { createPrSession })
     if (typeof result === 'string') throw new Error(result)
     expect(result.skipped).toEqual([])
     expect(result.created.map((s) => s.prNumber)).toEqual([5])
-    expect(createPrSession).toHaveBeenCalledWith('/proj', 5, null)
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 5, null, {})
   })
 
   it('returns an empty summary for an empty number list', async () => {
     const sm = await loadSessionManager()
     const createPrSession = vi.fn()
-    const result = await sm.createPrSessions('/proj', [], null, { createPrSession })
+    const result = await sm.createPrSessions('/proj', [], null, {}, { createPrSession })
     if (typeof result === 'string') throw new Error(result)
     expect(result).toEqual({ created: [], skipped: [], failed: [] })
     expect(createPrSession).not.toHaveBeenCalled()
+  })
+
+  it('forwards the selected tool through options to createPrSession', async () => {
+    const sm = await loadSessionManager()
+    const createPrSession = vi.fn(
+      async (_projectPath: string, prNumber: number, _hostId: string | null) =>
+        baseLocalSession({ id: `s-${prNumber}`, prNumber }) as Session | string
+    )
+    await sm.createPrSessions('/proj', [11], null, { tool: 'codex' }, { createPrSession })
+    expect(createPrSession).toHaveBeenCalledWith('/proj', 11, null, { tool: 'codex' })
   })
 })

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -733,7 +733,8 @@ async function createRemoteSession(
 async function createRemotePrSession(
   hostId: string,
   projectPath: string,
-  prNumber: number
+  prNumber: number,
+  options: CreateSessionOptions = {}
 ): Promise<Session | string> {
   const host = getRequiredHost(hostId)
   const remoteProject = getRemoteProject(hostId, projectPath)
@@ -780,7 +781,7 @@ async function createRemotePrSession(
       return `PR #${prNumber} is ${prInfo.state.toLowerCase()}, not open.`
     }
 
-    const effectiveTool: AgentTool = getConfig().defaultTool
+    const effectiveTool: AgentTool = options.tool ?? getConfig().defaultTool
     const agentPath = agentPaths[effectiveTool]
     if (!agentPath) {
       return `${effectiveTool} is not installed on host ${host.label || host.alias}.`
@@ -1381,7 +1382,8 @@ type ListNumberedItems = (
 type CreateNumberedSession = (
   projectPath: string,
   number: number,
-  hostId: string | null
+  hostId: string | null,
+  options?: CreateSessionOptions
 ) => Promise<Session | string>
 type RemoteGhProbe = { ok: true } | { ok: false; error: string }
 
@@ -1398,7 +1400,8 @@ interface CreateIssueSessionDeps {
   createSessionForWorktree?: (
     projectPath: string,
     worktreePath: string,
-    label?: string
+    label?: string,
+    tool?: AgentTool
   ) => Promise<Session>
 }
 
@@ -1516,7 +1519,8 @@ async function createSessionsForNumbers(
   hostId: string | null,
   field: 'prNumber' | 'issueNumber',
   numbers: number[],
-  createSession: CreateNumberedSession
+  createSession: CreateNumberedSession,
+  options: CreateSessionOptions = {}
 ): Promise<OpenSessionsSummary> {
   const existing = new Set<number>()
   for (const entry of sessions.values()) {
@@ -1534,7 +1538,7 @@ async function createSessionsForNumbers(
 
   for (const item of toCreate) {
     try {
-      const result = await createSession(projectPath, item.number, hostId)
+      const result = await createSession(projectPath, item.number, hostId, options)
       if (typeof result === 'string') {
         failed.push({ number: item.number, error: result })
       } else {
@@ -1599,9 +1603,10 @@ async function probeRemoteGh(host: Host): Promise<RemoteGhProbe> {
 export async function createPrSession(
   projectPath: string,
   prNumber: number,
-  hostId: string | null = null
+  hostId: string | null = null,
+  options: CreateSessionOptions = {}
 ): Promise<Session | string> {
-  if (hostId !== null) return createRemotePrSession(hostId, projectPath, prNumber)
+  if (hostId !== null) return createRemotePrSession(hostId, projectPath, prNumber, options)
 
   // Look up PR via gh CLI
   let prInfo: { headRefName: string; state: string; title: string }
@@ -1652,7 +1657,12 @@ export async function createPrSession(
     }
   }
 
-  const session = await createSessionForWorktree(projectPath, worktreePath, worktreeName)
+  const session = await createSessionForWorktree(
+    projectPath,
+    worktreePath,
+    worktreeName,
+    options.tool
+  )
   // We already know the PR number; set it directly so it shows immediately
   // (the async lookup fired by adoptWorktree will no-op since prNumber is set).
   session.prNumber = prNumber
@@ -1668,6 +1678,7 @@ export async function createPrSessions(
   projectPath: string,
   prNumbers: number[],
   hostId: string | null = null,
+  options: CreateSessionOptions = {},
   deps: { createPrSession?: CreateNumberedSession } = {}
 ): Promise<OpenSessionsSummary | string> {
   const deduped = Array.from(new Set(prNumbers)).sort((a, b) => a - b)
@@ -1676,7 +1687,8 @@ export async function createPrSessions(
     hostId,
     'prNumber',
     deduped,
-    deps.createPrSession ?? createPrSession
+    deps.createPrSession ?? createPrSession,
+    options
   )
 }
 
@@ -1684,9 +1696,10 @@ export async function createIssueSession(
   projectPath: string,
   issueNumber: number,
   hostId: string | null = null,
+  options: CreateSessionOptions = {},
   deps: CreateIssueSessionDeps = {}
 ): Promise<Session | string> {
-  if (hostId !== null) return createRemoteIssueSession(hostId, projectPath, issueNumber)
+  if (hostId !== null) return createRemoteIssueSession(hostId, projectPath, issueNumber, options)
 
   const branch = `issue-${issueNumber}`
   const worktreeName = `issue-${issueNumber}`
@@ -1733,7 +1746,7 @@ export async function createIssueSession(
     }
   }
 
-  const session = await adopt(projectPath, worktreePath, worktreeName)
+  const session = await adopt(projectPath, worktreePath, worktreeName, options.tool)
   session.issueNumber = issueNumber
   onSessionsChanged()
   return session
@@ -1742,7 +1755,8 @@ export async function createIssueSession(
 async function createRemoteIssueSession(
   hostId: string,
   projectPath: string,
-  issueNumber: number
+  issueNumber: number,
+  options: CreateSessionOptions = {}
 ): Promise<Session | string> {
   const host = getRequiredHost(hostId)
   const remoteProject = getRemoteProject(hostId, projectPath)
@@ -1758,7 +1772,7 @@ async function createRemoteIssueSession(
   }
 
   return remoteHostRuntime.withPreparedHost(host, async ({ notifyScriptPath, agentPaths }) => {
-    const effectiveTool: AgentTool = getConfig().defaultTool
+    const effectiveTool: AgentTool = options.tool ?? getConfig().defaultTool
     const agentPath = agentPaths[effectiveTool]
     if (!agentPath) {
       return `${effectiveTool} is not installed on host ${host.label || host.alias}.`

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,10 +20,18 @@ contextBridge.exposeInMainWorld('api', {
     hostId?: string | null,
     options?: CreateSessionOptions
   ) => ipcRenderer.invoke('sessions:create', projectPath, name, hostId ?? null, options),
-  createPrSession: (projectPath: string, prNumber: number, hostId?: string | null) =>
-    ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber, hostId ?? null),
-  createPrSessions: (projectPath: string, prNumbers: number[], hostId?: string | null) =>
-    ipcRenderer.invoke('sessions:create-prs', projectPath, prNumbers, hostId ?? null),
+  createPrSession: (
+    projectPath: string,
+    prNumber: number,
+    hostId?: string | null,
+    options?: CreateSessionOptions
+  ) => ipcRenderer.invoke('sessions:create-pr', projectPath, prNumber, hostId ?? null, options),
+  createPrSessions: (
+    projectPath: string,
+    prNumbers: number[],
+    hostId?: string | null,
+    options?: CreateSessionOptions
+  ) => ipcRenderer.invoke('sessions:create-prs', projectPath, prNumbers, hostId ?? null, options),
   openSessionsForOpenPrs: (projectPath: string, hostId?: string | null) =>
     ipcRenderer.invoke('sessions:open-all-prs', projectPath, hostId ?? null),
   openSessionsForOpenIssues: (projectPath: string, hostId?: string | null) =>

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -35,6 +35,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const [createError, setCreateError] = useState<string | null>(null)
   const [pendingPrPath, setPendingPrPath] = useState<string | null>(null)
   const [pendingPrHostId, setPendingPrHostId] = useState<string | null>(null)
+  const [pendingPrTool, setPendingPrTool] = useState<AgentTool>('claude')
   const [prNumberInput, setPrNumberInput] = useState('')
   const [prError, setPrError] = useState<string | null>(null)
   const [toast, setToast] = useState<string | null>(null)
@@ -180,6 +181,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
         onClick: () => {
           setPendingPrPath(menu.projectPath)
           setPendingPrHostId(hostId)
+          setPendingPrTool(defaultTool)
           setPrNumberInput('')
           setPrError(null)
         },
@@ -224,6 +226,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
         onClick: () => {
           setPendingPrPath(menu.projectPath)
           setPendingPrHostId(null)
+          setPendingPrTool(defaultTool)
           setPrNumberInput('')
           setPrError(null)
         },
@@ -337,7 +340,8 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
       const result = await window.api.createPrSessions(
         pendingPrPath,
         parsed.numbers,
-        pendingPrHostId
+        pendingPrHostId,
+        { tool: pendingPrTool }
       )
       if (typeof result === 'string') {
         setPrError(result)
@@ -458,6 +462,29 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
             }}
             autoFocus
           />
+          <div className="session-name-label">Tool:</div>
+          <div className="tool-picker">
+            <label>
+              <input
+                type="radio"
+                name="pr-tool"
+                value="claude"
+                checked={pendingPrTool === 'claude'}
+                onChange={() => setPendingPrTool('claude')}
+              />
+              Claude
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="pr-tool"
+                value="codex"
+                checked={pendingPrTool === 'codex'}
+                onChange={() => setPendingPrTool('codex')}
+              />
+              Codex
+            </label>
+          </div>
           {prError && <div className="pr-error">{prError}</div>}
           <div className="create-actions">
             <button className="create-btn" onClick={handleCreatePrSession} disabled={creating}>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -34,12 +34,14 @@ declare global {
       createPrSession: (
         projectPath: string,
         prNumber: number,
-        hostId?: string | null
+        hostId?: string | null,
+        options?: CreateSessionOptions
       ) => Promise<Session | string>
       createPrSessions: (
         projectPath: string,
         prNumbers: number[],
-        hostId?: string | null
+        hostId?: string | null,
+        options?: CreateSessionOptions
       ) => Promise<OpenSessionsSummary | string>
       openSessionsForOpenPrs: (
         projectPath: string,


### PR DESCRIPTION
## Summary
- The **New PR session...** dialog now exposes a Claude / Codex picker, mirroring the regular **New session...** dialog. It seeds from the configured `defaultTool` each time it opens.
- `CreateSessionOptions` is threaded through `sessions:create-pr` / `sessions:create-prs` IPC, the preload bridge, and the `createPrSession` / `createPrSessions` / `createRemotePrSession` chain so the chosen tool drives both local hook installation and remote agent path resolution.
- `createIssueSession` / `createRemoteIssueSession` / `CreateNumberedSession` keep a uniform shape with the new options arg so the bulk-action paths (`Open sessions for all open PRs/issues`) compile without behavior change. They still pass `{}`, defaulting to `getConfig().defaultTool`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] `npx vitest run` — 337 tests pass, including a new test asserting `options.tool` is forwarded to `createPrSession` from `createPrSessions`
- [ ] Manual: open **New PR session...**, switch radio to Codex, create a PR session, confirm the resulting session uses the codex tool (hooks installed under `.codex/hooks.json`)
- [ ] Manual: same flow with Claude (default) leaves `.claude/settings.local.json` hooks installed