### PR TITLE
fix: stop showing a black terminal when session revival fails

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -51,6 +51,27 @@ interface PtyEntry {
 const ptys = new Map<string, PtyEntry>()
 let flushInterval: ReturnType<typeof setInterval> | null = null
 
+// Fires when the underlying node-pty exits without going through
+// destroyPty/detachPty/destroyRemotePty (those all delete the entry from
+// `ptys` *before* killing the pty, so an entry that's still present at
+// onExit time means the agent or tmux died on its own — e.g. `claude
+// --continue` exiting because no prior conversation exists for the worktree).
+// Lets session-manager flip the session back to 'dead' instead of leaving it
+// at 'idle' with no backing pty, which the Terminal component renders as a
+// permanently empty xterm.
+type UnexpectedExitListener = (sessionId: string) => void
+let unexpectedExitListener: UnexpectedExitListener | null = null
+
+export function setUnexpectedExitListener(fn: UnexpectedExitListener | null): void {
+  unexpectedExitListener = fn
+}
+
+function notifyUnexpectedExitIfPresent(sessionId: string): void {
+  if (!ptys.has(sessionId)) return
+  ptys.delete(sessionId)
+  unexpectedExitListener?.(sessionId)
+}
+
 function flushBuffers(): void {
   for (const [sessionId, entry] of ptys) {
     if (entry.buffer.length > 0) {
@@ -62,7 +83,7 @@ function flushBuffers(): void {
 
 export function isTmuxAvailable(): boolean {
   try {
-    execFileSync('which', ['tmux'])
+    execFileSync('which', ['tmux'], { stdio: 'pipe' })
     return true
   } catch {
     return false
@@ -98,19 +119,11 @@ export function createPty(sessionId: string, cwd: string, options?: SpawnOptions
 
   // Create a detached tmux session that directly runs the agent CLI.
   // Using tmux's shell command avoids issues with interactive shell init (omz, etc.)
-  execFileSync('tmux', [
-    'new-session',
-    '-d',
-    '-s',
-    tmuxSession,
-    '-c',
-    cwd,
-    '-x',
-    '120',
-    '-y',
-    '30',
-    ...agentArgs,
-  ])
+  execFileSync(
+    'tmux',
+    ['new-session', '-d', '-s', tmuxSession, '-c', cwd, '-x', '120', '-y', '30', ...agentArgs],
+    { stdio: 'pipe' }
+  )
 
   // Attach to it via node-pty
   const ptyProcess = pty.spawn('tmux', ['attach-session', '-t', tmuxSession], {
@@ -132,7 +145,7 @@ export function createPty(sessionId: string, cwd: string, options?: SpawnOptions
   })
 
   ptyProcess.onExit(() => {
-    ptys.delete(sessionId)
+    notifyUnexpectedExitIfPresent(sessionId)
   })
 
   ptys.set(sessionId, entry)
@@ -193,8 +206,8 @@ export async function createRemotePty(
   })
 
   ptyProcess.onExit(() => {
-    ptys.delete(sessionId)
     releaseRemoteEntry(entry)
+    notifyUnexpectedExitIfPresent(sessionId)
   })
 
   ptys.set(sessionId, entry)
@@ -248,7 +261,7 @@ export function destroyPty(sessionId: string): void {
   // Always attempt to kill the tmux session — the pty onExit handler may have
   // already removed the map entry, but the tmux session can still be alive.
   try {
-    execFileSync('tmux', ['kill-session', '-t', tmuxSession])
+    execFileSync('tmux', ['kill-session', '-t', tmuxSession], { stdio: 'pipe' })
   } catch {
     // Session may already be dead
   }
@@ -303,7 +316,10 @@ export function hasPty(sessionId: string): boolean {
 
 export function hasTmuxSession(sessionId: string): boolean {
   try {
-    execFileSync('tmux', ['has-session', '-t', `pewpew-${sessionId}`], { timeout: 3000 })
+    execFileSync('tmux', ['has-session', '-t', `pewpew-${sessionId}`], {
+      timeout: 3000,
+      stdio: 'pipe',
+    })
     return true
   } catch {
     return false
@@ -328,6 +344,7 @@ export async function captureThumbnails(opts?: {
       const text = execFileSync('tmux', ['capture-pane', '-t', entry.tmuxSession, '-p'], {
         encoding: 'utf-8',
         timeout: 3000,
+        stdio: 'pipe',
       })
       result[sessionId] = text
       opts?.onCapture?.(sessionId, text)
@@ -405,6 +422,7 @@ export async function getScrollback(sessionId: string): Promise<string> {
     return execFileSync('tmux', ['capture-pane', '-t', tmuxSession, '-p', '-e', '-S', '-5000'], {
       encoding: 'utf-8',
       timeout: 5000,
+      stdio: 'pipe',
     })
   } catch {
     return ''
@@ -416,6 +434,7 @@ export function discoverTmuxSessions(): string[] {
     const output = execFileSync('tmux', ['list-sessions', '-F', '#{session_name}'], {
       encoding: 'utf-8',
       timeout: 5000,
+      stdio: 'pipe',
     })
     const sessions: string[] = []
     for (const name of output.split('\n')) {
@@ -451,7 +470,7 @@ export function reattachPty(sessionId: string): void {
   })
 
   ptyProcess.onExit(() => {
-    ptys.delete(sessionId)
+    notifyUnexpectedExitIfPresent(sessionId)
   })
 
   ptys.set(sessionId, entry)
@@ -461,7 +480,7 @@ export function reattachPty(sessionId: string): void {
     const scrollback = execFileSync(
       'tmux',
       ['capture-pane', '-t', tmuxSession, '-p', '-e', '-S', '-5000'],
-      { encoding: 'utf-8', timeout: 5000 }
+      { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' }
     )
     if (scrollback) {
       entry.buffer += scrollback
@@ -495,8 +514,8 @@ export async function reattachRemotePty(sessionId: string, host: Host): Promise<
   })
 
   ptyProcess.onExit(() => {
-    ptys.delete(sessionId)
     releaseRemoteEntry(entry)
+    notifyUnexpectedExitIfPresent(sessionId)
   })
 
   ptys.set(sessionId, entry)

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -25,6 +25,9 @@ const state = vi.hoisted(() => ({
   detachPtyCalls: [] as string[],
   hasRemoteTmuxResult: new Map<string, boolean>(),
   probeRemoteTmuxResult: new Map<string, 'present' | 'absent' | 'unreachable'>(),
+  // Captures the listener registered via setUnexpectedExitListener so tests
+  // can invoke it synchronously without spinning up a real node-pty.
+  unexpectedExitListener: null as null | ((sessionId: string) => void),
   // Per-session side effect fired before the probe resolves. Lets tests
   // simulate a concurrent reconnect advancing another session's state while
   // the batch is in flight.
@@ -168,6 +171,9 @@ vi.mock('./pty-manager', () => ({
     state.createRemotePtyCalls.push({ sessionId, cwd, hostId: host.hostId })
     state.runtimeRefs.set(host.hostId, (state.runtimeRefs.get(host.hostId) ?? 0) + 1)
   },
+  setUnexpectedExitListener: (fn: null | ((sessionId: string) => void)) => {
+    state.unexpectedExitListener = fn
+  },
 }))
 
 vi.mock('./host-connection', () => ({
@@ -295,6 +301,7 @@ beforeEach(() => {
   state.execRemoteResults = new Map()
   state.ensureHostConnectionThrows = null
   state.ensureHostConnectionGate = null
+  state.unexpectedExitListener = null
 })
 
 afterEach(() => {
@@ -1156,6 +1163,48 @@ describe('restoreSessions — local path unchanged (AC #10 regression)', () => {
     expect(got.connectionState).toBeUndefined()
     expect(state.reattachPtyCalls).toEqual(['l1'])
     expect(state.ensureHostConnectionCalls).toEqual([])
+  })
+})
+
+describe('unexpected pty exit listener', () => {
+  it('flips a local session to dead when its pty dies on its own', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    state.liveTmuxIds = ['l1']
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.initSessionManager()
+    expect(state.unexpectedExitListener).not.toBeNull()
+
+    state.unexpectedExitListener?.('l1')
+
+    expect(sm.getSessions()[0].status).toBe('dead')
+  })
+
+  it('does not touch remote sessions (their connection state machinery owns recovery)', async () => {
+    const remote = baseRemoteSession({ id: 'r1', status: 'idle' })
+    writeSessionsJson([remote])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.initSessionManager()
+
+    state.unexpectedExitListener?.('r1')
+
+    expect(sm.getSessions()[0].status).toBe('idle')
+  })
+
+  it('is a no-op for unknown ids and already-dead sessions', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'dead' })
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.initSessionManager()
+    const broadcastsBefore = state.sessionsUpdatedBroadcasts
+
+    state.unexpectedExitListener?.('l1')
+    state.unexpectedExitListener?.('unknown-id')
+
+    expect(state.sessionsUpdatedBroadcasts).toBe(broadcastsBefore)
   })
 })
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -2046,8 +2046,14 @@ export async function relocateProject(
 // which collapses the tmux pane immediately and leaves the session unusable.
 // In that case we spawn fresh instead, matching the existing codex fallback
 // (no agentSessionId → spawn fresh) in `restoreSessions`.
+//
+// Claude keys the per-worktree directory off the *canonical* path, so we
+// canonicalize here too. `restoreSessions` migrates legacy symlink-form
+// `worktreePath`s only after the auto-recovery branch runs, so without this
+// `realpathSync` a migrated session would probe an encoded symlink path,
+// find nothing, and silently lose its conversation history on reboot.
 function hasClaudeConversationHistory(worktreePath: string): boolean {
-  const encoded = worktreePath.replace(/[^a-zA-Z0-9-]/g, '-')
+  const encoded = canonicalPath(worktreePath).replace(/[^a-zA-Z0-9-]/g, '-')
   return existsSync(join(homedir(), '.claude', 'projects', encoded))
 }
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util'
 import { readFileSync, writeFileSync, existsSync, realpathSync } from 'fs'
 import { join, basename, sep } from 'path'
 import { posix } from 'path'
+import { homedir } from 'os'
 import { randomUUID } from 'crypto'
 import { dialog, shell } from 'electron'
 import { broadcastToAll, getMainWindow } from './window-registry'
@@ -23,6 +24,7 @@ import {
   reattachPty,
   reattachRemotePty,
   createRemotePty,
+  setUnexpectedExitListener,
 } from './pty-manager'
 import { getRepoFingerprint, gitWorktrees } from './project-scanner'
 import {
@@ -404,6 +406,19 @@ export function initSessionManager(): void {
       if (entry.session.prNumber === undefined) resolvePrNumberAsync(entry.session.id)
     }
   }, PR_REFRESH_INTERVAL_MS).unref()
+
+  // When a local pty dies on its own (e.g. `claude --continue` exits with
+  // "No conversation found to continue" and the tmux session collapses), flip
+  // the session back to 'dead' so the renderer shows the "Restart terminal"
+  // overlay instead of a permanently empty xterm. Remote sessions are skipped:
+  // an SSH drop kills the local pty but the remote tmux session can still be
+  // alive, and reconnectRemoteSession already drives that flow.
+  setUnexpectedExitListener((sessionId) => {
+    const entry = sessions.get(sessionId)
+    if (!entry || entry.session.hostId) return
+    if (entry.session.status === 'dead') return
+    updateSession(sessionId, 'dead')
+  })
 }
 
 async function deriveLabel(worktreePath: string): Promise<string> {
@@ -1259,13 +1274,28 @@ export async function reviveSession(id: string): Promise<void> {
   if (hasTmuxSession(id)) {
     reattachPty(id)
   } else {
+    const canResume = canResumeAgent(session)
+    if (!canResume) {
+      console.warn(
+        `Session ${id} (${session.tool}) has no prior conversation; spawning fresh instead of resuming`
+      )
+    }
     createPty(id, session.worktreePath, {
-      continueSession: true,
+      continueSession: canResume,
       tool: session.tool,
       agentSessionId: session.agentSessionId,
     })
   }
   updateSession(id, 'idle')
+}
+
+// Decides whether resuming an agent will work. For claude, --continue exits
+// non-zero when there's no per-worktree project directory in ~/.claude/projects,
+// killing the tmux pane on spawn. For codex, `codex resume <id>` requires the
+// captured agentSessionId from the SessionStart hook.
+function canResumeAgent(session: Session): boolean {
+  if (session.tool === 'codex') return !!session.agentSessionId
+  return hasClaudeConversationHistory(session.worktreePath)
 }
 
 export async function removeWorktree(id: string): Promise<void> {
@@ -2008,6 +2038,19 @@ export async function relocateProject(
   return { migratedCount: toMigrate.length }
 }
 
+// claude stores per-worktree conversations under
+// `~/.claude/projects/<encoded-path>/`, where the encoding replaces any
+// character outside [a-zA-Z0-9-] with '-'. We use this to decide whether
+// `claude --continue` would succeed on revival: if the directory is missing,
+// claude prints "No conversation found to continue" and exits with code 1,
+// which collapses the tmux pane immediately and leaves the session unusable.
+// In that case we spawn fresh instead, matching the existing codex fallback
+// (no agentSessionId → spawn fresh) in `restoreSessions`.
+function hasClaudeConversationHistory(worktreePath: string): boolean {
+  const encoded = worktreePath.replace(/[^a-zA-Z0-9-]/g, '-')
+  return existsSync(join(homedir(), '.claude', 'projects', encoded))
+}
+
 // Backfill / reconcile fields added in later versions. For local sessions
 // (worktreePath exists on this machine) the live git branch trumps whatever
 // was persisted — an earlier version stored a wrong default that we self-heal
@@ -2084,12 +2127,12 @@ export function restoreSessions(): void {
           skippedForNoTmux++
         } else {
           // tmux server lost the session (e.g., PC reboot) but the worktree
-          // survives — auto-recreate and resume the claude conversation.
+          // survives — auto-recreate and resume the agent conversation.
           try {
-            const canResume = session.tool !== 'codex' || !!session.agentSessionId
-            if (session.tool === 'codex' && !session.agentSessionId) {
+            const canResume = canResumeAgent(session)
+            if (!canResume) {
               console.warn(
-                `codex session ${session.id} has no agentSessionId; spawning fresh instead of resuming`
+                `Session ${session.id} (${session.tool}) has no prior conversation; spawning fresh instead of resuming`
               )
             }
             createPty(session.id, session.worktreePath, {


### PR DESCRIPTION
## Summary

Two coupled bugs left a "Restart terminal" click ending in a permanently black xterm:

- `claude --continue` exits with `No conversation found to continue` in worktrees that never hosted a Claude conversation (e.g. `s11/arm64Further` after a fresh `git worktree add`). With default `remain-on-exit off` the tmux pane collapses immediately. Both `restoreSessions` (auto-recovery) and `reviveSession` (the user-facing button) hard-coded `--continue`, so revival was guaranteed to fail.
- The pty `onExit` handlers only deleted the entry from `ptys` — they never told `session-manager` the agent died. The session stayed at `idle` with no backing pty, so `<Terminal>` mounted, subscribed to a silent `pty:data` stream, and rendered an empty pane forever.

The two changes:

- **pty-manager:** new `setUnexpectedExitListener`. `destroyPty` / `detachPty` / `destroyRemotePty` already delete the entry **before** killing, so an entry still present at `onExit` time means an unintended death. `session-manager.initSessionManager` registers a listener that flips local sessions back to `dead`; remote sessions are left to the existing `reconnectRemoteSession` connection-state machinery.
- **session-manager:** new `hasClaudeConversationHistory(worktreePath)` (checks `~/.claude/projects/<encoded-cwd>/`) plus `canResumeAgent(session)`, which extends the existing codex `agentSessionId` fallback to claude. Both `restoreSessions` and `reviveSession` now spawn fresh whenever resume would crash, so the user sees a real Claude welcome screen instead of a dead pane.

Also added `stdio: 'pipe'` to every tmux `execFileSync`. Node's default inherits stderr, so the 3 s `captureThumbnails` tick and any dying `attach-session` were leaking `can't find pane/session` lines to the AppImage's stdout.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src` — clean
- [x] `npx vitest run` — 370 passed (3 new tests for the listener wiring: local flips to dead, remote no-op, unknown/already-dead no-op)
- [ ] Manual: on a worktree with no `~/.claude/projects/<encoded>/` entry, click "Restart terminal" — should now spawn a fresh Claude instead of a black pane.
- [ ] Manual: kill `claude` from inside its pane (`/exit`); session should flip to "Session terminated" overlay rather than a silently empty xterm.