### PR TITLE
fix(canvas): keep session cards inside cluster border

### DIFF
--- a/src/renderer/components/SessionCanvas.tsx
+++ b/src/renderer/components/SessionCanvas.tsx
@@ -354,7 +354,6 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
       const cy = e.clientY - rect.top
 
       const cap = computeMaxZoom(rect.width, rect.height)
-      let committedZoom = zoomRef.current
       setZoom((prevZoom) => {
         const zoomDelta = -e.deltaY * ZOOM_SENSITIVITY * prevZoom
         const newZoom = Math.max(MIN_ZOOM, Math.min(cap, prevZoom + zoomDelta))
@@ -363,7 +362,6 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
         setPanX(newPanX)
         setPanY(newPanY)
         persistCanvas(newZoom, newPanX, newPanY)
-        committedZoom = newZoom
         return newZoom
       })
 
@@ -385,10 +383,11 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
       }
 
       // Threshold: either dimension of the rendered card >= FILL_THRESHOLD of viewport.
-      const renderedW = CARD_WIDTH * committedZoom
-      const renderedH = CARD_HEIGHT * committedZoom
+      // Measure the actual rendered rect — card height varies with chip wrap.
+      const cardRect = cardEl.getBoundingClientRect()
       const filled =
-        renderedW >= rect.width * FILL_THRESHOLD || renderedH >= rect.height * FILL_THRESHOLD
+        cardRect.width >= rect.width * FILL_THRESHOLD ||
+        cardRect.height >= rect.height * FILL_THRESHOLD
       if (!filled) {
         thresholdCrossedAtRef.current = null
         return
@@ -407,7 +406,6 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
       if (!sessionId) return
       const sessionRec = sessions.find((s) => s.id === sessionId)
       if (!sessionRec) return
-      const cardRect = cardEl.getBoundingClientRect()
       zoomOpenFiredRef.current = true
       thresholdCrossedAtRef.current = null
       onZoomOpen?.({

--- a/src/renderer/components/SessionCluster.tsx
+++ b/src/renderer/components/SessionCluster.tsx
@@ -5,10 +5,6 @@ import { useProjectsStore } from '../stores/projects'
 import SessionCard from './SessionCard'
 import ContextMenu, { type MenuItem } from './ContextMenu'
 
-const CARD_WIDTH = 240
-const CARD_GAP = 12
-const CLUSTER_COLS = 2
-
 interface Props {
   projectPath: string
   projectName: string
@@ -121,32 +117,16 @@ export default function SessionCluster({
       >
         {projectName}
       </div>
-      <div
-        className="cluster-cards"
-        style={{
-          width: Math.min(sessions.length, CLUSTER_COLS) * (CARD_WIDTH + CARD_GAP) - CARD_GAP,
-          height: Math.ceil(sessions.length / CLUSTER_COLS) * (230 + CARD_GAP) - CARD_GAP,
-        }}
-      >
-        {sessions.map((session, i) => {
-          const col = i % CLUSTER_COLS
-          const row = Math.floor(i / CLUSTER_COLS)
-          return (
-            <SessionCard
-              key={session.id}
-              session={session}
-              thumbnail={thumbnails[session.id]}
-              onOpenSession={onOpenSession}
-              onSelect={onSelect}
-              style={{
-                position: 'absolute',
-                left: col * (CARD_WIDTH + CARD_GAP),
-                top: row * (230 + CARD_GAP),
-                width: CARD_WIDTH,
-              }}
-            />
-          )
-        })}
+      <div className="cluster-cards">
+        {sessions.map((session) => (
+          <SessionCard
+            key={session.id}
+            session={session}
+            thumbnail={thumbnails[session.id]}
+            onOpenSession={onOpenSession}
+            onSelect={onSelect}
+          />
+        ))}
       </div>
 
       {headerMenu && (

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -319,7 +319,10 @@ body,
 }
 
 .cluster-cards {
-  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, 240px);
+  gap: 12px;
+  align-items: start;
 }
 
 .session-card {


### PR DESCRIPTION
## Summary
- Cluster height was computed from a hardcoded 230px card height, but the chip row added in ee4c359 pushed actual cards to ~280px, so cards overflowed the dashed cluster border and overlapped each other when stacked.
- Switch `.cluster-cards` to CSS grid (`repeat(2, 240px)`) so the cluster auto-sizes to whatever the cards need — no more height guessing.
- Use `cardEl.getBoundingClientRect()` for the zoom-to-open fill threshold instead of `CARD_WIDTH/CARD_HEIGHT * zoom`, so the gesture stays accurate as card content changes.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .` on changed files
- [x] `npx vitest run` (361 passed)
- [x] CDP screenshot: every card now sits inside its cluster's dashed border, no overlap between adjacent clusters