### PR TITLE
chore: rename cc-pewpew to pewpew

### DIFF
--- a/.github/scripts/smoke-test.mjs
+++ b/.github/scripts/smoke-test.mjs
@@ -14,7 +14,7 @@ const CDP_PORT = 9333
 const BOOT_TIMEOUT_MS = 30_000
 const POLL_INTERVAL_MS = 500
 
-const xdgConfigHome = mkdtempSync(join(tmpdir(), 'cc-pewpew-smoke-'))
+const xdgConfigHome = mkdtempSync(join(tmpdir(), 'pewpew-smoke-'))
 
 const electronArgs = [
   '.',

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -6,7 +6,7 @@ Developers managing multiple parallel Claude Code sessions across git projects. 
 
 ### Brand Personality
 
-**Focused, technical, calm.** A professional developer tool that communicates status clearly without being flashy. The name "cc-pewpew" adds personality but the UI itself is restrained and functional.
+**Focused, technical, calm.** A professional developer tool that communicates status clearly without being flashy. The name "pewpew" adds personality but the UI itself is restrained and functional.
 
 ### Aesthetic Direction
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-cc-pewpew is a desktop GUI (Electron + TypeScript + React) for launching, monitoring, and visualizing Claude Code sessions with embedded terminals across git projects. See @PLAN.md for full architecture and implementation phases.
+pewpew is a desktop GUI (Electron + TypeScript + React) for launching, monitoring, and visualizing Claude Code sessions with embedded terminals across git projects. See @PLAN.md for full architecture and implementation phases.
 
 ## Stack
 
@@ -40,15 +40,15 @@ const fs = require('fs');
 const pageId = JSON.parse(require('child_process').execSync('curl -s http://127.0.0.1:9229/json/list'))[0].id;
 const socket = new ws('ws://127.0.0.1:9229/devtools/page/' + pageId);
 socket.on('open', () => socket.send(JSON.stringify({id:1, method:'Page.captureScreenshot', params:{format:'png'}})));
-socket.on('message', (d) => { const m = JSON.parse(d.toString()); if(m.result?.data) { fs.writeFileSync('/tmp/cc-pewpew-screenshot.png', Buffer.from(m.result.data,'base64')); socket.close(); }});
+socket.on('message', (d) => { const m = JSON.parse(d.toString()); if(m.result?.data) { fs.writeFileSync('/tmp/pewpew-screenshot.png', Buffer.from(m.result.data,'base64')); socket.close(); }});
 "
 ```
 
-Then `Read /tmp/cc-pewpew-screenshot.png` to view the UI visually.
+Then `Read /tmp/pewpew-screenshot.png` to view the UI visually.
 
 ### Automated UI debugging workflow
 
-Port 9229 may conflict with cc-pewpew's own tmux server. If so, use a different port:
+Port 9229 may conflict with pewpew's own tmux server. If so, use a different port:
 
 ```bash
 npx electron-vite build && npx electron --remote-debugging-port=9333 .
@@ -96,9 +96,9 @@ When debugging visual issues, **always use this approach first** rather than ask
 ## Supported agents
 
 - **Claude Code** (`claude`) — default. Uses `--continue` to resume. Hooks installed at `<worktree>/.claude/settings.local.json`.
-- **OpenAI Codex** (`codex`) — opt-in per session. Resume uses `codex resume <session_id>` (the `agentSessionId` is captured from the `SessionStart` hook payload). Hooks installed at `<worktree>/.codex/hooks.json` and gated behind `[features].codex_hooks = true` in `~/.codex/config.toml`, which cc-pewpew enables idempotently on first codex session install.
+- **OpenAI Codex** (`codex`) — opt-in per session. Resume uses `codex resume <session_id>` (the `agentSessionId` is captured from the `SessionStart` hook payload). Hooks installed at `<worktree>/.codex/hooks.json` and gated behind `[features].codex_hooks = true` in `~/.codex/config.toml`, which pewpew enables idempotently on first codex session install.
 
-The default tool is configurable via `defaultTool` in `~/.config/cc-pewpew/config.json`. Per-session selection is exposed in the "New session" dialog. Both `claude` and `codex` must be in `PATH` (locally and on every remote host where the corresponding tool is selected).
+The default tool is configurable via `defaultTool` in `~/.config/pewpew/config.json`. Per-session selection is exposed in the "New session" dialog. Both `claude` and `codex` must be in `PATH` (locally and on every remote host where the corresponding tool is selected).
 
 ## Implementation
 
@@ -115,4 +115,4 @@ Three-process Electron structure:
 
 Terminal stack: xterm.js (renderer) + node-pty (main) + tmux (persistence).
 
-User data stored in `~/.config/cc-pewpew/` (config, sessions, IPC socket, hooks).
+User data stored in `~/.config/pewpew/` (config, sessions, IPC socket, hooks).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# cc-pewpew
+# pewpew
 
-[![CI](https://github.com/pmatos/cc-pewpew/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/pmatos/cc-pewpew/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/pmatos/cc-pewpew/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/pmatos/cc-pewpew/actions/workflows/codeql.yml)
-[![codecov](https://codecov.io/gh/pmatos/cc-pewpew/branch/main/graph/badge.svg)](https://codecov.io/gh/pmatos/cc-pewpew)
+[![CI](https://github.com/pmatos/pewpew/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/pmatos/pewpew/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/pmatos/pewpew/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/pmatos/pewpew/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/pmatos/pewpew/branch/main/graph/badge.svg)](https://codecov.io/gh/pmatos/pewpew)
 
 A desktop GUI for launching, monitoring, and visualizing Claude Code sessions with embedded terminals across your git projects.
 
@@ -27,8 +27,8 @@ A desktop GUI for launching, monitoring, and visualizing Claude Code sessions wi
 ## Getting started
 
 ```bash
-git clone https://github.com/pmatos/cc-pewpew.git
-cd cc-pewpew
+git clone https://github.com/pmatos/pewpew.git
+cd pewpew
 npm install
 npm run rebuild-pty   # rebuild node-pty for Electron
 npm run dev           # start in development mode
@@ -37,7 +37,7 @@ npm run dev           # start in development mode
 ## Usage
 
 1. Projects from `~/dev` appear in the sidebar
-2. Right-click a project → **Setup for cc-pewpew** (installs Claude Code hooks)
+2. Right-click a project → **Setup for pewpew** (installs Claude Code hooks)
 3. Right-click again → **New session...** (optionally name it)
 4. A session card appears on the canvas with a live terminal preview
 5. Click the card to open the full interactive terminal
@@ -46,7 +46,7 @@ npm run dev           # start in development mode
 
 ## Configuration
 
-Edit `~/.config/cc-pewpew/config.json`:
+Edit `~/.config/pewpew/config.json`:
 
 ```json
 {

--- a/hooks/notify.sh
+++ b/hooks/notify.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # Called by Claude Code hooks — reads event JSON from stdin,
-# forwards to cc-pewpew orchestrator via Unix socket.
+# forwards to pewpew orchestrator via Unix socket.
 
 set -euo pipefail
 
 INPUT=$(cat)
-CC_PEWPEW_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/cc-pewpew"
-SOCKET=$(cat "$CC_PEWPEW_DIR/socket-path" 2>/dev/null || echo "")
+PEWPEW_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/pewpew"
+SOCKET=$(cat "$PEWPEW_DIR/socket-path" 2>/dev/null || echo "")
 if [ -z "$SOCKET" ] || [ ! -S "$SOCKET" ]; then
-  exit 0  # cc-pewpew not running, silently ignore
+  exit 0  # pewpew not running, silently ignore
 fi
 
 EVENT_NAME=$(echo "$INPUT" | jq -r '.hook_event_name // empty')

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cc-pewpew",
+  "name": "pewpew",
   "version": "0.1.1-pre.0",
   "description": "Desktop GUI for launching and monitoring Claude Code sessions with embedded terminals",
   "author": {
@@ -24,8 +24,8 @@
     "dist:linux": "electron-vite build && electron-builder --linux --publish never"
   },
   "build": {
-    "appId": "com.cc-pewpew.app",
-    "productName": "cc-pewpew",
+    "appId": "com.pewpew.app",
+    "productName": "pewpew",
     "directories": {
       "output": "release"
     },

--- a/plans/issue-11-remote-sessions.md
+++ b/plans/issue-11-remote-sessions.md
@@ -1,8 +1,8 @@
 # Plan: Remote Sessions End-to-End
 
-> Source issue: [pmatos/cc-pewpew#11](https://github.com/pmatos/cc-pewpew/issues/11)  
-> Parent PRD: [pmatos/cc-pewpew#8](https://github.com/pmatos/cc-pewpew/issues/8)  
-> Prerequisite: [pmatos/cc-pewpew#10](https://github.com/pmatos/cc-pewpew/issues/10) is closed and its remote-project registry/UI work is present on `origin/main`.
+> Source issue: [pmatos/pewpew#11](https://github.com/pmatos/pewpew/issues/11)  
+> Parent PRD: [pmatos/pewpew#8](https://github.com/pmatos/pewpew/issues/8)  
+> Prerequisite: [pmatos/pewpew#10](https://github.com/pmatos/pewpew/issues/10) is closed and its remote-project registry/UI work is present on `origin/main`.
 
 ## Current Baseline
 
@@ -47,7 +47,7 @@ Turn `HostConnection` from standalone functions into a process-owning manager wh
 
 ### Acceptance criteria
 
-- [ ] `HostConnection.ensureLive(host)` starts `ssh -N` with `ControlMaster=yes`, `ControlPersist=10m`, `ExitOnForwardFailure=yes`, keepalives, and `-R /tmp/cc-pewpew-{uid}.sock:<local ipc-host socket>`.
+- [ ] `HostConnection.ensureLive(host)` starts `ssh -N` with `ControlMaster=yes`, `ControlPersist=10m`, `ExitOnForwardFailure=yes`, keepalives, and `-R /tmp/pewpew-{uid}.sock:<local ipc-host socket>`.
 - [ ] Repeated `ensureLive()` calls for the same host reuse the in-flight/live connection.
 - [ ] `exec(host, argv)` multiplexes through the host's ControlPath and preserves argv quoting.
 - [ ] `spawnAttach(host, argv)` returns a child suitable for `node-pty` bridging via local `ssh ... tmux attach-session ...`.
@@ -81,8 +81,8 @@ Add `src/main/host-bootstrap.ts` as a deterministic orchestration module around 
 
 - [ ] Probes `tmux`, `git`, `jq`, `socat`, and `claude` on the remote PATH.
 - [ ] Checks whether sshd supports the required StreamLocalBindUnlink behavior for the reverse Unix socket.
-- [ ] Installs `~/.config/cc-pewpew/hooks/notify-v1.sh` if absent or wrong version.
-- [ ] Writes a remote breadcrumb pointing at `/tmp/cc-pewpew-{uid}.sock`.
+- [ ] Installs `~/.config/pewpew/hooks/notify-v1.sh` if absent or wrong version.
+- [ ] Writes a remote breadcrumb pointing at `/tmp/pewpew-{uid}.sock`.
 - [ ] Returns typed, actionable errors for missing deps and StreamLocalBindUnlink failure.
 - [ ] Caches successful bootstrap per host per app session.
 - [ ] Unit tests cover all-deps-present, selective missing dependency, and already-installed script cases with fake exec responses.
@@ -96,10 +96,10 @@ Branch session creation on `hostId`. For remote projects, create the worktree an
 ### Acceptance criteria
 
 - [ ] Remote `git worktree add` runs on the remote host under `{projectPath}/.claude/worktrees/{worktreeName}`.
-- [ ] Remote branch fallback mirrors local behavior: try `-b cc-pewpew/{worktreeName}`, then retry without `-b`.
+- [ ] Remote branch fallback mirrors local behavior: try `-b pewpew/{worktreeName}`, then retry without `-b`.
 - [ ] Remote hook config is installed into `{worktreePath}/.claude/settings.local.json`.
 - [ ] The hook command uses the absolute remote `notify-v1.sh` path.
-- [ ] Remote tmux creation runs `tmux new-session -d -s cc-pewpew-{id} -c {worktreePath} claude --dangerously-skip-permissions`.
+- [ ] Remote tmux creation runs `tmux new-session -d -s pewpew-{id} -c {worktreePath} claude --dangerously-skip-permissions`.
 - [ ] Remote attach streams into the existing renderer terminal data path.
 - [ ] Missing dependency/bootstrap errors block creation and surface a specific message.
 - [ ] Concurrent sessions on the same remote project get independent worktree hook files.

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -37,7 +37,7 @@ export interface AppConfig {
 
 export const CONFIG_DIR = join(
   process.env.XDG_CONFIG_HOME || join(homedir(), '.config'),
-  'cc-pewpew'
+  'pewpew'
 )
 const CONFIG_PATH = join(CONFIG_DIR, 'config.json')
 

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -35,10 +35,7 @@ export interface AppConfig {
   theme: Theme
 }
 
-export const CONFIG_DIR = join(
-  process.env.XDG_CONFIG_HOME || join(homedir(), '.config'),
-  'pewpew'
-)
+export const CONFIG_DIR = join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'pewpew')
 const CONFIG_PATH = join(CONFIG_DIR, 'config.json')
 
 const DEFAULT_CONFIG: AppConfig = {

--- a/src/main/hook-installer.test.ts
+++ b/src/main/hook-installer.test.ts
@@ -14,7 +14,7 @@ vi.mock('os', async () => {
 })
 
 vi.mock('./config', () => ({
-  CONFIG_DIR: '/tmp/cc-pewpew-test-config',
+  CONFIG_DIR: '/tmp/pewpew-test-config',
 }))
 
 beforeEach(() => {
@@ -45,10 +45,10 @@ describe('installCodexHooks', () => {
     expect(json.hooks.Stop).toHaveLength(1)
     expect(json.hooks.PostToolUse).toHaveLength(1)
     expect(json.hooks.PostToolUse[0].matcher).toBe('.*')
-    expect(json.hooks.SessionStart[0].hooks[0].command).toContain('cc-pewpew')
+    expect(json.hooks.SessionStart[0].hooks[0].command).toContain('pewpew')
   })
 
-  it('preserves existing non-cc-pewpew entries when merging', async () => {
+  it('preserves existing non-pewpew entries when merging', async () => {
     const codexDir = join(state.tmpProject, '.codex')
     mkdirSync(codexDir, { recursive: true })
     writeFileSync(
@@ -70,10 +70,10 @@ describe('installCodexHooks', () => {
     expect(json.hooks.SessionStart).toHaveLength(2)
     const commands = json.hooks.SessionStart.map((g) => g.hooks[0].command)
     expect(commands).toContain('/usr/local/bin/other-hook.sh')
-    expect(commands.some((c: string) => c.includes('cc-pewpew'))).toBe(true)
+    expect(commands.some((c: string) => c.includes('pewpew'))).toBe(true)
   })
 
-  it('replaces stale cc-pewpew entries on re-install', async () => {
+  it('replaces stale pewpew entries on re-install', async () => {
     const { installCodexHooks } = await loadInstaller()
     await installCodexHooks(state.tmpProject, { skipGitignore: true })
     await installCodexHooks(state.tmpProject, { skipGitignore: true })

--- a/src/main/hook-installer.ts
+++ b/src/main/hook-installer.ts
@@ -82,7 +82,7 @@ function parseAsObject(raw: string): Record<string, unknown> {
 }
 
 function isExternalHook(entry: unknown): boolean {
-  return !/cc-pewpew/.test(JSON.stringify(entry))
+  return !/pewpew/.test(JSON.stringify(entry))
 }
 
 export async function installHooks(
@@ -129,7 +129,7 @@ export async function installRemoteHooks(
     'jq --argjson newHooks "$2" \'\n' +
     '  .hooks = (.hooks // {}) |\n' +
     '  reduce ($newHooks | keys[]) as $k (.;\n' +
-    '    .hooks[$k] = (((.hooks[$k] // []) | map(select(((. | tostring) | contains("cc-pewpew")) | not))) + $newHooks[$k])\n' +
+    '    .hooks[$k] = (((.hooks[$k] // []) | map(select(((. | tostring) | contains("pewpew")) | not))) + $newHooks[$k])\n' +
     '  )\n' +
     '\' > "$settings.tmp"\n' +
     'mv "$settings.tmp" "$settings"\n'
@@ -213,7 +213,7 @@ export async function installCodexHooks(
 export interface RemoteCodexHooksSnapshot {
   worktreePath: string
   // True when a prior `.codex/hooks.json` existed and was backed up to
-  // `.codex/hooks.json.cc-pewpew.bak` before merge. Rollback restores from
+  // `.codex/hooks.json.pewpew.bak` before merge. Rollback restores from
   // that backup. False means there was no prior file; rollback unlinks.
   hadPrior: boolean
 }
@@ -238,7 +238,7 @@ export async function installRemoteCodexHooks(
     'set -e\n' +
     'codex_dir="$1/.codex"\n' +
     'hooks="$codex_dir/hooks.json"\n' +
-    'backup="$codex_dir/hooks.json.cc-pewpew.bak"\n' +
+    'backup="$codex_dir/hooks.json.pewpew.bak"\n' +
     'mkdir -p "$codex_dir"\n' +
     'if [ -f "$hooks" ]; then cp "$hooks" "$backup"; printf "1"; else printf "0"; fi\n' +
     'if [ -s "$hooks" ] && jq -e \'type == "object"\' "$hooks" >/dev/null 2>&1; then\n' +
@@ -249,7 +249,7 @@ export async function installRemoteCodexHooks(
     'jq --argjson newHooks "$2" \'\n' +
     '  .hooks = (.hooks // {}) |\n' +
     '  reduce ($newHooks | keys[]) as $k (.;\n' +
-    '    .hooks[$k] = (((.hooks[$k] // []) | map(select(((. | tostring) | contains("cc-pewpew")) | not))) + $newHooks[$k])\n' +
+    '    .hooks[$k] = (((.hooks[$k] // []) | map(select(((. | tostring) | contains("pewpew")) | not))) + $newHooks[$k])\n' +
     '  )\n' +
     '\' > "$hooks.tmp"\n' +
     'mv "$hooks.tmp" "$hooks"\n'
@@ -274,7 +274,7 @@ export async function rollbackRemoteCodexHooks(
       // rather than deleting it (less destructive).
       'set -e\n' +
       'hooks="$1/.codex/hooks.json"\n' +
-      'backup="$1/.codex/hooks.json.cc-pewpew.bak"\n' +
+      'backup="$1/.codex/hooks.json.pewpew.bak"\n' +
       'if [ -f "$backup" ]; then mv "$backup" "$hooks"; fi\n'
     : 'set -e\n' + 'rm -f "$1/.codex/hooks.json"\n'
   await execRemote(['sh', '-c', script, '_', snapshot.worktreePath], {
@@ -289,7 +289,7 @@ export async function commitRemoteCodexHooks(
 ): Promise<void> {
   if (!snapshot.hadPrior) return
   await execRemote(
-    ['sh', '-c', 'rm -f "$1/.codex/hooks.json.cc-pewpew.bak"', '_', snapshot.worktreePath],
+    ['sh', '-c', 'rm -f "$1/.codex/hooks.json.pewpew.bak"', '_', snapshot.worktreePath],
     { timeoutMs: 5000 }
   ).catch(() => undefined)
 }

--- a/src/main/hook-server.test.ts
+++ b/src/main/hook-server.test.ts
@@ -66,7 +66,7 @@ function send(socketPath: string, payload: unknown): Promise<unknown> {
 
 describe('hook-server', () => {
   beforeEach(() => {
-    state.configDir = mkdtempSync(join(tmpdir(), 'cc-pewpew-hook-'))
+    state.configDir = mkdtempSync(join(tmpdir(), 'pewpew-hook-'))
     state.hookResult = true
     state.hookCalls = []
     state.broadcasts = []

--- a/src/main/host-bootstrap.test.ts
+++ b/src/main/host-bootstrap.test.ts
@@ -63,9 +63,9 @@ describe('bootstrapHost', () => {
     })
     expect(calls.some((argv) => argv.some((a) => a.includes('resolve_one claude')))).toBe(true)
     expect(calls.some((argv) => argv.includes('/tmp/ipc'))).toBe(true)
-    expect(
-      calls.some((argv) => argv.includes('/home/dev/.config/pewpew/hooks/notify-v1.sh'))
-    ).toBe(true)
+    expect(calls.some((argv) => argv.includes('/home/dev/.config/pewpew/hooks/notify-v1.sh'))).toBe(
+      true
+    )
   })
 
   it('hard-fails on missing strict deps but tolerates missing agent CLIs', async () => {

--- a/src/main/host-bootstrap.test.ts
+++ b/src/main/host-bootstrap.test.ts
@@ -57,14 +57,14 @@ describe('bootstrapHost', () => {
     )
 
     expect(result).toEqual({
-      notifyScriptPath: '/home/dev/.config/cc-pewpew/hooks/notify-v1.sh',
+      notifyScriptPath: '/home/dev/.config/pewpew/hooks/notify-v1.sh',
       remoteSocketPath: '/tmp/ipc',
       agentPaths: { claude: '/usr/bin/claude', codex: '/usr/bin/codex' },
     })
     expect(calls.some((argv) => argv.some((a) => a.includes('resolve_one claude')))).toBe(true)
     expect(calls.some((argv) => argv.includes('/tmp/ipc'))).toBe(true)
     expect(
-      calls.some((argv) => argv.includes('/home/dev/.config/cc-pewpew/hooks/notify-v1.sh'))
+      calls.some((argv) => argv.includes('/home/dev/.config/pewpew/hooks/notify-v1.sh'))
     ).toBe(true)
   })
 
@@ -114,7 +114,7 @@ describe('bootstrapHost', () => {
       argv.some((part) => part.includes(`notify-v${NOTIFY_SCRIPT_VERSION}.sh`))
     )
     expect(installCall).toBeDefined()
-    expect(installCall?.[2]).toContain('grep -q "CC_PEWPEW_NOTIFY_VERSION=$5"')
+    expect(installCall?.[2]).toContain('grep -q "PEWPEW_NOTIFY_VERSION=$5"')
     expect(installCall).toContain(String(NOTIFY_SCRIPT_VERSION))
   })
 

--- a/src/main/host-bootstrap.ts
+++ b/src/main/host-bootstrap.ts
@@ -8,13 +8,13 @@ const STRICT_DEPS = ['tmux', 'git', 'jq', 'socat'] as const
 const AGENT_TOOLS: readonly AgentTool[] = ['claude', 'codex'] as const
 
 const notifyScript = `#!/usr/bin/env bash
-# cc-pewpew notify script v${NOTIFY_SCRIPT_VERSION}
-CC_PEWPEW_NOTIFY_VERSION=${NOTIFY_SCRIPT_VERSION}
+# pewpew notify script v${NOTIFY_SCRIPT_VERSION}
+PEWPEW_NOTIFY_VERSION=${NOTIFY_SCRIPT_VERSION}
 set -euo pipefail
 
 INPUT=$(cat)
-CC_PEWPEW_DIR="\${XDG_CONFIG_HOME:-$HOME/.config}/cc-pewpew"
-SOCKET=$(cat "$CC_PEWPEW_DIR/hooks/socket-path" 2>/dev/null || echo "")
+PEWPEW_DIR="\${XDG_CONFIG_HOME:-$HOME/.config}/pewpew"
+SOCKET=$(cat "$PEWPEW_DIR/hooks/socket-path" 2>/dev/null || echo "")
 if [ -z "$SOCKET" ] || [ ! -S "$SOCKET" ]; then
   exit 0
 fi
@@ -219,13 +219,13 @@ export async function bootstrapHost(
     throw new HostBootstrapError('install-failed', 'Remote config root is not an absolute path')
   }
 
-  const hooksDir = posix.join(configRoot, 'cc-pewpew', 'hooks')
+  const hooksDir = posix.join(configRoot, 'pewpew', 'hooks')
   const notifyScriptPath = posix.join(hooksDir, `notify-v${NOTIFY_SCRIPT_VERSION}.sh`)
   const breadcrumbPath = posix.join(hooksDir, 'socket-path')
   const installScript =
     'set -e\n' +
     'mkdir -p "$1"\n' +
-    'if [ ! -f "$2" ] || ! grep -q "CC_PEWPEW_NOTIFY_VERSION=$5" "$2"; then\n' +
+    'if [ ! -f "$2" ] || ! grep -q "PEWPEW_NOTIFY_VERSION=$5" "$2"; then\n' +
     '  printf "%s" "$4" > "$2"\n' +
     '  chmod 700 "$2"\n' +
     'fi\n' +

--- a/src/main/host-connection.test.ts
+++ b/src/main/host-connection.test.ts
@@ -56,7 +56,7 @@ vi.mock('./config', async () => {
     import('path'),
   ])
   return {
-    CONFIG_DIR: pathJoin(getTmpDir(), `cc-pewpew-host-connection-test-${process.pid}`),
+    CONFIG_DIR: pathJoin(getTmpDir(), `pewpew-host-connection-test-${process.pid}`),
   }
 })
 
@@ -270,7 +270,7 @@ describe('exec ring-buffer + toast wiring', () => {
       error: { name: 'Error', message: 'x', code: 1 } as unknown as NodeJS.ErrnoException,
       exitCode: 1,
     }
-    await exec(HOST, ['tmux', 'has-session', '-t', 'cc-pewpew-x'])
+    await exec(HOST, ['tmux', 'has-session', '-t', 'pewpew-x'])
     expect(emittedToasts).toHaveLength(0)
     // The ring buffer still records the exec, so diagnostics retain it.
     expect(recordedEntries).toHaveLength(1)
@@ -293,7 +293,7 @@ describe('ensureHostConnection / startRuntime', () => {
   it('reaches live state when the parent ssh exits 0 after daemonization', async () => {
     // controlCheck always succeeds — the daemon is serving the socket.
     nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
-    const promise = ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    const promise = ensureHostConnection(HOST, '/tmp/pewpew-test-local.sock')
     expect(pendingSpawn).not.toBeNull()
     // Simulate the foreground parent forking to the background and exiting 0.
     pendingSpawn!.child.exitCode = 0
@@ -327,7 +327,7 @@ describe('ensureHostConnection / startRuntime', () => {
       return { stdout: '', stderr: '', error: null, exitCode: 0 }
     }
 
-    const promise = ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    const promise = ensureHostConnection(HOST, '/tmp/pewpew-test-local.sock')
     expect(pendingSpawn).not.toBeNull()
     // Wait for the first failed controlCheck to resolve, then simulate the
     // parent ssh forking to background and exiting cleanly. The next poll
@@ -344,7 +344,7 @@ describe('ensureHostConnection / startRuntime', () => {
 
   it('returns immediately on subsequent calls once the runtime is live', async () => {
     nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
-    const first = ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    const first = ensureHostConnection(HOST, '/tmp/pewpew-test-local.sock')
     pendingSpawn!.child.exitCode = 0
     pendingSpawn!.child.emit('exit', 0)
     await first
@@ -354,7 +354,7 @@ describe('ensureHostConnection / startRuntime', () => {
     // handle has already exited, so the live fast-path cannot rely on a
     // running parent process to detect liveness.
     pendingSpawn = null
-    const second = await ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    const second = await ensureHostConnection(HOST, '/tmp/pewpew-test-local.sock')
     expect(pendingSpawn).toBeNull()
     expect(second.controlPath).toContain(HOST.hostId)
     await stopHostConnection(HOST.hostId)
@@ -364,7 +364,7 @@ describe('ensureHostConnection / startRuntime', () => {
     // controlCheck would succeed — but the parent exits with auth failure
     // before the live socket gets used. exitPromise must win the race.
     nextResult = { stdout: '', stderr: '', error: null, exitCode: 0 }
-    const promise = ensureHostConnection(HOST, '/tmp/cc-pewpew-test-local.sock')
+    const promise = ensureHostConnection(HOST, '/tmp/pewpew-test-local.sock')
     expect(pendingSpawn).not.toBeNull()
     pendingSpawn!.child.stderr.emit('data', Buffer.from('Permission denied (publickey).\n'))
     pendingSpawn!.child.exitCode = 255

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -176,7 +176,7 @@ export function remoteSocketPathForHost(hostId: HostId): string {
   // Include hostId so two configured hosts that resolve to the same remote
   // account don't collide on the reverse-forwarded socket (StreamLocalBindUnlink
   // would otherwise let the later connection steal the earlier one's socket).
-  return `/tmp/cc-pewpew-${uidSegment()}-${sanitizeHostIdForPath(hostId)}.sock`
+  return `/tmp/pewpew-${uidSegment()}-${sanitizeHostIdForPath(hostId)}.sock`
 }
 
 function controlPathForHost(hostId: HostId): string {

--- a/src/main/host-registry.test.ts
+++ b/src/main/host-registry.test.ts
@@ -5,7 +5,7 @@ let fakeHosts: Host[] = []
 const saveConfigSpy = vi.fn()
 
 vi.mock('./config', () => ({
-  CONFIG_DIR: '/tmp/cc-pewpew-test',
+  CONFIG_DIR: '/tmp/pewpew-test',
   getConfig: () => ({
     scanDirs: [],
     pinnedPaths: [],

--- a/src/main/host-registry.ts
+++ b/src/main/host-registry.ts
@@ -153,7 +153,7 @@ function hasSessionsBoundTo(hostId: HostId): boolean {
 // Local-only forget. Cascading teardown (PTY detach, SSH connection close, IPC
 // socket unlink, remote-project removal) is orchestrated by the `hosts:delete`
 // IPC handler in index.ts, which calls this last. Remote tmux/worktrees and
-// the host's ~/.config/cc-pewpew/ tree are intentionally not touched — that is
+// the host's ~/.config/pewpew/ tree are intentionally not touched — that is
 // the v1 contract per issue #14. The retarget guards in updateHost above stay
 // in place; alias-retargeting still requires no bindings.
 export function deleteHost(hostId: HostId): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -157,7 +157,7 @@ if (process.platform === 'linux') {
     }
   }
 
-  // cc-pewpew never plays video, but Chromium still tries to bring up VA-API
+  // pewpew never plays video, but Chromium still tries to bring up VA-API
   // at startup. Inside AppImages the bundled libva can't load the host's
   // matching driver, producing a noisy `vaInitialize failed: unknown libva
   // error`. The feature-flag disable alone doesn't gate the probe in
@@ -194,7 +194,7 @@ function createWindow(): BrowserWindow {
     height: ws?.height ?? 800,
     x: ws?.x,
     y: ws?.y,
-    title: 'cc-pewpew',
+    title: 'pewpew',
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       contextIsolation: true,
@@ -679,7 +679,7 @@ app.whenReady().then(async () => {
     const swimWindow = new BrowserWindow({
       width: 1200,
       height: 800,
-      title: `cc-pewpew — Swimming Lanes (${sessionIds.length})`,
+      title: `pewpew — Swimming Lanes (${sessionIds.length})`,
       webPreferences: {
         preload: join(__dirname, '../preload/index.js'),
         contextIsolation: true,
@@ -721,7 +721,7 @@ app.whenReady().then(async () => {
   //   3. stopHookServerForHost — explicit belt-and-braces for the offline
   //      path (no runtime → no callback fires); idempotent otherwise.
   //   4. Drop bootstrap cache, remote projects, and finally the host itself.
-  // Remote tmux/worktrees and the remote ~/.config/cc-pewpew/ are untouched.
+  // Remote tmux/worktrees and the remote ~/.config/pewpew/ are untouched.
   ipcMain.handle('hosts:delete', async (_event, hostId: string) => {
     removeSessionsForHost(hostId)
     await stopHostConnection(hostId).catch(() => undefined)

--- a/src/main/project-scanner.test.ts
+++ b/src/main/project-scanner.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, symlinkSync, rmSync, chmodSync } from 'fs'
+import { mkdtempSync, mkdirSync, symlinkSync, rmSync, chmodSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { discoverRepos, parseWorktreeList } from './project-scanner'
+import { detectSetupState, discoverRepos, parseWorktreeList } from './project-scanner'
 
 describe('parseWorktreeList', () => {
   it('returns empty array for empty input', () => {
@@ -233,5 +233,51 @@ describe('discoverRepos', () => {
 
     // Depth 6 means the walk visits depth 1..6; 'repo' at level 7 is out of reach.
     expect(result).toEqual([])
+  })
+})
+
+describe('detectSetupState', () => {
+  let repo: string
+
+  function writeSettings(command: string): void {
+    mkdirSync(join(repo, '.claude'), { recursive: true })
+    writeFileSync(
+      join(repo, '.claude', 'settings.local.json'),
+      JSON.stringify({
+        hooks: { SessionStart: [{ hooks: [{ type: 'command', command }] }] },
+      })
+    )
+  }
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'detectSetupState-'))
+  })
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('returns unsetup when settings file is missing', () => {
+    expect(detectSetupState(repo)).toBe('unsetup')
+  })
+
+  it('returns ready for a current-path hook command', () => {
+    writeSettings('/home/user/.config/pewpew/hooks/notify.sh')
+    expect(detectSetupState(repo)).toBe('ready')
+  })
+
+  it('returns ready for a tilde-expanded hook command', () => {
+    writeSettings('~/.config/pewpew/hooks/notify.sh')
+    expect(detectSetupState(repo)).toBe('ready')
+  })
+
+  it('returns unsetup for legacy cc-pewpew XDG path', () => {
+    writeSettings('/home/user/.config/cc-pewpew/hooks/notify.sh')
+    expect(detectSetupState(repo)).toBe('unsetup')
+  })
+
+  it('returns unsetup for legacy ~/.cc-pewpew/ path', () => {
+    writeSettings('~/.cc-pewpew/hooks/notify.sh')
+    expect(detectSetupState(repo)).toBe('unsetup')
   })
 })

--- a/src/main/project-scanner.test.ts
+++ b/src/main/project-scanner.test.ts
@@ -17,7 +17,7 @@ describe('parseWorktreeList', () => {
       '',
       'worktree /home/user/repo/.claude/worktrees/feat-a',
       'HEAD def456',
-      'branch refs/heads/cc-pewpew/feat-a',
+      'branch refs/heads/pewpew/feat-a',
       '',
       'worktree /tmp/external-wt',
       'HEAD 789abc',
@@ -37,7 +37,7 @@ describe('parseWorktreeList', () => {
     expect(result[1]).toEqual({
       name: 'feat-a',
       path: '/home/user/repo/.claude/worktrees/feat-a',
-      branch: 'cc-pewpew/feat-a',
+      branch: 'pewpew/feat-a',
       isMain: false,
     })
     expect(result[2]).toEqual({

--- a/src/main/project-scanner.ts
+++ b/src/main/project-scanner.ts
@@ -70,7 +70,7 @@ function detectSetupState(repoPath: string): 'ready' | 'unsetup' {
   try {
     const raw = readFileSync(settingsPath, 'utf-8')
     const content = JSON.stringify(JSON.parse(raw))
-    return content.includes('cc-pewpew') ? 'ready' : 'unsetup'
+    return content.includes('pewpew') ? 'ready' : 'unsetup'
   } catch {
     return 'unsetup'
   }

--- a/src/main/project-scanner.ts
+++ b/src/main/project-scanner.ts
@@ -63,14 +63,14 @@ export async function gitWorktrees(repoPath: string): Promise<Worktree[]> {
   }
 }
 
-function detectSetupState(repoPath: string): 'ready' | 'unsetup' {
+export function detectSetupState(repoPath: string): 'ready' | 'unsetup' {
   const settingsPath = join(repoPath, '.claude', 'settings.local.json')
   if (!existsSync(settingsPath)) return 'unsetup'
 
   try {
     const raw = readFileSync(settingsPath, 'utf-8')
     const content = JSON.stringify(JSON.parse(raw))
-    return content.includes('pewpew') ? 'ready' : 'unsetup'
+    return content.includes('/pewpew/hooks/') ? 'ready' : 'unsetup'
   } catch {
     return 'unsetup'
   }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -88,12 +88,12 @@ export function createPty(sessionId: string, cwd: string, options?: SpawnOptions
   if (!isTmuxAvailable()) {
     dialog.showErrorBox(
       'tmux not found',
-      'tmux is required for embedded terminals.\nPlease install tmux and restart cc-pewpew.'
+      'tmux is required for embedded terminals.\nPlease install tmux and restart pewpew.'
     )
     throw new Error('tmux not found')
   }
 
-  const tmuxSession = `cc-pewpew-${sessionId}`
+  const tmuxSession = `pewpew-${sessionId}`
   const agentArgs = buildAgentArgs(options)
 
   // Create a detached tmux session that directly runs the agent CLI.
@@ -150,7 +150,7 @@ export async function createRemotePty(
   host: Host,
   options?: SpawnOptions
 ): Promise<void> {
-  const tmuxSession = `cc-pewpew-${sessionId}`
+  const tmuxSession = `pewpew-${sessionId}`
   const agentArgs = buildAgentArgs(options)
 
   const create = await execRemote(host, [
@@ -232,7 +232,7 @@ export function detachPty(sessionId: string): void {
 /** Kill both node-pty and the tmux session (full teardown). */
 export function destroyPty(sessionId: string): void {
   const entry = ptys.get(sessionId)
-  const tmuxSession = entry?.tmuxSession ?? `cc-pewpew-${sessionId}`
+  const tmuxSession = entry?.tmuxSession ?? `pewpew-${sessionId}`
 
   if (entry) {
     ptys.delete(sessionId)
@@ -256,7 +256,7 @@ export function destroyPty(sessionId: string): void {
 
 export async function destroyRemotePty(sessionId: string, host: Host): Promise<void> {
   const entry = ptys.get(sessionId)
-  const tmuxSession = entry?.tmuxSession ?? `cc-pewpew-${sessionId}`
+  const tmuxSession = entry?.tmuxSession ?? `pewpew-${sessionId}`
 
   const result = await execRemote(host, ['tmux', 'kill-session', '-t', tmuxSession], {
     timeoutMs: 5000,
@@ -303,7 +303,7 @@ export function hasPty(sessionId: string): boolean {
 
 export function hasTmuxSession(sessionId: string): boolean {
   try {
-    execFileSync('tmux', ['has-session', '-t', `cc-pewpew-${sessionId}`], { timeout: 3000 })
+    execFileSync('tmux', ['has-session', '-t', `pewpew-${sessionId}`], { timeout: 3000 })
     return true
   } catch {
     return false
@@ -353,7 +353,7 @@ export async function captureThumbnails(opts?: {
 }
 
 export async function hasRemoteTmuxSession(sessionId: string, host: Host): Promise<boolean> {
-  const result = await execRemote(host, ['tmux', 'has-session', '-t', `cc-pewpew-${sessionId}`], {
+  const result = await execRemote(host, ['tmux', 'has-session', '-t', `pewpew-${sessionId}`], {
     timeoutMs: 3000,
   })
   return result.code === 0 && !result.timedOut
@@ -370,7 +370,7 @@ export async function probeRemoteTmuxSession(
   sessionId: string,
   host: Host
 ): Promise<RemoteTmuxProbeResult> {
-  const result = await execRemote(host, ['tmux', 'has-session', '-t', `cc-pewpew-${sessionId}`], {
+  const result = await execRemote(host, ['tmux', 'has-session', '-t', `pewpew-${sessionId}`], {
     timeoutMs: 3000,
   })
   if (result.timedOut) return 'unreachable'
@@ -400,7 +400,7 @@ export async function getScrollback(sessionId: string): Promise<string> {
     return result.code === 0 && !result.timedOut ? result.stdout : ''
   }
 
-  const tmuxSession = `cc-pewpew-${sessionId}`
+  const tmuxSession = `pewpew-${sessionId}`
   try {
     return execFileSync('tmux', ['capture-pane', '-t', tmuxSession, '-p', '-e', '-S', '-5000'], {
       encoding: 'utf-8',
@@ -419,8 +419,8 @@ export function discoverTmuxSessions(): string[] {
     })
     const sessions: string[] = []
     for (const name of output.split('\n')) {
-      if (name.startsWith('cc-pewpew-')) {
-        sessions.push(name.replace('cc-pewpew-', ''))
+      if (name.startsWith('pewpew-')) {
+        sessions.push(name.replace('pewpew-', ''))
       }
     }
     return sessions
@@ -430,7 +430,7 @@ export function discoverTmuxSessions(): string[] {
 }
 
 export function reattachPty(sessionId: string): void {
-  const tmuxSession = `cc-pewpew-${sessionId}`
+  const tmuxSession = `pewpew-${sessionId}`
 
   // Attach to existing tmux session via node-pty
   const ptyProcess = pty.spawn('tmux', ['attach-session', '-t', tmuxSession], {
@@ -472,7 +472,7 @@ export function reattachPty(sessionId: string): void {
 }
 
 export async function reattachRemotePty(sessionId: string, host: Host): Promise<void> {
-  const tmuxSession = `cc-pewpew-${sessionId}`
+  const tmuxSession = `pewpew-${sessionId}`
 
   const ptyProcess = spawnAttach(host, ['tmux', 'attach-session', '-t', tmuxSession], {
     name: 'xterm-256color',

--- a/src/main/remote-project-registry.test.ts
+++ b/src/main/remote-project-registry.test.ts
@@ -6,7 +6,7 @@ let fakeRemoteProjects: RemoteProject[] = []
 const saveConfigSpy = vi.fn()
 
 vi.mock('./config', () => ({
-  CONFIG_DIR: '/tmp/cc-pewpew-test',
+  CONFIG_DIR: '/tmp/pewpew-test',
   getConfig: () => ({
     scanDirs: [],
     pinnedPaths: [],

--- a/src/main/remote-thumbnail.test.ts
+++ b/src/main/remote-thumbnail.test.ts
@@ -42,8 +42,8 @@ describe('captureRemotePaneTexts', () => {
 
     const result = await captureRemotePaneTexts(
       [
-        { sessionId: 's1', host, tmuxSession: 'cc-pewpew-s1' },
-        { sessionId: 's2', host, tmuxSession: 'cc-pewpew-s2' },
+        { sessionId: 's1', host, tmuxSession: 'pewpew-s1' },
+        { sessionId: 's2', host, tmuxSession: 'pewpew-s2' },
       ],
       { exec }
     )
@@ -52,9 +52,9 @@ describe('captureRemotePaneTexts', () => {
     expect(calls).toHaveLength(2)
     expect(calls[0]).toEqual({
       host,
-      argv: ['tmux', 'capture-pane', '-t', 'cc-pewpew-s1', '-p'],
+      argv: ['tmux', 'capture-pane', '-t', 'pewpew-s1', '-p'],
     })
-    expect(calls[1].argv).toEqual(['tmux', 'capture-pane', '-t', 'cc-pewpew-s2', '-p'])
+    expect(calls[1].argv).toEqual(['tmux', 'capture-pane', '-t', 'pewpew-s2', '-p'])
   })
 
   it('caps captured output to the configured row limit', async () => {
@@ -62,7 +62,7 @@ describe('captureRemotePaneTexts', () => {
     const exec = async () => ok(big)
 
     const result = await captureRemotePaneTexts(
-      [{ sessionId: 's1', host, tmuxSession: 'cc-pewpew-s1' }],
+      [{ sessionId: 's1', host, tmuxSession: 'pewpew-s1' }],
       { exec, maxRows: 24 }
     )
 
@@ -73,14 +73,14 @@ describe('captureRemotePaneTexts', () => {
 
   it('skips a session whose exec rejects but still returns the others', async () => {
     const exec = async (_h: Host, argv: string[]) => {
-      if (argv.includes('cc-pewpew-broken')) throw new Error('boom')
+      if (argv.includes('pewpew-broken')) throw new Error('boom')
       return ok('ok-out\n')
     }
 
     const result = await captureRemotePaneTexts(
       [
-        { sessionId: 'broken', host, tmuxSession: 'cc-pewpew-broken' },
-        { sessionId: 'good', host, tmuxSession: 'cc-pewpew-good' },
+        { sessionId: 'broken', host, tmuxSession: 'pewpew-broken' },
+        { sessionId: 'good', host, tmuxSession: 'pewpew-good' },
       ],
       { exec }
     )
@@ -90,10 +90,10 @@ describe('captureRemotePaneTexts', () => {
 
   it('skips a session whose capture times out or fails non-zero', async () => {
     const exec = async (_h: Host, argv: string[]): Promise<ExecResult> => {
-      if (argv.includes('cc-pewpew-timeout')) {
+      if (argv.includes('pewpew-timeout')) {
         return { stdout: '', stderr: 'timed out', code: 1, timedOut: true }
       }
-      if (argv.includes('cc-pewpew-noexit')) {
+      if (argv.includes('pewpew-noexit')) {
         return { stdout: '', stderr: "can't find session", code: 1, timedOut: false }
       }
       return ok('alive\n')
@@ -101,9 +101,9 @@ describe('captureRemotePaneTexts', () => {
 
     const result = await captureRemotePaneTexts(
       [
-        { sessionId: 'timeout', host, tmuxSession: 'cc-pewpew-timeout' },
-        { sessionId: 'noexit', host, tmuxSession: 'cc-pewpew-noexit' },
-        { sessionId: 'alive', host, tmuxSession: 'cc-pewpew-alive' },
+        { sessionId: 'timeout', host, tmuxSession: 'pewpew-timeout' },
+        { sessionId: 'noexit', host, tmuxSession: 'pewpew-noexit' },
+        { sessionId: 'alive', host, tmuxSession: 'pewpew-alive' },
       ],
       { exec }
     )
@@ -122,7 +122,7 @@ describe('captureRemotePaneTexts', () => {
       return ok('hi\n')
     }
 
-    await captureRemotePaneTexts([{ sessionId: 's1', host, tmuxSession: 'cc-pewpew-s1' }], { exec })
+    await captureRemotePaneTexts([{ sessionId: 's1', host, tmuxSession: 'pewpew-s1' }], { exec })
 
     expect(seenTimeouts).toHaveLength(1)
     expect(seenTimeouts[0]).toBeDefined()
@@ -137,7 +137,7 @@ describe('captureRemotePaneTexts', () => {
     const fastEmitsObservedSlowState: boolean[] = []
 
     const exec = async (_h: Host, argv: string[]): Promise<ExecResult> => {
-      if (argv.includes('cc-pewpew-slow')) {
+      if (argv.includes('pewpew-slow')) {
         await new Promise((r) => setTimeout(r, 60))
         slowSettled = true
         return ok('slow\n')
@@ -147,8 +147,8 @@ describe('captureRemotePaneTexts', () => {
 
     await captureRemotePaneTexts(
       [
-        { sessionId: 'fast', host, tmuxSession: 'cc-pewpew-fast' },
-        { sessionId: 'slow', host, tmuxSession: 'cc-pewpew-slow' },
+        { sessionId: 'fast', host, tmuxSession: 'pewpew-fast' },
+        { sessionId: 'slow', host, tmuxSession: 'pewpew-slow' },
       ],
       {
         exec,
@@ -164,12 +164,12 @@ describe('captureRemotePaneTexts', () => {
   it('passes the capped per-session text to onCapture and the aggregate return', async () => {
     const calls: { sid: string; text: string }[] = []
     const exec = async (_h: Host, argv: string[]) =>
-      ok(argv.includes('cc-pewpew-s1') ? 's1-text\n' : 's2-text\n')
+      ok(argv.includes('pewpew-s1') ? 's1-text\n' : 's2-text\n')
 
     const result = await captureRemotePaneTexts(
       [
-        { sessionId: 's1', host, tmuxSession: 'cc-pewpew-s1' },
-        { sessionId: 's2', host, tmuxSession: 'cc-pewpew-s2' },
+        { sessionId: 's1', host, tmuxSession: 'pewpew-s1' },
+        { sessionId: 's2', host, tmuxSession: 'pewpew-s2' },
       ],
       { exec, onCapture: (sid, text) => calls.push({ sid, text }) }
     )

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -100,7 +100,7 @@ vi.mock('./remote-project-registry', () => ({
 }))
 
 vi.mock('./hook-server', () => ({
-  listenHookServerForHost: (hostId: string) => `/tmp/cc-pewpew-ipc-${hostId}.sock`,
+  listenHookServerForHost: (hostId: string) => `/tmp/pewpew-ipc-${hostId}.sock`,
 }))
 
 vi.mock('./host-bootstrap', () => ({
@@ -223,9 +223,9 @@ function baseRemoteSession(overrides: Partial<Session>): Session {
     projectName: 'proj',
     worktreeName: 'feat',
     worktreePath: '/remote/proj/.claude/worktrees/feat',
-    branch: 'cc-pewpew/feat',
+    branch: 'pewpew/feat',
     pid: 0,
-    tmuxSession: 'cc-pewpew-r1',
+    tmuxSession: 'pewpew-r1',
     status: 'idle',
     lastActivity: 1000,
     hookEvents: [],
@@ -242,9 +242,9 @@ function baseLocalSession(overrides: Partial<Session>): Session {
     projectName: 'proj',
     worktreeName: 'local-feat',
     worktreePath: join(state.configDir, 'local-wt'),
-    branch: 'cc-pewpew/local-feat',
+    branch: 'pewpew/local-feat',
     pid: 0,
-    tmuxSession: 'cc-pewpew-l1',
+    tmuxSession: 'pewpew-l1',
     status: 'idle',
     lastActivity: 1000,
     hookEvents: [],
@@ -1203,7 +1203,7 @@ describe('codex agent integration', () => {
           worktreePath: '/p/w',
           branch: 'main',
           pid: 0,
-          tmuxSession: 'cc-pewpew-legacy1',
+          tmuxSession: 'pewpew-legacy1',
           status: 'idle',
           lastActivity: 0,
           hookEvents: [],
@@ -1263,7 +1263,7 @@ describe('codex agent integration', () => {
 describe('sanitizeBranchPrefix', () => {
   it('preserves valid ref-component characters', async () => {
     const sm = await loadSessionManager()
-    expect(sm.sanitizeBranchPrefix('cc-pewpew')).toBe('cc-pewpew')
+    expect(sm.sanitizeBranchPrefix('pewpew')).toBe('pewpew')
     expect(sm.sanitizeBranchPrefix('my_repo.v2')).toBe('my_repo.v2')
   })
 
@@ -1292,11 +1292,11 @@ describe('sanitizeBranchPrefix', () => {
     expect(sm.sanitizeBranchPrefix('proj-.lock')).toBe('proj')
   })
 
-  it('falls back to `cc-pewpew` when nothing valid remains', async () => {
+  it('falls back to `pewpew` when nothing valid remains', async () => {
     const sm = await loadSessionManager()
-    expect(sm.sanitizeBranchPrefix('   ')).toBe('cc-pewpew')
-    expect(sm.sanitizeBranchPrefix(':::')).toBe('cc-pewpew')
-    expect(sm.sanitizeBranchPrefix('')).toBe('cc-pewpew')
+    expect(sm.sanitizeBranchPrefix('   ')).toBe('pewpew')
+    expect(sm.sanitizeBranchPrefix(':::')).toBe('pewpew')
+    expect(sm.sanitizeBranchPrefix('')).toBe('pewpew')
   })
 })
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -73,7 +73,7 @@ function parseIssueNumber(...sources: (string | undefined)[]): number | undefine
 // remote-project label), so they can contain characters that are illegal in a
 // git ref component (space, `:`, `~`, `^`, `?`, `*`, `[`, `\`, control chars,
 // `..`, leading `-`/`.`, etc.). Coerce to a safe slug; fall back to
-// `cc-pewpew` when nothing valid remains.
+// `pewpew` when nothing valid remains.
 export function sanitizeBranchPrefix(name: string): string {
   const slug = name
     .replace(/[^A-Za-z0-9._-]+/g, '-')
@@ -82,7 +82,7 @@ export function sanitizeBranchPrefix(name: string): string {
     .replace(/^[-._]+|[-._]+$/g, '')
     .replace(/(?:\.lock)+$/i, '')
     .replace(/^[-._]+|[-._]+$/g, '')
-  return slug || 'cc-pewpew'
+  return slug || 'pewpew'
 }
 
 // Read the actual branch checked out in a worktree. Falls back to the
@@ -523,7 +523,7 @@ async function adoptWorktree(
   const id = randomUUID().slice(0, 8)
   const projectName = basename(projectPath)
   const worktreeName = label || (await deriveLabel(worktreePath))
-  const tmuxSession = `cc-pewpew-${id}`
+  const tmuxSession = `pewpew-${id}`
   const branch = resolveBranchFromWorktree(worktreePath, worktreeName, projectName)
 
   await installAgentHooks(tool, worktreePath)
@@ -634,7 +634,7 @@ async function createRemoteSession(
   }
 
   const id = randomUUID().slice(0, 8)
-  const tmuxSession = `cc-pewpew-${id}`
+  const tmuxSession = `pewpew-${id}`
   const branchName = `${sanitizeBranchPrefix(remoteProject.name)}/${worktreeName}`
   const baseRef = effectiveWorktreeBase(options)
 
@@ -797,7 +797,7 @@ async function createRemotePrSession(
 
     const branch = prInfo.headRefName
     const id = randomUUID().slice(0, 8)
-    const tmuxSession = `cc-pewpew-${id}`
+    const tmuxSession = `pewpew-${id}`
 
     await execRemote(host, ['git', '-C', projectPath, 'fetch', 'origin', branch]).catch(
       () => undefined
@@ -1321,7 +1321,7 @@ export async function removeSession(id: string): Promise<void> {
 // host (releases the host-connection refcount via releaseRemoteEntry without
 // talking to the remote tmux), then drop the entries so they vanish from
 // sessions.json on the next persist. Worktrees, remote tmux sessions, and the
-// remote ~/.config/cc-pewpew/ tree are intentionally left alone — that is the
+// remote ~/.config/pewpew/ tree are intentionally left alone — that is the
 // v1 host-delete contract (issue #14).
 export function removeSessionsForHost(hostId: string): void {
   let removed = false
@@ -1818,7 +1818,7 @@ async function createRemoteIssueSession(
     }
 
     const id = randomUUID().slice(0, 8)
-    const tmuxSession = `cc-pewpew-${id}`
+    const tmuxSession = `pewpew-${id}`
     let originRef: string
     try {
       originRef = await resolveOriginDefaultBase((argv) =>

--- a/src/main/session-state-machine.test.ts
+++ b/src/main/session-state-machine.test.ts
@@ -12,7 +12,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     worktreePath: '/p/w',
     branch: 'main',
     pid: 0,
-    tmuxSession: 'cc-pewpew-s1',
+    tmuxSession: 'pewpew-s1',
     status: 'idle',
     lastActivity: 0,
     hookEvents: [],

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -23,7 +23,7 @@ function showAndOpenSession(sessionId: string): void {
 
 export function createTray(): void {
   tray = new Tray(createTrayIcon())
-  tray.setToolTip('cc-pewpew — 0 sessions')
+  tray.setToolTip('pewpew — 0 sessions')
 
   tray.on('click', () => {
     const win = getMainWindow()
@@ -42,13 +42,13 @@ export function createTray(): void {
 export function updateTray(sessions: Session[]): void {
   if (!tray) return
 
-  tray.setToolTip(`cc-pewpew — ${sessions.length} session${sessions.length !== 1 ? 's' : ''}`)
+  tray.setToolTip(`pewpew — ${sessions.length} session${sessions.length !== 1 ? 's' : ''}`)
 
   const needsInput = sessions.filter((s) => s.status === 'needs_input')
 
   const menuItems: Electron.MenuItemConstructorOptions[] = [
     {
-      label: 'Show cc-pewpew',
+      label: 'Show pewpew',
       click: () => {
         const win = getMainWindow()
         if (win) {

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -155,10 +155,10 @@ function HostDeleteConfirm({ host, onConfirm, onCancel }: HostDeleteConfirmProps
       }}
     >
       <div className="hosts-delete-confirm-body">
-        Forget <strong>{host.label}</strong> ({host.alias})? cc-pewpew will mark its sessions dead,
+        Forget <strong>{host.label}</strong> ({host.alias})? pewpew will mark its sessions dead,
         close its SSH connection, and remove it from your registry.{' '}
         <strong>
-          Remote tmux sessions, worktrees, and ~/.config/cc-pewpew/ on the host are not touched.
+          Remote tmux sessions, worktrees, and ~/.config/pewpew/ on the host are not touched.
         </strong>
       </div>
       <div className="create-actions">

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -271,7 +271,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
 
     if (setupState === 'unsetup') {
       items.push({
-        label: 'Setup for cc-pewpew',
+        label: 'Setup for pewpew',
         onClick: async () => {
           await window.api.setupProject(projectPath)
           scanProjects()
@@ -327,7 +327,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         },
       })
       items.push({
-        label: 'Re-setup for cc-pewpew',
+        label: 'Re-setup for pewpew',
         onClick: async () => {
           await window.api.setupProject(projectPath)
           scanProjects()
@@ -571,7 +571,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
               )}
               {project.hostId === null &&
                 (project.setupState === 'ready' ? (
-                  <span className="badge-ready" title="cc-pewpew hooks installed">
+                  <span className="badge-ready" title="pewpew hooks installed">
                     ●
                   </span>
                 ) : (
@@ -595,7 +595,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
                       {canMirror && (
                         <button
                           className="worktree-mirror-btn"
-                          title="Mirror this worktree as a cc-pewpew session"
+                          title="Mirror this worktree as a pewpew session"
                           onClick={async (e) => {
                             e.stopPropagation()
                             try {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -7,7 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
     />
-    <title>cc-pewpew</title>
+    <title>pewpew</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/renderer/stores/sessions.test.ts
+++ b/src/renderer/stores/sessions.test.ts
@@ -13,7 +13,7 @@ function makeSession(id: string): Session {
     worktreePath: '/p/w',
     branch: 'main',
     pid: 0,
-    tmuxSession: `cc-pewpew-${id}`,
+    tmuxSession: `pewpew-${id}`,
     status: 'idle',
     lastActivity: 0,
     hookEvents: [],

--- a/src/renderer/stores/theme.ts
+++ b/src/renderer/stores/theme.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import type { Theme } from '../../shared/types'
 
-const THEME_CHANGED_EVENT = 'cc-pewpew:theme-changed'
+const THEME_CHANGED_EVENT = 'pewpew:theme-changed'
 
 function applyTheme(theme: Theme): void {
   document.documentElement.dataset.theme = theme

--- a/src/renderer/swim-lanes.html
+++ b/src/renderer/swim-lanes.html
@@ -7,7 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
     />
-    <title>cc-pewpew — Swimming Lanes</title>
+    <title>pewpew — Swimming Lanes</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

Clean-break rebrand from `cc-pewpew` to `pewpew`. No migration shims — existing tmux sessions, config dir, and hook entries with the old name are orphaned and users re-run Setup.

- `package.json`: name, `appId=com.pewpew.app`, productName
- tmux session prefix `cc-pewpew-*` → `pewpew-*`
- config dir `~/.config/cc-pewpew/` → `~/.config/pewpew/`
- socket paths `/tmp/cc-pewpew-*.sock` → `/tmp/pewpew-*.sock`
- notify script env vars `CC_PEWPEW_*` → `PEWPEW_*`
- UI strings (titles, tray, menus, tooltips), theme event name
- README/CLAUDE.md/.impeccable.md/plans documentation
- Branch prefix fallback `cc-pewpew` → `pewpew`

GitHub repo has been renamed `pmatos/cc-pewpew` → `pmatos/pewpew`; old URLs auto-redirect.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] `npx vitest run` — 362/362 passing
- [x] `npm run build` clean
- [ ] Launch rebuilt app and confirm `~/.config/pewpew/` is created on first run
- [ ] Confirm new tmux sessions are named `pewpew-<id>`