### PR TITLE
[codex] Fix react-doctor UI accessibility warnings

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -27,6 +27,7 @@ export default function App() {
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const [activeSessionName, setActiveSessionName] = useState('')
   const [morphPayload, setMorphPayload] = useState<ZoomOpenPayload | null>(null)
+  const createProjectInputRef = useRef<HTMLInputElement>(null)
 
   const handleZoomOpen = useCallback((payload: ZoomOpenPayload) => {
     // Keep canvas rendered during the morph; mount DetailPane only on morph grown.
@@ -46,6 +47,10 @@ export default function App() {
   useEffect(() => {
     return initSessions()
   }, [initSessions])
+
+  useEffect(() => {
+    if (showCreateDialog) createProjectInputRef.current?.focus()
+  }, [showCreateDialog])
 
   // Subscribe to open-detail IPC from tray/notifications
   useEffect(() => {
@@ -177,16 +182,16 @@ export default function App() {
           {showCreateDialog ? (
             <div className="create-dialog">
               <input
+                ref={createProjectInputRef}
                 type="text"
                 className="create-input"
-                placeholder="Project name..."
+                placeholder="Project name…"
                 value={newProjectName}
                 onChange={(e) => setNewProjectName(e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') handleCreate()
                   if (e.key === 'Escape') setShowCreateDialog(false)
                 }}
-                autoFocus
               />
               <div className="create-actions">
                 <button className="create-btn" onClick={handleCreate}>
@@ -223,7 +228,12 @@ export default function App() {
         </div>
       </aside>
 
-      <div className="sidebar-resizer" onMouseDown={handleResizeStart} />
+      <div
+        className="sidebar-resizer"
+        role="separator"
+        aria-orientation="vertical"
+        onMouseDown={handleResizeStart}
+      />
 
       <main className="canvas">
         {activeSessionId ? (

--- a/src/renderer/SwimLanesApp.tsx
+++ b/src/renderer/SwimLanesApp.tsx
@@ -88,7 +88,20 @@ export default function SwimLanesApp() {
           const isReviewOpen = flipCount % 2 === 1
 
           return (
-            <div key={id} className="lane" data-lane-id={id} onClick={() => setFocusedLane(id)}>
+            <div
+              key={id}
+              className="lane"
+              data-lane-id={id}
+              role="group"
+              tabIndex={0}
+              onClick={() => setFocusedLane(id)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  setFocusedLane(id)
+                }
+              }}
+            >
               <LaneHeader session={session} focused={focusedLane === id} />
               <div className="lane-terminal">
                 {isDead ? (

--- a/src/renderer/SwimLanesApp.tsx
+++ b/src/renderer/SwimLanesApp.tsx
@@ -96,6 +96,7 @@ export default function SwimLanesApp() {
               tabIndex={0}
               onClick={() => setFocusedLane(id)}
               onKeyDown={(e) => {
+                if (e.target !== e.currentTarget) return
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault()
                   setFocusedLane(id)

--- a/src/renderer/components/AddRemoteProjectDialog.tsx
+++ b/src/renderer/components/AddRemoteProjectDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { Host } from '../../shared/types'
 import { useProjectsStore } from '../stores/projects'
 import { useHostsStore } from '../stores/hosts'
@@ -64,6 +64,11 @@ function AddRemoteProjectDialogContent({
 }: AddRemoteProjectDialogContentProps) {
   const [selectedHostId, setSelectedHostId] = useState(() => hosts[0]?.hostId ?? '')
   const [remotePath, setRemotePath] = useState('')
+  const hostSelectRef = useRef<HTMLSelectElement>(null)
+
+  useEffect(() => {
+    hostSelectRef.current?.focus()
+  }, [])
 
   const selectedHostAvailable = hosts.some((h) => h.hostId === selectedHostId)
   const activeHostId = selectedHostAvailable ? selectedHostId : (hosts[0]?.hostId ?? '')
@@ -86,10 +91,11 @@ function AddRemoteProjectDialogContent({
   return (
     <div
       className="hosts-dialog-overlay"
+      role="presentation"
       onClick={closeDialog}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <div className="hosts-dialog" onClick={(e) => e.stopPropagation()}>
+      <div className="hosts-dialog" role="presentation" onClick={(e) => e.stopPropagation()}>
         <div className="hosts-dialog-header">
           <div className="session-name-label">Add remote project</div>
           <button className="create-btn cancel" onClick={closeDialog}>
@@ -98,9 +104,9 @@ function AddRemoteProjectDialogContent({
         </div>
 
         {error && (
-          <div className="hosts-error" onClick={clearError}>
+          <button type="button" className="hosts-error" onClick={clearError}>
             {error}
-          </div>
+          </button>
         )}
 
         {hosts.length === 0 ? (
@@ -119,7 +125,7 @@ function AddRemoteProjectDialogContent({
         ) : (
           <div className="add-remote-form hosts-form">
             <select
-              autoFocus
+              ref={hostSelectRef}
               className="create-input"
               value={activeHostId}
               onChange={(e) => setSelectedHostId(e.target.value)}

--- a/src/renderer/components/BroadcastBar.tsx
+++ b/src/renderer/components/BroadcastBar.tsx
@@ -30,7 +30,7 @@ export default function BroadcastBar({ sessionIds }: Props) {
       <input
         ref={inputRef}
         type="text"
-        placeholder="Broadcast command to all lanes..."
+        placeholder="Broadcast command to all lanes…"
         value={command}
         onChange={(e) => setCommand(e.target.value)}
         onKeyDown={handleKeyDown}

--- a/src/renderer/components/BroadcastDialog.tsx
+++ b/src/renderer/components/BroadcastDialog.tsx
@@ -47,16 +47,17 @@ function BroadcastDialogContent() {
   return (
     <div
       className="broadcast-dialog-overlay"
+      role="presentation"
       onClick={closeBroadcastDialog}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <div className="broadcast-dialog" onClick={(e) => e.stopPropagation()}>
+      <div className="broadcast-dialog" role="presentation" onClick={(e) => e.stopPropagation()}>
         <div className="session-name-label">Send command to {selectedIds.size} sessions</div>
         <input
           ref={inputRef}
           type="text"
           className="create-input"
-          placeholder="Type a command..."
+          placeholder="Type a command…"
           value={command}
           onChange={(e) => setCommand(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/src/renderer/components/ContextMenu.tsx
+++ b/src/renderer/components/ContextMenu.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 
 export interface MenuItem {
   label: string
+  id?: string
   disabled?: boolean
   separator?: boolean
   onClick: () => void
@@ -60,6 +61,8 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
     }
   }, [onClose])
 
+  let separatorCount = 0
+
   return createPortal(
     <div
       className="context-menu"
@@ -68,12 +71,16 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
       style={{ left: x, top: y }}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      {items.map((item, i) =>
+      {items.map((item) =>
         item.separator ? (
-          <div key={i} className="context-menu-separator" role="separator" />
+          <div
+            key={item.id ?? `separator-${separatorCount++}`}
+            className="context-menu-separator"
+            role="separator"
+          />
         ) : (
           <button
-            key={i}
+            key={item.id ?? item.label}
             role="menuitem"
             className={`context-menu-item${item.disabled ? ' disabled' : ''}`}
             disabled={item.disabled}

--- a/src/renderer/components/DetailPane.tsx
+++ b/src/renderer/components/DetailPane.tsx
@@ -138,7 +138,7 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
                 terminal in the same worktree.
               </p>
               <button className="dead-session-restart" onClick={handleRevive} disabled={reviving}>
-                {reviving ? 'Restarting...' : 'Restart terminal'}
+                {reviving ? 'Restarting…' : 'Restart terminal'}
               </button>
             </div>
           </div>
@@ -185,7 +185,7 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
                 onClick={handleReconnect}
                 disabled={reconnecting || isConnecting}
               >
-                {reconnecting || isConnecting ? 'Connecting...' : isPending ? 'Connect' : 'Retry'}
+                {reconnecting || isConnecting ? 'Connecting…' : isPending ? 'Connect' : 'Retry'}
               </button>
             </div>
           </div>

--- a/src/renderer/components/LaneHeader.tsx
+++ b/src/renderer/components/LaneHeader.tsx
@@ -10,7 +10,7 @@ export default function LaneHeader({ session, focused }: Props) {
   if (!session) {
     return (
       <div className="lane-header">
-        <span className="lane-header-name">Loading...</span>
+        <span className="lane-header-name">Loading…</span>
       </div>
     )
   }

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useHostsStore } from '../stores/hosts'
 import type { Host, HostId, TestConnectionResult } from '../../shared/types'
 
@@ -33,6 +33,11 @@ function HostForm({
   const [alias, setAlias] = useState(initialAlias)
   const [label, setLabel] = useState(initialLabel)
   const [submitting, setSubmitting] = useState(false)
+  const aliasInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    aliasInputRef.current?.focus()
+  }, [])
 
   const canSubmit = alias.trim().length > 0 && label.trim().length > 0 && !submitting
 
@@ -60,7 +65,7 @@ function HostForm({
   return (
     <div className="hosts-form">
       <input
-        autoFocus
+        ref={aliasInputRef}
         type="text"
         className="create-input"
         placeholder="Host from ~/.ssh/config (e.g. devbox)"
@@ -96,6 +101,11 @@ interface HostDeleteConfirmProps {
 
 function HostDeleteConfirm({ host, onConfirm, onCancel }: HostDeleteConfirmProps) {
   const [submitting, setSubmitting] = useState(false)
+  const confirmButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    confirmButtonRef.current?.focus()
+  }, [])
 
   // `submitting` only meaningfully blocks a re-click while we await the async
   // delete; without `await onConfirm()` the lock would clear synchronously,
@@ -114,6 +124,7 @@ function HostDeleteConfirm({ host, onConfirm, onCancel }: HostDeleteConfirmProps
   return (
     <div
       className="hosts-form hosts-delete-confirm"
+      role="group"
       tabIndex={-1}
       onKeyDown={(e) => {
         if (e.key === 'Escape') onCancel()
@@ -128,7 +139,7 @@ function HostDeleteConfirm({ host, onConfirm, onCancel }: HostDeleteConfirmProps
       </div>
       <div className="create-actions">
         <button
-          autoFocus
+          ref={confirmButtonRef}
           className="create-btn cancel"
           disabled={submitting}
           onClick={handleConfirm}
@@ -233,10 +244,11 @@ export default function ManageHostsDialog() {
   return (
     <div
       className="hosts-dialog-overlay"
+      role="presentation"
       onClick={closeDialog}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <div className="hosts-dialog" onClick={(e) => e.stopPropagation()}>
+      <div className="hosts-dialog" role="presentation" onClick={(e) => e.stopPropagation()}>
         <div className="hosts-dialog-header">
           <div className="session-name-label">Manage hosts</div>
           <button className="create-btn cancel" onClick={closeDialog}>

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useProjectsStore } from '../stores/projects'
 import { useSessionsStore } from '../stores/sessions'
 import { useHostsStore } from '../stores/hosts'
@@ -39,6 +39,8 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   const [prNumberInput, setPrNumberInput] = useState('')
   const [prError, setPrError] = useState<string | null>(null)
   const [toast, setToast] = useState<string | null>(null)
+  const sessionNameInputRef = useRef<HTMLInputElement>(null)
+  const prNumberInputRef = useRef<HTMLInputElement>(null)
 
   const showToast = (msg: string) => {
     setToast(msg)
@@ -64,6 +66,14 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
       cancelled = true
     }
   }, [])
+
+  useEffect(() => {
+    if (pendingSessionPath) sessionNameInputRef.current?.focus()
+  }, [pendingSessionPath])
+
+  useEffect(() => {
+    if (pendingPrPath) prNumberInputRef.current?.focus()
+  }, [pendingPrPath])
 
   const toggle = (path: string) => {
     setExpanded((prev) => {
@@ -171,13 +181,13 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
     if (menu.hostId !== null) {
       const hostId = menu.hostId
       items.push({
-        label: 'New session...',
+        label: 'New session…',
         onClick: async () => {
           await openNewSessionDialog(menu.projectPath, hostId)
         },
       })
       items.push({
-        label: 'New PR session...',
+        label: 'New PR session…',
         onClick: () => {
           setPendingPrPath(menu.projectPath)
           setPendingPrHostId(hostId)
@@ -216,13 +226,13 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
       })
     } else {
       items.push({
-        label: 'New session...',
+        label: 'New session…',
         onClick: async () => {
           await openNewSessionDialog(menu.projectPath, null)
         },
       })
       items.push({
-        label: 'New PR session...',
+        label: 'New PR session…',
         onClick: () => {
           setPendingPrPath(menu.projectPath)
           setPendingPrHostId(null)
@@ -292,7 +302,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
   }
 
   if (loading) {
-    return <div className="project-loading">Scanning...</div>
+    return <div className="project-loading">Scanning…</div>
   }
 
   const displayProjects = filterReady ? projects.filter((p) => p.setupState === 'ready') : projects
@@ -376,9 +386,10 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
         <div className="session-name-dialog">
           <div className="session-name-label">Session name (optional):</div>
           <input
+            ref={sessionNameInputRef}
             type="text"
             className="create-input"
-            placeholder="Leave empty for auto-name..."
+            placeholder="Leave empty for auto-name…"
             value={sessionNameInput}
             onChange={(e) => setSessionNameInput(e.target.value)}
             onKeyDown={(e) => {
@@ -389,7 +400,6 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
                 setCreateError(null)
               }
             }}
-            autoFocus
           />
           <div className="session-name-label">Tool:</div>
           <div className="tool-picker">
@@ -428,7 +438,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
           {createError && <div className="pr-error">{createError}</div>}
           <div className="create-actions">
             <button className="create-btn" onClick={handleCreateSession} disabled={creating}>
-              {creating ? 'Creating...' : 'Create'}
+              {creating ? 'Creating…' : 'Create'}
             </button>
             <button
               className="create-btn cancel"
@@ -447,6 +457,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
         <div className="session-name-dialog">
           <div className="session-name-label">PR number(s):</div>
           <input
+            ref={prNumberInputRef}
             type="text"
             className="create-input"
             placeholder="e.g. 42 or 1,2,22-28"
@@ -460,7 +471,6 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
                 setPrError(null)
               }
             }}
-            autoFocus
           />
           <div className="session-name-label">Tool:</div>
           <div className="tool-picker">
@@ -488,7 +498,7 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
           {prError && <div className="pr-error">{prError}</div>}
           <div className="create-actions">
             <button className="create-btn" onClick={handleCreatePrSession} disabled={creating}>
-              {creating ? 'Creating...' : 'Create'}
+              {creating ? 'Creating…' : 'Create'}
             </button>
             <button
               className="create-btn cancel"
@@ -510,7 +520,8 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
 
         return (
           <div key={`${project.hostId ?? 'local'}:${project.path}`} className="project-node">
-            <div
+            <button
+              type="button"
               className="project-row"
               onClick={() => hasWorktrees && toggle(project.path)}
               onContextMenu={(e) =>
@@ -536,26 +547,15 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
                     [Setup]
                   </span>
                 ))}
-            </div>
+            </button>
 
             {isExpanded && (
               <div className="worktree-list">
                 {project.worktrees.map((wt) => {
                   const matchingSession = sessions.find((s) => s.worktreePath === wt.path)
                   const canMirror = !matchingSession && !wt.isMain
-                  return (
-                    <div
-                      key={wt.path}
-                      className={`worktree-item${matchingSession ? ' clickable' : ''}`}
-                      onClick={() => {
-                        if (matchingSession && onOpenSession) {
-                          onOpenSession(
-                            matchingSession.id,
-                            `${matchingSession.projectName}/${matchingSession.worktreeName}`
-                          )
-                        }
-                      }}
-                    >
+                  const worktreeContent = (
+                    <>
                       <span className="worktree-label">
                         {wt.name}
                         {wt.branch && <span className="worktree-branch"> ({wt.branch})</span>}
@@ -584,6 +584,28 @@ export default function ProjectTree({ onOpenSession }: TreeProps) {
                           + Mirror
                         </button>
                       )}
+                    </>
+                  )
+                  if (matchingSession && onOpenSession) {
+                    return (
+                      <button
+                        key={wt.path}
+                        type="button"
+                        className="worktree-item clickable"
+                        onClick={() => {
+                          onOpenSession(
+                            matchingSession.id,
+                            `${matchingSession.projectName}/${matchingSession.worktreeName}`
+                          )
+                        }}
+                      >
+                        {worktreeContent}
+                      </button>
+                    )
+                  }
+                  return (
+                    <div key={wt.path} className="worktree-item">
+                      {worktreeContent}
                     </div>
                   )
                 })}

--- a/src/renderer/components/ReviewOverlay.tsx
+++ b/src/renderer/components/ReviewOverlay.tsx
@@ -364,7 +364,7 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
                       setConfirmAction(null)
                     }}
                   >
-                    Continue
+                    Omit unreviewed
                   </button>
                 </div>
               </div>
@@ -393,7 +393,7 @@ export default function ReviewOverlay({ sessionId, onClose }: Props) {
                       setPendingBranch(null)
                     }}
                   >
-                    Continue
+                    Switch mode
                   </button>
                 </div>
               </div>

--- a/src/renderer/components/SessionCanvas.tsx
+++ b/src/renderer/components/SessionCanvas.tsx
@@ -511,6 +511,8 @@ export default function SessionCanvas({ onOpenSession, onZoomOpen, morphActive }
     <div
       className="canvas-viewport"
       ref={viewportRef}
+      role="application"
+      tabIndex={0}
       onWheel={handleWheel}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -43,7 +43,7 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
 
   const sessionName = `${session.projectName}/${session.worktreeName}`
 
-  const handleClick = (e: React.MouseEvent) => {
+  const openOrSelectSession = (e: React.MouseEvent) => {
     if (e.ctrlKey || e.metaKey || e.shiftKey) {
       onSelect?.(session.id, e)
       return
@@ -168,10 +168,11 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
     .join(' ')
 
   return (
-    <div
+    <button
+      type="button"
       className={classes}
       data-session-id={session.id}
-      onClick={handleClick}
+      onClick={openOrSelectSession}
       onContextMenu={handleContextMenu}
       style={style}
     >
@@ -224,6 +225,6 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
       {menu && (
         <ContextMenu x={menu.x} y={menu.y} items={buildMenuItems()} onClose={() => setMenu(null)} />
       )}
-    </div>
+    </button>
   )
 }

--- a/src/renderer/components/SessionCluster.tsx
+++ b/src/renderer/components/SessionCluster.tsx
@@ -94,7 +94,7 @@ export default function SessionCluster({
     ...(isOrphaned
       ? [
           { separator: true } as MenuItem,
-          { label: 'Locate moved project...', onClick: handleLocateProject } as MenuItem,
+          { label: 'Locate moved project…', onClick: handleLocateProject } as MenuItem,
         ]
       : []),
   ]
@@ -109,14 +109,15 @@ export default function SessionCluster({
         borderColor: accentColor,
       }}
     >
-      <div
+      <button
+        type="button"
         className={`cluster-header${isOrphaned ? ' cluster-header--orphaned' : ''}`}
         style={isOrphaned ? undefined : { color: accentColor }}
         onMouseDown={handleMouseDown}
         onContextMenu={handleHeaderContextMenu}
       >
         {projectName}
-      </div>
+      </button>
       <div
         className="cluster-cards"
         style={{ gridTemplateColumns: `repeat(${Math.min(sessions.length, 2)}, 240px)` }}

--- a/src/renderer/components/review/DiffViewer.tsx
+++ b/src/renderer/components/review/DiffViewer.tsx
@@ -48,7 +48,7 @@ function AnnotationBadge({
         ? (annotation.comment ?? 'Comment')
         : (annotation.comment ?? 'Rejected')
 
-  const displayLabel = label.length > 60 ? label.slice(0, 60) + '...' : label
+  const displayLabel = label.length > 60 ? `${label.slice(0, 60)}…` : label
 
   return (
     <div
@@ -115,8 +115,11 @@ function DiffHunkView({
           />
         )}
       </div>
-      {hunk.lines.map((line, i) => (
-        <DiffLineRow key={i} line={line} />
+      {hunk.lines.map((line) => (
+        <DiffLineRow
+          key={`${line.lineType}:${line.oldLineNo ?? ''}:${line.newLineNo ?? ''}:${line.content}`}
+          line={line}
+        />
       ))}
       {annotations.map((ann) => (
         <AnnotationBadge

--- a/src/renderer/components/review/FeedbackInput.tsx
+++ b/src/renderer/components/review/FeedbackInput.tsx
@@ -27,7 +27,7 @@ const FeedbackInput: React.FC<FeedbackInputProps> = ({ mode, onSubmit, onCancel 
   }
 
   return (
-    <div className="rv-feedback-input" onKeyDown={handleKeyDown}>
+    <div className="rv-feedback-input" role="group" onKeyDown={handleKeyDown}>
       {mode === 'reject' && (
         <div className="rv-feedback-radio-group">
           <label>
@@ -57,7 +57,7 @@ const FeedbackInput: React.FC<FeedbackInputProps> = ({ mode, onSubmit, onCancel 
         className="rv-feedback-textarea"
         value={comment}
         onChange={(e) => setComment(e.target.value)}
-        placeholder={mode === 'reject' ? 'Describe your feedback...' : 'Add a comment...'}
+        placeholder={mode === 'reject' ? 'Describe your feedback…' : 'Add a comment…'}
       />
       <div className="rv-feedback-actions">
         <button className="rv-feedback-btn rv-feedback-btn--cancel" onClick={onCancel}>
@@ -67,7 +67,7 @@ const FeedbackInput: React.FC<FeedbackInputProps> = ({ mode, onSubmit, onCancel 
           className="rv-feedback-btn rv-feedback-btn--submit"
           onClick={() => onSubmit(comment, mode === 'reject' ? rejectMode : undefined)}
         >
-          Submit
+          {mode === 'reject' ? 'Add rejection' : 'Add comment'}
         </button>
       </div>
     </div>

--- a/src/renderer/components/review/FileTree.tsx
+++ b/src/renderer/components/review/FileTree.tsx
@@ -53,14 +53,15 @@ function DirectoryNode({
 
   return (
     <div className="rv-file-tree-dir">
-      <div
+      <button
+        type="button"
         className="rv-file-tree-dir-label"
         style={{ paddingLeft: depth * 16 + 8 }}
         onClick={() => setExpanded(!expanded)}
       >
         <span className="rv-file-tree-arrow">{expanded ? '\u25BC' : '\u25B6'}</span>
         <span className="rv-file-tree-dir-name">{node.name}/</span>
-      </div>
+      </button>
       {expanded && (
         <div>
           {dirs.map((dir) => (
@@ -102,13 +103,14 @@ function FileNode({
   const isFocused = focusedFile === file.path
 
   return (
-    <div
+    <button
+      type="button"
       className={`rv-file-tree-file${isFocused ? ' rv-file-tree-file--focused' : ''}`}
       style={{ paddingLeft: depth * 16 + 26 }}
       onClick={() => onFileClick(file.path)}
     >
       <span className="rv-file-tree-file-name">{node.name}</span>
-    </div>
+    </button>
   )
 }
 

--- a/src/renderer/components/review/ReviewBottomBar.tsx
+++ b/src/renderer/components/review/ReviewBottomBar.tsx
@@ -1,5 +1,3 @@
-import type { JSX } from 'react'
-
 interface ReviewBottomBarProps {
   approved: number
   commented: number
@@ -17,28 +15,28 @@ export default function ReviewBottomBar({
   onSendToSession,
   onCopyToClipboard,
 }: ReviewBottomBarProps) {
-  const parts: JSX.Element[] = []
+  const parts: { key: string; className: string; label: string }[] = []
 
   if (approved > 0) {
-    parts.push(
-      <span key="approved" className="rv-bottom-bar-count--approved">
-        {approved} approved
-      </span>
-    )
+    parts.push({
+      key: 'approved',
+      className: 'rv-bottom-bar-count--approved',
+      label: `${approved} approved`,
+    })
   }
   if (commented > 0) {
-    parts.push(
-      <span key="commented" className="rv-bottom-bar-count--commented">
-        {commented} commented
-      </span>
-    )
+    parts.push({
+      key: 'commented',
+      className: 'rv-bottom-bar-count--commented',
+      label: `${commented} commented`,
+    })
   }
   if (rejected > 0) {
-    parts.push(
-      <span key="rejected" className="rv-bottom-bar-count--rejected">
-        {rejected} rejected
-      </span>
-    )
+    parts.push({
+      key: 'rejected',
+      className: 'rv-bottom-bar-count--rejected',
+      label: `${rejected} rejected`,
+    })
   }
 
   return (
@@ -46,11 +44,12 @@ export default function ReviewBottomBar({
       <div className="rv-bottom-bar-stats">
         {parts.length > 0 ? (
           <>
-            {parts.reduce<JSX.Element[]>((acc, el, i) => {
-              if (i > 0) acc.push(<span key={`sep-${i}`}> &middot; </span>)
-              acc.push(el)
-              return acc
-            }, [])}
+            {parts.flatMap((part, partIndex) => [
+              ...(partIndex > 0 ? [<span key={`sep-${part.key}`}> &middot; </span>] : []),
+              <span key={part.key} className={part.className}>
+                {part.label}
+              </span>,
+            ])}
             {' / '}
             {total} total
           </>

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -302,11 +302,17 @@ body,
 }
 
 .cluster-header {
+  width: 100%;
+  border: 0;
+  background: transparent;
   padding: 8px 4px;
+  color: inherit;
+  font: inherit;
   font-size: 14px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  text-align: left;
   cursor: grab;
   user-select: none;
 }
@@ -328,9 +334,15 @@ body,
 }
 
 .session-card {
+  display: block;
+  width: 100%;
   background: var(--bg-sidebar);
   border: 1px solid var(--border);
   border-radius: 8px;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   overflow: hidden;
   cursor: pointer;
   box-shadow: 0 1px 2px var(--shadow-sm);
@@ -600,9 +612,15 @@ body,
 }
 
 .project-row {
+  width: 100%;
+  border: 0;
+  background: transparent;
   display: flex;
   align-items: center;
   padding: 4px 8px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
   border-radius: 4px;
   gap: 4px;
@@ -667,9 +685,14 @@ body,
 }
 
 .worktree-item {
+  width: 100%;
+  border: 0;
+  background: transparent;
   padding: 2px 8px;
   font-size: 14px;
   color: var(--text-secondary);
+  font-family: inherit;
+  text-align: left;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -1240,9 +1263,13 @@ body,
 }
 
 .hosts-error {
+  border: 0;
+  background: transparent;
   color: var(--accent-error);
   font-size: 12px;
+  font-family: inherit;
   padding: 4px 8px;
+  text-align: left;
 }
 
 .hosts-empty {
@@ -1695,6 +1722,9 @@ body,
 }
 
 .rv-file-tree-dir-label {
+  width: 100%;
+  border: 0;
+  background: transparent;
   display: flex;
   align-items: center;
   gap: 4px;
@@ -1702,6 +1732,8 @@ body,
   cursor: pointer;
   border-radius: 3px;
   color: var(--text-secondary);
+  font: inherit;
+  text-align: left;
 }
 
 .rv-file-tree-dir-label:hover {
@@ -1719,12 +1751,17 @@ body,
 }
 
 .rv-file-tree-file {
+  width: 100%;
+  border: 0;
+  background: transparent;
   display: flex;
   align-items: center;
   padding: 3px 8px;
   cursor: pointer;
   border-radius: 3px;
   color: var(--text-primary);
+  font: inherit;
+  text-align: left;
 }
 
 .rv-file-tree-file:hover {


### PR DESCRIPTION
## Summary

- clears the react-doctor accessibility diagnostics by using semantic buttons/groups for clickable UI surfaces
- removes `autoFocus` attributes in favor of explicit focus effects where dialogs already expected initial focus
- replaces index keys/vague labels/three-period ellipses flagged by react-doctor

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npx --yes react-doctor@latest --json --full --offline --no-dead-code` reports no remaining Accessibility, Correctness, or design-label diagnostics; remaining non-dead-code diagnostics are the state/architecture bucket for the next PR