### PR TITLE
fix(canvas): shrink cluster border to fit a single card

### DIFF
--- a/src/renderer/components/SessionCluster.tsx
+++ b/src/renderer/components/SessionCluster.tsx
@@ -117,7 +117,10 @@ export default function SessionCluster({
       >
         {projectName}
       </div>
-      <div className="cluster-cards">
+      <div
+        className="cluster-cards"
+        style={{ gridTemplateColumns: `repeat(${Math.min(sessions.length, 2)}, 240px)` }}
+      >
         {sessions.map((session) => (
           <SessionCard
             key={session.id}


### PR DESCRIPTION
## Summary
- One-card clusters showed an oversized dashed border because the grid template was hardcoded to two 240px columns, reserving an empty second column.
- Set `gridTemplateColumns` inline to `repeat(min(sessions.length, 2), 240px)` so the cluster shrink-to-fits a single card and still lays out two columns when there are 2+ sessions.
- Regression introduced in #81 (switch from absolute positioning to CSS grid).

## Test plan
- [ ] Single-session cluster: dashed border hugs the card with no empty column.
- [ ] Two-session cluster: layout unchanged (two columns side by side).
- [ ] 3+ sessions: cards still wrap into two columns and the cluster height grows accordingly.
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] `npx vitest run` (361 tests pass)