### PR TITLE
fix: prompt worktree cleanup when codex (or any agent) exits

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -71,6 +71,13 @@ function fireAgentExit(sessionId: string, entry: PtyEntry): void {
   if (!listener) return
 
   if (!entry.host) {
+    // Local: pty.onExit fires for any `tmux attach-session` client detach,
+    // not just for the agent exiting. A normal tmux detach (e.g. Ctrl-b d
+    // passing through xterm.js, or another `detach-client` from outside)
+    // would otherwise be misclassified as agent exit and the cleanup prompt
+    // would offer to delete a still-live worktree. Confirm the cc-pewpew
+    // tmux session is actually gone before firing the listener.
+    if (hasTmuxSession(sessionId)) return
     listener(sessionId)
     return
   }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -46,10 +46,29 @@ interface PtyEntry {
   buffer: string
   host?: Host
   released?: boolean
+  // Set by detachPty/destroyPty/destroyRemotePty before they kill the pty,
+  // so the onExit handler can tell "user/cc-pewpew tore this down" apart from
+  // "the agent (claude/codex) exited on its own". Only the latter triggers
+  // the cleanup-prompt callback.
+  intentionallyClosed?: boolean
 }
 
 const ptys = new Map<string, PtyEntry>()
 let flushInterval: ReturnType<typeof setInterval> | null = null
+let teardownStarted = false
+
+type AgentExitListener = (sessionId: string) => void
+let agentExitListener: AgentExitListener | null = null
+
+export function setOnAgentExit(listener: AgentExitListener | null): void {
+  agentExitListener = listener
+}
+
+function fireAgentExit(sessionId: string, entry: PtyEntry): void {
+  if (teardownStarted) return
+  if (entry.intentionallyClosed) return
+  agentExitListener?.(sessionId)
+}
 
 function flushBuffers(): void {
   for (const [sessionId, entry] of ptys) {
@@ -74,6 +93,7 @@ export function initPtyManager(): void {
 }
 
 export function stopPtyManager(): void {
+  teardownStarted = true
   if (flushInterval) {
     clearInterval(flushInterval)
     flushInterval = null
@@ -133,6 +153,7 @@ export function createPty(sessionId: string, cwd: string, options?: SpawnOptions
 
   ptyProcess.onExit(() => {
     ptys.delete(sessionId)
+    fireAgentExit(sessionId, entry)
   })
 
   ptys.set(sessionId, entry)
@@ -195,6 +216,7 @@ export async function createRemotePty(
   ptyProcess.onExit(() => {
     ptys.delete(sessionId)
     releaseRemoteEntry(entry)
+    fireAgentExit(sessionId, entry)
   })
 
   ptys.set(sessionId, entry)
@@ -219,6 +241,7 @@ export function detachPty(sessionId: string): void {
   const entry = ptys.get(sessionId)
   if (!entry) return
 
+  entry.intentionallyClosed = true
   ptys.delete(sessionId)
   releaseRemoteEntry(entry)
 
@@ -235,6 +258,7 @@ export function destroyPty(sessionId: string): void {
   const tmuxSession = entry?.tmuxSession ?? `cc-pewpew-${sessionId}`
 
   if (entry) {
+    entry.intentionallyClosed = true
     ptys.delete(sessionId)
     releaseRemoteEntry(entry)
 
@@ -257,6 +281,13 @@ export function destroyPty(sessionId: string): void {
 export async function destroyRemotePty(sessionId: string, host: Host): Promise<void> {
   const entry = ptys.get(sessionId)
   const tmuxSession = entry?.tmuxSession ?? `cc-pewpew-${sessionId}`
+
+  // Mark before issuing the kill so the inevitable pty.onExit (triggered when
+  // the remote tmux dies and ssh attach drops) is recognised as our doing,
+  // not as the agent exiting on its own. Set even when the kill rejects: the
+  // remote side may already have exited, and we don't want a race here to
+  // re-fire promptCleanup.
+  if (entry) entry.intentionallyClosed = true
 
   const result = await execRemote(host, ['tmux', 'kill-session', '-t', tmuxSession], {
     timeoutMs: 5000,

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -67,7 +67,32 @@ export function setOnAgentExit(listener: AgentExitListener | null): void {
 function fireAgentExit(sessionId: string, entry: PtyEntry): void {
   if (teardownStarted) return
   if (entry.intentionallyClosed) return
-  agentExitListener?.(sessionId)
+  const listener = agentExitListener
+  if (!listener) return
+
+  if (!entry.host) {
+    listener(sessionId)
+    return
+  }
+
+  // Remote: pty.onExit fires when the local `ssh -tt ... tmux attach-session`
+  // PTY drops. That can be an actual remote agent exit (tmux session ended),
+  // but it can also be a transport-level drop with the remote tmux still alive
+  // — network blip, ControlMaster teardown, peer SSH death. Probe the remote
+  // before treating this as an agent exit; only fire on a definitive 'absent'.
+  // 'unreachable' falls through silently — the existing reconnect machinery
+  // will reconcile the session's connectionState without our help, and we'd
+  // rather miss a codex-remote-/exit cleanup prompt than racefully delete a
+  // still-live remote worktree.
+  const remoteHost = entry.host
+  void (async () => {
+    try {
+      const probe = await probeRemoteTmuxSession(sessionId, remoteHost)
+      if (probe === 'absent') listener(sessionId)
+    } catch {
+      // Probe itself threw — treat as 'unreachable' and bail.
+    }
+  })()
 }
 
 function flushBuffers(): void {
@@ -480,6 +505,7 @@ export function reattachPty(sessionId: string): void {
 
   ptyProcess.onExit(() => {
     ptys.delete(sessionId)
+    fireAgentExit(sessionId, entry)
   })
 
   ptys.set(sessionId, entry)
@@ -525,6 +551,7 @@ export async function reattachRemotePty(sessionId: string, host: Host): Promise<
   ptyProcess.onExit(() => {
     ptys.delete(sessionId)
     releaseRemoteEntry(entry)
+    fireAgentExit(sessionId, entry)
   })
 
   ptys.set(sessionId, entry)

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -23,6 +23,7 @@ import {
   reattachPty,
   reattachRemotePty,
   createRemotePty,
+  setOnAgentExit,
 } from './pty-manager'
 import { getRepoFingerprint, gitWorktrees } from './project-scanner'
 import {
@@ -397,6 +398,18 @@ export function initSessionManager(): void {
       if (entry.session.prNumber === undefined) resolvePrNumberAsync(entry.session.id)
     }
   }, PR_REFRESH_INTERVAL_MS).unref()
+
+  // When a session's agent (claude/codex) exits on its own — by /exit, crash,
+  // or any path that wasn't cc-pewpew tearing the pty down ourselves —
+  // open the cleanup prompt. Claude's SessionEnd hook already does this via
+  // the session.end RPC; this fallback covers Codex (which has no SessionEnd
+  // hook) and any abnormal exit on either tool. promptCleanup's
+  // cleanupInProgress lock dedupes the two paths if they both fire.
+  setOnAgentExit((sessionId) => {
+    promptCleanup(sessionId).catch((err) => {
+      console.error(`promptCleanup(${sessionId}) failed via agent-exit:`, err)
+    })
+  })
 }
 
 async function deriveLabel(worktreePath: string): Promise<string> {
@@ -1290,7 +1303,10 @@ export async function removeWorktree(id: string): Promise<void> {
   }
 }
 
-export async function removeSession(id: string): Promise<void> {
+export async function removeSession(
+  id: string,
+  options: { keepWorktree?: boolean } = {}
+): Promise<void> {
   const entry = sessions.get(id)
   if (entry?.session.hostId) {
     const host = getRequiredHost(entry.session.hostId)
@@ -1298,7 +1314,7 @@ export async function removeSession(id: string): Promise<void> {
   } else {
     destroyPty(id)
   }
-  await removeWorktree(id)
+  if (!options.keepWorktree) await removeWorktree(id)
   sessions.delete(id)
   onSessionsChanged()
 }
@@ -1324,18 +1340,23 @@ const cleanupInProgress = new Set<string>()
 
 async function promptCleanup(id: string): Promise<void> {
   if (cleanupInProgress.has(id)) return
+  // Bail before grabbing the lock if the session is already gone — e.g. a
+  // previous prompt-cleanup answered "Delete" and removeSession() ran. Without
+  // this check, a late pty-onExit triggered by the same agent shutdown would
+  // re-open the dialog with no session to clean up.
+  const entry = sessions.get(id)
+  if (!entry) return
+
   cleanupInProgress.add(id)
   try {
-    const entry = sessions.get(id)
-    if (!entry) return
-
     const session = entry.session
     const parentWindow = getMainWindow()
 
     const options = {
       type: 'question' as const,
       title: 'Session ended',
-      message: `Session "${session.projectName}/${session.worktreeName}" ended.\nClean up worktree?`,
+      message: `Session "${session.projectName}/${session.worktreeName}" ended.\nDelete the worktree?`,
+      detail: 'The session will be removed from the canvas either way.',
       buttons: ['Delete worktree', 'Keep worktree', 'Keep and open in file manager'],
       defaultId: 1,
       cancelId: 1,
@@ -1345,13 +1366,19 @@ async function promptCleanup(id: string): Promise<void> {
       ? await dialog.showMessageBox(parentWindow, options)
       : await dialog.showMessageBox(options)
 
+    // All three responses end with the session removed. The dialog only
+    // controls whether the worktree directory is deleted.
     if (response === 0) {
       await removeSession(id)
-    } else if (response === 1) {
-      updateSession(id, 'completed')
     } else if (response === 2) {
-      updateSession(id, 'completed')
-      shell.openPath(session.worktreePath)
+      // Capture the path before removeSession drops the entry. keepWorktree
+      // means the directory itself survives — we just need its path to hand
+      // to the file manager.
+      const path = session.worktreePath
+      await removeSession(id, { keepWorktree: true })
+      shell.openPath(path)
+    } else {
+      await removeSession(id, { keepWorktree: true })
     }
   } finally {
     cleanupInProgress.delete(id)


### PR DESCRIPTION
## Summary

- Codex sessions never triggered the worktree-cleanup dialog because Codex has no `SessionEnd` hook (only Claude does). Detect agent exit via the pty hitting EOF when the tmux session command (claude/codex) exits, and route that into the existing `promptCleanup`.
- `cleanupInProgress` lock + a `intentionallyClosed` flag on `PtyEntry` keep the new path from racing with Claude's `session.end` RPC and from misfiring when cc-pewpew itself tears the pty down (Kill session, Remove from canvas, Reconnect detach, app quit).
- The cleanup dialog now always removes the card from the canvas — only worktree deletion stays user-controlled. `removeSession` gains a `keepWorktree` option so the "Keep worktree" and "Keep + open in file manager" responses both reuse the full teardown path.
- As a side effect, abnormal exits (crash, OOM, kill -9) on either tool now also surface the cleanup prompt instead of leaving a dead card.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] `npx vitest run` — 361 tests pass
- [ ] Local Claude `/exit` → dialog appears, all three buttons remove the card; "Delete" also removes the worktree dir
- [ ] Local Codex `/exit` → same
- [ ] Kill session via UI → no spurious dialog, card flips to dead
- [ ] Remove from canvas via UI → no spurious dialog, card disappears
- [ ] Reconnect remote session → no spurious dialog
- [ ] App quit while a session is alive → no spurious dialog