### PR TITLE
feat: add light theme and themable token system

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import type { AgentTool, Host, RemoteProject, WorktreeBase } from '../shared/types'
+import type { AgentTool, Host, RemoteProject, Theme, WorktreeBase } from '../shared/types'
 
 export interface CanvasState {
   zoom: number
@@ -32,6 +32,7 @@ export interface AppConfig {
   remoteProjects: RemoteProject[]
   defaultTool: AgentTool
   worktreeBase: WorktreeBase
+  theme: Theme
 }
 
 export const CONFIG_DIR = join(
@@ -54,6 +55,7 @@ const DEFAULT_CONFIG: AppConfig = {
   remoteProjects: [],
   defaultTool: 'claude',
   worktreeBase: 'local',
+  theme: 'dark',
 }
 
 export function shouldWarnGitignore(projectPath: string): boolean {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -611,6 +611,14 @@ app.whenReady().then(async () => {
     const config = getConfig()
     config.theme = theme
     saveConfig(config)
+    // Broadcast to every renderer so secondary windows (Swim Lanes etc.)
+    // pick up the new theme without needing to reload. The sender no-ops
+    // on its own broadcast because state.theme already matches.
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) {
+        win.webContents.send('theme:changed', theme)
+      }
+    }
   })
 
   ipcMain.handle('swim-lanes:open', (_event, sessionIds: string[]) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -603,6 +603,16 @@ app.whenReady().then(async () => {
     return getConfig().worktreeBase
   })
 
+  ipcMain.handle('config:get-theme', () => {
+    return getConfig().theme
+  })
+
+  ipcMain.handle('config:save-theme', (_event, theme: 'dark' | 'light') => {
+    const config = getConfig()
+    config.theme = theme
+    saveConfig(config)
+  })
+
   ipcMain.handle('swim-lanes:open', (_event, sessionIds: string[]) => {
     const swimWindow = new BrowserWindow({
       width: 1200,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -65,6 +65,11 @@ contextBridge.exposeInMainWorld('api', {
   getWorktreeBase: () => ipcRenderer.invoke('config:get-worktree-base'),
   getTheme: () => ipcRenderer.invoke('config:get-theme') as Promise<Theme>,
   saveTheme: (theme: Theme) => ipcRenderer.invoke('config:save-theme', theme),
+  onThemeBroadcast: (callback: (theme: Theme) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, theme: Theme) => callback(theme)
+    ipcRenderer.on('theme:changed', handler)
+    return () => ipcRenderer.removeListener('theme:changed', handler)
+  },
   onTextThumbnails: (callback: (data: Record<string, string>) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: Record<string, string>) =>
       callback(data)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { AgentTool, CreateSessionOptions, ToastEvent } from '../shared/types'
+import type { AgentTool, CreateSessionOptions, Theme, ToastEvent } from '../shared/types'
 
 contextBridge.exposeInMainWorld('api', {
   scanProjects: () => ipcRenderer.invoke('projects:scan'),
@@ -63,6 +63,8 @@ contextBridge.exposeInMainWorld('api', {
   getUiScale: () => ipcRenderer.invoke('config:get-ui-scale'),
   getDefaultTool: () => ipcRenderer.invoke('config:get-default-tool') as Promise<AgentTool>,
   getWorktreeBase: () => ipcRenderer.invoke('config:get-worktree-base'),
+  getTheme: () => ipcRenderer.invoke('config:get-theme') as Promise<Theme>,
+  saveTheme: (theme: Theme) => ipcRenderer.invoke('config:save-theme', theme),
   onTextThumbnails: (callback: (data: Record<string, string>) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: Record<string, string>) =>
       callback(data)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import { useProjectsStore } from './stores/projects'
 import { useSessionsStore } from './stores/sessions'
 import { useHostsStore } from './stores/hosts'
 import { useToastsStore } from './stores/toasts'
+import { useThemeStore } from './stores/theme'
 
 export default function App() {
   const { scanProjects, filterReady, toggleFilterReady } = useProjectsStore()
@@ -33,6 +34,10 @@ export default function App() {
   }, [])
   const resizing = useRef(false)
   const resizeStart = useRef({ x: 0, width: 0 })
+
+  useEffect(() => {
+    void useThemeStore.getState().init()
+  }, [])
 
   useEffect(() => {
     void fetchHosts()

--- a/src/renderer/SwimLanesApp.tsx
+++ b/src/renderer/SwimLanesApp.tsx
@@ -4,6 +4,7 @@ import BroadcastBar from './components/BroadcastBar'
 import LaneHeader from './components/LaneHeader'
 import Terminal from './components/Terminal'
 import ReviewOverlay from './components/ReviewOverlay'
+import { useThemeStore } from './stores/theme'
 
 function parseSessionIds(): string[] {
   const params = new URLSearchParams(window.location.search)
@@ -18,6 +19,10 @@ export default function SwimLanesApp() {
   // Per-lane monotonic flip count: each toggle increments by 1, rotating +180deg.
   // Keeps the return flip in the same direction as the opening flip.
   const [laneFlipCounts, setLaneFlipCounts] = useState<Map<string, number>>(new Map())
+
+  useEffect(() => {
+    void useThemeStore.getState().init()
+  }, [])
 
   useEffect(() => {
     window.api.getSessions().then((all) => {

--- a/src/renderer/components/SessionCanvas.tsx
+++ b/src/renderer/components/SessionCanvas.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback, useMemo, useLayoutEffect } fr
 import { useSessionsStore } from '../stores/sessions'
 import { useProjectsStore } from '../stores/projects'
 import { useCanvasStore } from '../stores/canvas'
+import { useThemeStore } from '../stores/theme'
 import SessionCluster from './SessionCluster'
 import EdgeIndicators from './EdgeIndicators'
 import BroadcastDialog from './BroadcastDialog'
@@ -11,7 +12,6 @@ const RESTING_MAX_ZOOM = 1.0
 const ZOOM_SENSITIVITY = 0.001
 const KEYBOARD_ZOOM_STEP = 0.1
 const DOT_SPACING = 30
-const DOT_COLOR = '#2a2a4a'
 const DOT_RADIUS = 1.5
 
 // Source of truth in SessionCluster.tsx — keep in sync.
@@ -68,6 +68,7 @@ interface CanvasProps {
 export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }: CanvasProps) {
   const { sessions, thumbnails, toggleSelect, rangeSelect, clearSelection } = useSessionsStore()
   const broadcastDialogOpen = useSessionsStore((s) => s.broadcastDialogOpen)
+  const theme = useThemeStore((s) => s.theme)
   const projects = useProjectsStore((s) => s.projects)
   const knownPaths = useMemo(() => new Set(projects.map((p) => p.path)), [projects])
   const viewportRef = useRef<HTMLDivElement>(null)
@@ -277,7 +278,9 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
     if (!ctx) return
 
     ctx.clearRect(0, 0, canvas.width, canvas.height)
-    ctx.fillStyle = DOT_COLOR
+    const dotColor =
+      getComputedStyle(document.documentElement).getPropertyValue('--border').trim() || '#2a2a4a'
+    ctx.fillStyle = dotColor
 
     const spacing = DOT_SPACING * zoom
     const offsetX = ((panX % spacing) + spacing) % spacing
@@ -290,7 +293,9 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
         ctx.fill()
       }
     }
-  }, [zoom, panX, panY, sessions.length])
+    // theme is intentionally in the dep array so the dot grid repaints when
+    // the user switches between dark and light mode.
+  }, [zoom, panX, panY, sessions.length, theme])
 
   // Resize observer
   useEffect(() => {

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -1,13 +1,18 @@
 import { useSessionsStore } from '../stores/sessions'
 import { useCanvasStore } from '../stores/canvas'
+import { useThemeStore } from '../stores/theme'
 
 export default function StatusBar() {
   const { sessions } = useSessionsStore()
   const panToCluster = useCanvasStore((s) => s.panToCluster)
+  const theme = useThemeStore((s) => s.theme)
+  const toggleTheme = useThemeStore((s) => s.toggle)
 
   const running = sessions.filter((s) => s.status === 'running').length
   const needsInput = sessions.filter((s) => s.status === 'needs_input')
   const completed = sessions.filter((s) => s.status === 'completed').length
+
+  const nextTheme = theme === 'dark' ? 'light' : 'dark'
 
   return (
     <footer className="statusbar">
@@ -33,6 +38,15 @@ export default function StatusBar() {
           ))}
         </div>
       )}
+      <button
+        type="button"
+        className="theme-toggle-btn"
+        onClick={toggleTheme}
+        title={`Switch to ${nextTheme} mode`}
+        aria-label={`Switch to ${nextTheme} mode`}
+      >
+        {theme === 'dark' ? '☾' : '☀'}
+      </button>
     </footer>
   )
 }

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -3,9 +3,20 @@ import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import '@xterm/xterm/css/xterm.css'
+import { onThemeChanged } from '../stores/theme'
 
 interface Props {
   sessionId: string
+}
+
+function readTerminalTheme() {
+  const styles = getComputedStyle(document.documentElement)
+  return {
+    background: styles.getPropertyValue('--bg-terminal').trim() || '#0e0e1e',
+    foreground: styles.getPropertyValue('--text-primary').trim() || '#e0e0e0',
+    cursor: styles.getPropertyValue('--accent-green').trim() || '#4ade80',
+    selectionBackground: styles.getPropertyValue('--border').trim() || '#2a2a4a',
+  }
 }
 
 export default function Terminal({ sessionId }: Props) {
@@ -18,15 +29,15 @@ export default function Terminal({ sessionId }: Props) {
     const container = containerRef.current
 
     const term = new XTerm({
-      theme: {
-        background: '#0e0e1e',
-        foreground: '#e0e0e0',
-        cursor: '#4ade80',
-        selectionBackground: '#2a2a4a',
-      },
+      theme: readTerminalTheme(),
       fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace",
       fontSize: 14,
       cursorBlink: true,
+    })
+
+    const themeUnsubscribe = onThemeChanged(() => {
+      term.options.theme = readTerminalTheme()
+      term.refresh(0, term.rows - 1)
     })
 
     const fitAddon = new FitAddon()
@@ -194,6 +205,7 @@ export default function Terminal({ sessionId }: Props) {
     return () => {
       aborted = true
       observer.disconnect()
+      themeUnsubscribe()
       window.removeEventListener('focus', handleWindowFocus)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       selectionDisposable.dispose()

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -81,6 +81,7 @@ declare global {
       getWorktreeBase: () => Promise<WorktreeBase>
       getTheme: () => Promise<Theme>
       saveTheme: (theme: Theme) => Promise<void>
+      onThemeBroadcast: (callback: (theme: Theme) => void) => () => void
       onTextThumbnails: (callback: (data: Record<string, string>) => void) => () => void
       pickDirectory: () => Promise<string | null>
       relocateProject: (oldPath: string, newPath: string) => Promise<{ migratedCount: number }>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -13,6 +13,7 @@ import type {
   ReviewDiffResult,
   Session,
   TestConnectionResult,
+  Theme,
   ToastEvent,
   WorktreeBase,
 } from '../shared/types'
@@ -78,6 +79,8 @@ declare global {
       getUiScale: () => Promise<number>
       getDefaultTool: () => Promise<AgentTool>
       getWorktreeBase: () => Promise<WorktreeBase>
+      getTheme: () => Promise<Theme>
+      saveTheme: (theme: Theme) => Promise<void>
       onTextThumbnails: (callback: (data: Record<string, string>) => void) => () => void
       pickDirectory: () => Promise<string | null>
       relocateProject: (oldPath: string, newPath: string) => Promise<{ migratedCount: number }>

--- a/src/renderer/stores/theme.ts
+++ b/src/renderer/stores/theme.ts
@@ -21,9 +21,19 @@ export const useThemeStore = create<ThemeStore>((set, get) => ({
   loaded: false,
   init: async () => {
     if (get().loaded) return
+    // Set `loaded` synchronously so a concurrent init() (StrictMode double
+    // mount, second window) bails at the guard above instead of racing on
+    // the same await.
+    const initialTheme = get().theme
+    set({ loaded: true })
     const persisted = await window.api.getTheme()
+    // If the user toggled during the await, setTheme has already applied
+    // and persisted their choice — don't clobber it with the stale value
+    // we just fetched.
+    if (get().theme !== initialTheme) return
+    if (persisted === initialTheme) return
     applyTheme(persisted)
-    set({ theme: persisted, loaded: true })
+    set({ theme: persisted })
   },
   setTheme: (theme) => {
     if (get().theme === theme) return

--- a/src/renderer/stores/theme.ts
+++ b/src/renderer/stores/theme.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand'
+import type { Theme } from '../../shared/types'
+
+const THEME_CHANGED_EVENT = 'cc-pewpew:theme-changed'
+
+function applyTheme(theme: Theme): void {
+  document.documentElement.dataset.theme = theme
+  window.dispatchEvent(new CustomEvent<Theme>(THEME_CHANGED_EVENT, { detail: theme }))
+}
+
+interface ThemeStore {
+  theme: Theme
+  loaded: boolean
+  init: () => Promise<void>
+  setTheme: (theme: Theme) => void
+  toggle: () => void
+}
+
+export const useThemeStore = create<ThemeStore>((set, get) => ({
+  theme: 'dark',
+  loaded: false,
+  init: async () => {
+    if (get().loaded) return
+    const persisted = await window.api.getTheme()
+    applyTheme(persisted)
+    set({ theme: persisted, loaded: true })
+  },
+  setTheme: (theme) => {
+    if (get().theme === theme) return
+    applyTheme(theme)
+    set({ theme })
+    void window.api.saveTheme(theme)
+  },
+  toggle: () => {
+    get().setTheme(get().theme === 'dark' ? 'light' : 'dark')
+  },
+}))
+
+export function onThemeChanged(callback: (theme: Theme) => void): () => void {
+  const handler = (e: Event) => {
+    const ce = e as CustomEvent<Theme>
+    callback(ce.detail)
+  }
+  window.addEventListener(THEME_CHANGED_EVENT, handler)
+  return () => window.removeEventListener(THEME_CHANGED_EVENT, handler)
+}

--- a/src/renderer/stores/theme.ts
+++ b/src/renderer/stores/theme.ts
@@ -21,20 +21,34 @@ interface ThemeStore {
   toggle: () => void
 }
 
+let broadcastListenerInstalled = false
+
 export const useThemeStore = create<ThemeStore>((set, get) => ({
   theme: 'dark',
   loaded: false,
   mutationCount: 0,
   init: async () => {
     if (get().loaded) return
+    // Subscribe to cross-window theme broadcasts before the IPC await so
+    // a change pushed by main during init isn't dropped. Doesn't go
+    // through setTheme — setTheme would re-save and trigger another
+    // broadcast.
+    if (!broadcastListenerInstalled) {
+      broadcastListenerInstalled = true
+      window.api.onThemeBroadcast((theme) => {
+        if (get().theme === theme) return
+        applyTheme(theme)
+        set({ theme, mutationCount: get().mutationCount + 1 })
+      })
+    }
     // Set `loaded` synchronously so a concurrent init() (StrictMode double
     // mount, second window) bails at the guard above instead of racing on
     // the same await.
     const initialMutation = get().mutationCount
     set({ loaded: true })
     const persisted = await window.api.getTheme()
-    // If setTheme ran during the await, the user's choice is already
-    // applied and persisted; do not clobber it with the value we fetched.
+    // If setTheme or a broadcast ran during the await, the latest theme
+    // is already applied; do not clobber it with the value we fetched.
     if (get().mutationCount !== initialMutation) return
     if (persisted === get().theme) return
     applyTheme(persisted)

--- a/src/renderer/stores/theme.ts
+++ b/src/renderer/stores/theme.ts
@@ -11,6 +11,11 @@ function applyTheme(theme: Theme): void {
 interface ThemeStore {
   theme: Theme
   loaded: boolean
+  // Monotonic counter incremented by setTheme on every actual state change.
+  // init() captures it before its IPC await and bails if it changed,
+  // catching a user toggle even when the net theme equals the initial value
+  // (e.g. dark → light → dark during a slow getTheme()).
+  mutationCount: number
   init: () => Promise<void>
   setTheme: (theme: Theme) => void
   toggle: () => void
@@ -19,26 +24,26 @@ interface ThemeStore {
 export const useThemeStore = create<ThemeStore>((set, get) => ({
   theme: 'dark',
   loaded: false,
+  mutationCount: 0,
   init: async () => {
     if (get().loaded) return
     // Set `loaded` synchronously so a concurrent init() (StrictMode double
     // mount, second window) bails at the guard above instead of racing on
     // the same await.
-    const initialTheme = get().theme
+    const initialMutation = get().mutationCount
     set({ loaded: true })
     const persisted = await window.api.getTheme()
-    // If the user toggled during the await, setTheme has already applied
-    // and persisted their choice — don't clobber it with the stale value
-    // we just fetched.
-    if (get().theme !== initialTheme) return
-    if (persisted === initialTheme) return
+    // If setTheme ran during the await, the user's choice is already
+    // applied and persisted; do not clobber it with the value we fetched.
+    if (get().mutationCount !== initialMutation) return
+    if (persisted === get().theme) return
     applyTheme(persisted)
     set({ theme: persisted })
   },
   setTheme: (theme) => {
     if (get().theme === theme) return
     applyTheme(theme)
-    set({ theme })
+    set({ theme, mutationCount: get().mutationCount + 1 })
     void window.api.saveTheme(theme)
   },
   toggle: () => {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -6,7 +6,12 @@
   box-sizing: border-box;
 }
 
-:root {
+/* Theme tokens. Two themes are hardcoded today (dark, light); add a new
+   [data-theme="..."] block to register more. The :root values mirror the
+   dark theme so first paint (before the persisted theme attribute is
+   applied) matches what the user last saw. */
+:root,
+:root[data-theme='dark'] {
   --bg-main: #1a1a2e;
   --bg-sidebar: #16162a;
   --bg-statusbar: #12122a;
@@ -20,7 +25,17 @@
   --accent-yellow: #facc15;
   --accent-red: #f87171;
   --accent-blue: #60a5fa;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  --accent-orange: #f59e0b;
+  --accent-error: #e07070;
+
+  --shadow-md: rgba(0, 0, 0, 0.4);
+  --shadow-lg: rgba(0, 0, 0, 0.5);
+  --shadow-sm: rgba(0, 0, 0, 0.3);
+  --modal-overlay-bg: rgba(0, 0, 0, 0.5);
+  --terminal-overlay-bg: rgba(14, 14, 30, 0.82);
+  --terminal-overlay-error-bg: rgba(64, 18, 24, 0.85);
+  --terminal-overlay-warn-bg: rgba(64, 56, 18, 0.85);
+  --connection-dot-border: rgba(14, 14, 30, 0.85);
 
   --review-bg: #12122a;
   --review-addition: rgba(74, 222, 128, 0.12);
@@ -31,6 +46,45 @@
   --review-approved: #4ade80;
   --review-commented: #facc15;
   --review-rejected: #f87171;
+
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+}
+
+:root[data-theme='light'] {
+  --bg-main: #f5f5fb;
+  --bg-sidebar: #ebebf2;
+  --bg-statusbar: #e0e0ea;
+  --bg-terminal: #ffffff;
+  --bg-context-menu: #ffffff;
+  --text-primary: #1a1a2e;
+  --text-secondary: #5a5a72;
+  --text-on-accent: #ffffff;
+  --border: #cfcfdb;
+  --accent-green: #16a34a;
+  --accent-yellow: #b45309;
+  --accent-red: #dc2626;
+  --accent-blue: #2563eb;
+  --accent-orange: #c2410c;
+  --accent-error: #b91c1c;
+
+  --shadow-md: rgba(15, 23, 42, 0.12);
+  --shadow-lg: rgba(15, 23, 42, 0.18);
+  --shadow-sm: rgba(15, 23, 42, 0.08);
+  --modal-overlay-bg: rgba(15, 23, 42, 0.35);
+  --terminal-overlay-bg: rgba(255, 255, 255, 0.82);
+  --terminal-overlay-error-bg: rgba(254, 226, 226, 0.92);
+  --terminal-overlay-warn-bg: rgba(254, 243, 199, 0.92);
+  --connection-dot-border: rgba(255, 255, 255, 0.85);
+
+  --review-bg: #f0f0f7;
+  --review-addition: rgba(22, 163, 74, 0.14);
+  --review-deletion: rgba(220, 38, 38, 0.12);
+  --review-addition-text: #166534;
+  --review-deletion-text: #991b1b;
+  --review-hunk-header: #e0e0ea;
+  --review-approved: #16a34a;
+  --review-commented: #b45309;
+  --review-rejected: #dc2626;
 }
 
 *:focus-visible {
@@ -260,8 +314,8 @@ body,
 }
 
 .cluster-header--orphaned {
-  color: #f59e0b;
-  border-bottom: 1px dashed #f59e0b;
+  color: var(--accent-orange);
+  border-bottom: 1px dashed var(--accent-orange);
 }
 
 .cluster-cards {
@@ -466,7 +520,7 @@ body,
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  border: 1px solid rgba(14, 14, 30, 0.85);
+  border: 1px solid var(--connection-dot-border);
   flex-shrink: 0;
 }
 
@@ -507,15 +561,15 @@ body,
 
 .connection-overlay--pending,
 .connection-overlay--connecting {
-  background: rgba(14, 14, 30, 0.82);
+  background: var(--terminal-overlay-bg);
 }
 
 .connection-overlay--auth-failed {
-  background: rgba(64, 18, 24, 0.85);
+  background: var(--terminal-overlay-error-bg);
 }
 
 .connection-overlay--unreachable {
-  background: rgba(64, 56, 18, 0.85);
+  background: var(--terminal-overlay-warn-bg);
 }
 
 .session-card-time {
@@ -686,7 +740,7 @@ body,
   border-radius: 6px;
   padding: 8px 12px;
   font-size: 13px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 12px var(--shadow-md);
   z-index: 100;
 }
 
@@ -715,7 +769,7 @@ body,
   border-radius: 6px;
   padding: 10px 12px;
   font-size: 13px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 4px 12px var(--shadow-lg);
   pointer-events: auto;
 }
 
@@ -770,7 +824,7 @@ body,
   border-radius: 6px;
   padding: 4px 0;
   min-width: 180px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 12px var(--shadow-md);
   z-index: 1000;
 }
 
@@ -893,7 +947,7 @@ body,
 }
 
 .pr-error {
-  color: #f87171;
+  color: var(--accent-red);
   font-size: 12px;
   padding: 4px 0;
 }
@@ -1059,10 +1113,28 @@ body,
   color: var(--text-on-accent);
 }
 
+.theme-toggle-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 4px;
+  margin-left: auto;
+}
+
+.theme-toggle-btn:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
 .broadcast-dialog-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--modal-overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1083,7 +1155,7 @@ body,
 .hosts-dialog-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--modal-overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1141,7 +1213,6 @@ body,
   font-size: 12px;
 }
 
-/* TODO: replace hardcoded #e07070 with a theme error-colour token once defined. */
 .host-test-result {
   font-size: 12px;
   margin-top: 2px;
@@ -1152,7 +1223,7 @@ body,
 }
 
 .host-test-result.err {
-  color: #e07070;
+  color: var(--accent-error);
 }
 
 .host-actions {
@@ -1162,7 +1233,7 @@ body,
 }
 
 .hosts-error {
-  color: #e07070;
+  color: var(--accent-error);
   font-size: 12px;
   padding: 4px 8px;
 }
@@ -1689,7 +1760,7 @@ body,
   background: var(--bg-context-menu);
   border: 1px solid var(--border);
   border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 8px var(--shadow-sm);
 }
 
 .rv-toolbar-btn {
@@ -1937,7 +2008,7 @@ body,
 .rv-confirm-overlay {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--modal-overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -30,6 +30,8 @@ export interface Worktree {
 
 export type AgentTool = 'claude' | 'codex'
 
+export type Theme = 'dark' | 'light'
+
 export interface Session {
   id: string
   hostId: string | null


### PR DESCRIPTION
## Summary
- Split CSS variables into `[data-theme="dark"]` and `[data-theme="light"]` blocks; adding a third theme is one new selector. `:root` mirrors the dark values so first paint is unchanged before the persisted theme attribute is applied.
- Persist `theme` in `AppConfig` (default `dark`) with `config:get-theme` / `config:save-theme` IPC, plumbed through preload.
- New `useThemeStore` (Zustand) sets `documentElement.dataset.theme`, persists, and dispatches a `cc-pewpew:theme-changed` event for components that don't render through CSS.
- Status bar gets a `☾`/`☀` toggle button.
- `Terminal.tsx` reads xterm theme colors from CSS vars and live-updates on theme change. `SessionCanvas.tsx` dot grid reads `--border` and re-paints on theme change.
- Replaced remaining hardcoded color literals (`#f59e0b`, `#e07070`, `rgba(0,0,0,…)`, `rgba(14,14,30,…)`, etc.) with new semantic tokens (`--accent-orange`, `--accent-error`, `--shadow-{sm,md,lg}`, `--modal-overlay-bg`, `--terminal-overlay-{,error,warn}-bg`, `--connection-dot-border`).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .`
- [x] `npx vitest run` (336/336)
- [x] `npx electron-vite build`
- [x] CDP screenshot in dark mode — unchanged from before
- [x] CDP screenshot in light mode — clean inversion, all chips/borders/cards/buttons readable
- [x] Round-trip via the new toggle button — confirmed `data-theme` flips and CSS reacts
- [ ] Manual: open a terminal and toggle theme to verify xterm picks up the new background/foreground without restart
- [ ] Manual: open the swim-lanes window and verify it inherits the same theme