### PR TITLE
ci: run react-doctor on PR diffs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,16 @@ jobs:
       - name: ESLint
         run: npx eslint .
 
+      - name: react-doctor (diff vs base, PR only)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=100 origin "${{ github.base_ref }}"
+          npx --yes react-doctor@0.1.6 \
+            --diff "origin/${{ github.base_ref }}" \
+            --annotations \
+            --fail-on error \
+            --offline
+
       - name: TypeScript (noEmit)
         run: npx tsc --noEmit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:
@@ -43,7 +45,6 @@ jobs:
       - name: react-doctor (diff vs base, PR only)
         if: github.event_name == 'pull_request'
         run: |
-          git fetch --no-tags --depth=100 origin "${{ github.base_ref }}"
           npx --yes react-doctor@0.1.6 \
             --diff "origin/${{ github.base_ref }}" \
             --annotations \

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format": "prettier --write .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "doctor": "react-doctor",
+    "doctor": "npx --yes react-doctor@0.1.6",
     "postinstall": "electron-builder install-app-deps",
     "dist": "electron-vite build && electron-builder --publish never",
     "dist:linux": "electron-vite build && electron-builder --linux --publish never"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --write .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "doctor": "react-doctor",
     "postinstall": "electron-builder install-app-deps",
     "dist": "electron-vite build && electron-builder --publish never",
     "dist:linux": "electron-vite build && electron-builder --linux --publish never"


### PR DESCRIPTION
## Summary
- Adds a PR-only CI step that runs `react-doctor@0.1.6 --diff origin/<base> --annotations --fail-on error --offline`, surfacing oxlint + knip diagnostics as inline annotations on changed files.
- Exposes the tool locally via `npm run doctor` so contributors can check before pushing.
- Pinned to `0.1.6` (telemetry off via `--offline`); diff-only keeps it fast and avoids surfacing pre-existing findings on unrelated files.

Closes #95

## Test plan
- [ ] CI passes on this PR (the new step itself runs and either reports clean or annotates only on the trivial files changed here)
- [ ] `npm run doctor` works locally
- [ ] On a follow-up PR that touches `src/`, confirm annotations appear inline and the step fails only when real errors are reported