### PR TITLE
feat(theme): optimize light theme contrast and visual hierarchy

### DIFF
--- a/src/renderer/components/SessionCanvas.tsx
+++ b/src/renderer/components/SessionCanvas.tsx
@@ -30,7 +30,9 @@ function computeMaxZoom(viewportW: number, viewportH: number): number {
 const FILL_THRESHOLD = 0.95
 const DWELL_MS = 120
 
-const ACCENT_COLORS = [
+// Cluster identity hues. Light-theme palette uses deeper, more saturated
+// counterparts so dashed borders read as identity on white instead of dust.
+const ACCENT_COLORS_DARK = [
   '#4ade80',
   '#60a5fa',
   '#f472b6',
@@ -41,12 +43,24 @@ const ACCENT_COLORS = [
   '#e879f9',
 ]
 
-function hashColor(path: string): string {
+const ACCENT_COLORS_LIGHT = [
+  '#15803d',
+  '#1d4ed8',
+  '#be185d',
+  '#a16207',
+  '#6d28d9',
+  '#c2410c',
+  '#0f766e',
+  '#86198f',
+]
+
+function hashColor(path: string, theme: 'dark' | 'light'): string {
+  const palette = theme === 'light' ? ACCENT_COLORS_LIGHT : ACCENT_COLORS_DARK
   let hash = 0
   for (let i = 0; i < path.length; i++) {
     hash = (hash + path.charCodeAt(i)) * 31
   }
-  return ACCENT_COLORS[Math.abs(hash) % ACCENT_COLORS.length]
+  return palette[Math.abs(hash) % palette.length]
 }
 
 const CLUSTER_WIDTH = 510
@@ -279,7 +293,7 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
 
     ctx.clearRect(0, 0, canvas.width, canvas.height)
     const dotColor =
-      getComputedStyle(document.documentElement).getPropertyValue('--border').trim() || '#2a2a4a'
+      getComputedStyle(document.documentElement).getPropertyValue('--dot-grid').trim() || '#2a2a4a'
     ctx.fillStyle = dotColor
 
     const spacing = DOT_SPACING * zoom
@@ -515,7 +529,7 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
             projectName={clusterSessions[0].projectName}
             sessions={clusterSessions}
             thumbnails={thumbnails}
-            accentColor={hashColor(projectPath)}
+            accentColor={hashColor(projectPath, theme)}
             position={resolvedClusterPositions[projectPath] || { x: 0, y: 0 }}
             zoom={zoom}
             isOrphaned={!knownPaths.has(projectPath)}
@@ -531,7 +545,7 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
           projectPath,
           projectName: clusterSessions[0].projectName,
           position: resolvedClusterPositions[projectPath] || { x: 0, y: 0 },
-          color: hashColor(projectPath),
+          color: hashColor(projectPath, theme),
         }))}
         zoom={zoom}
         panX={panX}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -21,6 +21,7 @@
   --text-secondary: #9a9a9a;
   --text-on-accent: #111;
   --border: #2a2a4a;
+  --dot-grid: #2a2a4a;
   --accent-green: #4ade80;
   --accent-yellow: #facc15;
   --accent-red: #f87171;
@@ -51,38 +52,39 @@
 }
 
 :root[data-theme='light'] {
-  --bg-main: #f5f5fb;
-  --bg-sidebar: #ebebf2;
-  --bg-statusbar: #e0e0ea;
+  --bg-main: #eef0f5;
+  --bg-sidebar: #ffffff;
+  --bg-statusbar: #d8dde7;
   --bg-terminal: #ffffff;
   --bg-context-menu: #ffffff;
-  --text-primary: #1a1a2e;
-  --text-secondary: #5a5a72;
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
   --text-on-accent: #ffffff;
-  --border: #cfcfdb;
-  --accent-green: #16a34a;
+  --border: #c8cfdc;
+  --dot-grid: #b6bfcf;
+  --accent-green: #15803d;
   --accent-yellow: #b45309;
   --accent-red: #dc2626;
-  --accent-blue: #2563eb;
+  --accent-blue: #1d4ed8;
   --accent-orange: #c2410c;
   --accent-error: #b91c1c;
 
-  --shadow-md: rgba(15, 23, 42, 0.12);
-  --shadow-lg: rgba(15, 23, 42, 0.18);
-  --shadow-sm: rgba(15, 23, 42, 0.08);
+  --shadow-md: rgba(15, 23, 42, 0.14);
+  --shadow-lg: rgba(15, 23, 42, 0.22);
+  --shadow-sm: rgba(15, 23, 42, 0.1);
   --modal-overlay-bg: rgba(15, 23, 42, 0.35);
   --terminal-overlay-bg: rgba(255, 255, 255, 0.82);
   --terminal-overlay-error-bg: rgba(254, 226, 226, 0.92);
   --terminal-overlay-warn-bg: rgba(254, 243, 199, 0.92);
   --connection-dot-border: rgba(255, 255, 255, 0.85);
 
-  --review-bg: #f0f0f7;
+  --review-bg: #eef0f5;
   --review-addition: rgba(22, 163, 74, 0.14);
   --review-deletion: rgba(220, 38, 38, 0.12);
   --review-addition-text: #166534;
   --review-deletion-text: #991b1b;
-  --review-hunk-header: #e0e0ea;
-  --review-approved: #16a34a;
+  --review-hunk-header: #dde2eb;
+  --review-approved: #15803d;
   --review-commented: #b45309;
   --review-rejected: #dc2626;
 }
@@ -328,6 +330,7 @@ body,
   border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
+  box-shadow: 0 1px 2px var(--shadow-sm);
   transition:
     border-color 0.3s ease,
     box-shadow 0.3s ease;
@@ -335,6 +338,7 @@ body,
 
 .session-card:hover {
   border-color: var(--accent-green);
+  box-shadow: 0 4px 12px var(--shadow-md);
 }
 
 .session-card.selected {


### PR DESCRIPTION
## Summary

Light theme reworked from "washed pastel" to "crisp paper on cool desk":

- Canvas cooled to `#eef0f5` so pure-white sidebar/cards visibly float (with new subtle card shadow)
- Sharper text (`#0f172a` primary / `#475569` secondary) and slightly stronger card border
- New `--dot-grid` token: canvas texture stays visible without making card borders louder
- Theme-aware cluster accent palette in `SessionCanvas.tsx` — light counterparts are 3-4 stops deeper (e.g. `#4ade80` → `#15803d`, `#f472b6` → `#be185d`, `#2dd4bf` → `#0f766e`) so dashed cluster borders read as identity instead of dust on white
- Dark theme tokens unchanged; card shadow is a no-op there

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Light theme verified via CDP screenshot — clusters, cards, sidebar, status bar all readable
- [x] Dark theme verified — visually unchanged from main