### PR TITLE
[codex] fix terminal restore render race

### DIFF
--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -151,6 +151,8 @@ export default function Terminal({ sessionId }: Props) {
         termRef.current = term
         fitRef.current = fitAddon
 
+        await syncTerminal(true)
+
         let sawLiveData = false
 
         dataCleanup = window.api.onPtyData((event) => {
@@ -160,7 +162,6 @@ export default function Terminal({ sessionId }: Props) {
           }
         })
 
-        await syncTerminal(true)
         await new Promise((r) => setTimeout(r, 120))
         if (aborted) return
 

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -85,6 +85,19 @@ export default function Terminal({ sessionId }: Props) {
     let aborted = false
     let dataCleanup: (() => void) | null = null
     let webglAddon: WebglAddon | null = null
+    let readyForPtyData = false
+    let pendingPtyData = ''
+    let sawLiveData = false
+
+    dataCleanup = window.api.onPtyData((event) => {
+      if (event.sessionId !== sessionId) return
+      sawLiveData = true
+      if (readyForPtyData) {
+        term.write(event.data)
+      } else {
+        pendingPtyData += event.data
+      }
+    })
 
     const syncTerminal = async (invalidateAtlas = false) => {
       if (aborted) return
@@ -152,15 +165,14 @@ export default function Terminal({ sessionId }: Props) {
         fitRef.current = fitAddon
 
         await syncTerminal(true)
-
-        let sawLiveData = false
-
-        dataCleanup = window.api.onPtyData((event) => {
-          if (event.sessionId === sessionId) {
-            sawLiveData = true
-            term.write(event.data)
-          }
-        })
+        if (aborted) return
+        while (pendingPtyData) {
+          const data = pendingPtyData
+          pendingPtyData = ''
+          await new Promise<void>((resolve) => term.write(data, resolve))
+          if (aborted) return
+        }
+        readyForPtyData = true
 
         await new Promise((r) => setTimeout(r, 120))
         if (aborted) return


### PR DESCRIPTION
## Summary

- Sync the xterm instance with `fit()`/`ptyResize()` before subscribing to live PTY data.
- Let early restored tmux output be recovered from scrollback after geometry is stable instead of painting it into xterm's default grid.

## Root cause

The intermittent broken rendering looked like a terminal/compositor issue because resizing the Niri window forced a repaint. CDP inspection showed this build is using xterm's DOM renderer at fractional effective DPR, not WebGL/canvas. The remaining race was init order: a restored PTY buffer could arrive before the first fit/resize pass, so xterm could render at the wrong initial geometry and only recover after a real resize.

## Validation

- `git diff --check`
- `npx tsc --noEmit`
- `npx eslint .`
- `npm run build`
- `npx vitest run` (20 files, 361 tests)
- CDP smoke check against copied `issue440` session at effective DPR 1.8