### PR TITLE
fix: scrub AppImage runtime env from spawned PTYs (#92)

### DIFF
--- a/src/main/appimage-env.test.ts
+++ b/src/main/appimage-env.test.ts
@@ -98,6 +98,47 @@ describe('sanitizeChildEnv', () => {
     expect('LD_PRELOAD' in out).toBe(false)
   })
 
+  // ld.so(8): "The items of the list can be separated by spaces or colons,
+  // and there is no support for escaping either separator."
+  it('filters space-delimited AppImage entries from LD_PRELOAD', () => {
+    const appDir = '/tmp/.mount_pewpewXYZ'
+    const env = {
+      APPIMAGE: '/path/to/pewpew.AppImage',
+      APPDIR: appDir,
+      LD_PRELOAD: `/usr/lib/libasan.so ${appDir}/usr/lib/libfoo.so`,
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect(out.LD_PRELOAD).toBe('/usr/lib/libasan.so')
+  })
+
+  it('handles LD_PRELOAD with mixed space and colon delimiters', () => {
+    const appDir = '/tmp/.mount_pewpewXYZ'
+    const env = {
+      APPIMAGE: '/path/to/pewpew.AppImage',
+      APPDIR: appDir,
+      LD_PRELOAD: `/usr/lib/libasan.so ${appDir}/usr/lib/libfoo.so:/opt/local/lib/libbar.so`,
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect(out.LD_PRELOAD).toBe('/usr/lib/libasan.so /opt/local/lib/libbar.so')
+  })
+
+  it('removes LD_PRELOAD entirely when only AppImage entries remain after space split', () => {
+    const appDir = '/tmp/.mount_pewpewXYZ'
+    const env = {
+      APPIMAGE: '/path/to/pewpew.AppImage',
+      APPDIR: appDir,
+      LD_PRELOAD: `${appDir}/usr/lib/libfoo.so ${appDir}/usr/lib/libbar.so`,
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect('LD_PRELOAD' in out).toBe(false)
+  })
+
   it('is a no-op when APPIMAGE is not set (dev runs, .deb installs)', () => {
     const env = {
       HOME: '/home/u',

--- a/src/main/appimage-env.test.ts
+++ b/src/main/appimage-env.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'child_process'
+import { existsSync } from 'fs'
+import { sanitizeChildEnv } from './appimage-env'
+
+describe('sanitizeChildEnv', () => {
+  it('drops APPIMAGE and APPDIR when both are set', () => {
+    const env = {
+      APPIMAGE: '/home/u/dev/pewpew/release/pewpew-0.2.1-pre.0.AppImage',
+      APPDIR: '/tmp/.mount_pewpewXYZ',
+      HOME: '/home/u',
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect(out.APPIMAGE).toBeUndefined()
+    expect(out.APPDIR).toBeUndefined()
+    expect(out.HOME).toBe('/home/u')
+  })
+
+  it('drops other AppImage launcher variables', () => {
+    const env = {
+      APPIMAGE: '/path/to/pewpew.AppImage',
+      APPDIR: '/tmp/.mount_pewpewXYZ',
+      ARGV0: 'pewpew-0.2.1-pre.0',
+      OWD: '/home/u/dev/project',
+      APPIMAGE_UUID: 'abc-123',
+      APPIMAGE_EXTRACT_AND_RUN: '1',
+      HOME: '/home/u',
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect(out.ARGV0).toBeUndefined()
+    expect(out.OWD).toBeUndefined()
+    expect(out.APPIMAGE_UUID).toBeUndefined()
+    expect(out.APPIMAGE_EXTRACT_AND_RUN).toBeUndefined()
+    expect(out.HOME).toBe('/home/u')
+  })
+
+  it('filters AppImage mount entries out of LD_LIBRARY_PATH but keeps user entries', () => {
+    const env = {
+      APPIMAGE: '/path/to/pewpew.AppImage',
+      APPDIR: '/tmp/.mount_pewpewXYZ',
+      LD_LIBRARY_PATH: '/tmp/.mount_pewpewXYZ/usr/lib:/usr/lib/custom:/opt/local/lib',
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect(out.LD_LIBRARY_PATH).toBe('/usr/lib/custom:/opt/local/lib')
+  })
+
+  it('removes LD_LIBRARY_PATH entirely when filtering empties it', () => {
+    const env = {
+      APPIMAGE: '/path/to/pewpew.AppImage',
+      APPDIR: '/tmp/.mount_pewpewXYZ',
+      LD_LIBRARY_PATH: '/tmp/.mount_pewpewXYZ/usr/lib:',
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect('LD_LIBRARY_PATH' in out).toBe(false)
+  })
+
+  it('filters /tmp/.mount_* entries even when APPDIR was already scrubbed by an intermediate process', () => {
+    const env = {
+      APPIMAGE: '/path/to/pewpew.AppImage',
+      LD_LIBRARY_PATH: '/tmp/.mount_pewpewXYZ/usr/lib:/usr/lib/custom',
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect(out.LD_LIBRARY_PATH).toBe('/usr/lib/custom')
+  })
+
+  it('broad-scrubs other path-list variables touched by the AppImage runtime', () => {
+    const appDir = '/tmp/.mount_pewpewXYZ'
+    const env = {
+      APPIMAGE: '/path/to/pewpew.AppImage',
+      APPDIR: appDir,
+      PATH: `${appDir}/usr/bin:/usr/local/bin:/usr/bin`,
+      XDG_DATA_DIRS: `${appDir}/usr/share:/usr/local/share:/usr/share`,
+      PYTHONPATH: `${appDir}/usr/lib/python3.12`,
+      GIO_MODULE_DIR: `${appDir}/usr/lib/gio/modules`,
+      GSETTINGS_SCHEMA_DIR: `${appDir}/usr/share/glib-2.0/schemas`,
+      QT_PLUGIN_PATH: `${appDir}/usr/plugins`,
+      LD_PRELOAD: `${appDir}/usr/lib/libfake.so`,
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect(out.PATH).toBe('/usr/local/bin:/usr/bin')
+    expect(out.XDG_DATA_DIRS).toBe('/usr/local/share:/usr/share')
+    expect('PYTHONPATH' in out).toBe(false)
+    expect('GIO_MODULE_DIR' in out).toBe(false)
+    expect('GSETTINGS_SCHEMA_DIR' in out).toBe(false)
+    expect('QT_PLUGIN_PATH' in out).toBe(false)
+    expect('LD_PRELOAD' in out).toBe(false)
+  })
+
+  it('is a no-op when APPIMAGE is not set (dev runs, .deb installs)', () => {
+    const env = {
+      HOME: '/home/u',
+      PATH: '/usr/local/bin:/usr/bin',
+      LD_LIBRARY_PATH: '/usr/lib/custom',
+      // An empty entry that would normally be filtered — proves we don't touch
+      // LD_LIBRARY_PATH at all when not running under AppImage.
+      PYTHONPATH: '',
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect(out).toEqual(env)
+  })
+
+  it('leaves user-provided path-list variables alone when they contain no AppImage entries', () => {
+    const env = {
+      APPIMAGE: '/path/to/pewpew.AppImage',
+      APPDIR: '/tmp/.mount_pewpewXYZ',
+      PATH: '/home/u/.local/bin:/usr/local/bin:/usr/bin',
+      PYTHONPATH: '/home/u/code/lib',
+    }
+
+    const out = sanitizeChildEnv(env)
+
+    expect(out.PATH).toBe('/home/u/.local/bin:/usr/local/bin:/usr/bin')
+    expect(out.PYTHONPATH).toBe('/home/u/code/lib')
+  })
+
+  describe('end-to-end through real child_process spawn', () => {
+    const hasEnv = existsSync('/usr/bin/env')
+
+    it.skipIf(!hasEnv)(
+      'a child spawned with sanitized env does not see APPIMAGE/APPDIR or AppImage mount paths',
+      () => {
+        const poisoned = {
+          ...process.env,
+          APPIMAGE: '/path/to/pewpew-0.2.1-pre.0.AppImage',
+          APPDIR: '/tmp/.mount_pewpewXYZ',
+          ARGV0: 'pewpew-0.2.1-pre.0',
+          OWD: '/home/u/dev/project',
+          LD_LIBRARY_PATH: '/tmp/.mount_pewpewXYZ/usr/lib:/usr/lib/custom',
+          PATH: `/tmp/.mount_pewpewXYZ/usr/bin:${process.env.PATH ?? '/usr/bin'}`,
+        }
+
+        const stdout = execFileSync('/usr/bin/env', {
+          env: sanitizeChildEnv(poisoned) as NodeJS.ProcessEnv,
+          encoding: 'utf-8',
+        })
+
+        const lines = stdout.split('\n')
+        expect(lines.some((l) => l.startsWith('APPIMAGE='))).toBe(false)
+        expect(lines.some((l) => l.startsWith('APPDIR='))).toBe(false)
+        expect(lines.some((l) => l.startsWith('ARGV0='))).toBe(false)
+        expect(lines.some((l) => l.startsWith('OWD='))).toBe(false)
+        expect(stdout).not.toContain('/tmp/.mount_pewpew')
+
+        const ldLine = lines.find((l) => l.startsWith('LD_LIBRARY_PATH='))
+        expect(ldLine).toBe('LD_LIBRARY_PATH=/usr/lib/custom')
+      }
+    )
+  })
+})

--- a/src/main/appimage-env.ts
+++ b/src/main/appimage-env.ts
@@ -1,0 +1,51 @@
+const SCALAR_VARS = ['APPIMAGE', 'APPDIR', 'ARGV0', 'OWD'] as const
+
+const PATH_LIST_VARS = [
+  'LD_LIBRARY_PATH',
+  'LD_PRELOAD',
+  'PATH',
+  'XDG_DATA_DIRS',
+  'XDG_CONFIG_DIRS',
+  'PYTHONPATH',
+  'PYTHONHOME',
+  'PERLLIB',
+  'PERL5LIB',
+  'GIO_MODULE_DIR',
+  'GSETTINGS_SCHEMA_DIR',
+  'GST_PLUGIN_SYSTEM_PATH',
+  'GDK_PIXBUF_MODULE_FILE',
+  'QT_PLUGIN_PATH',
+] as const
+
+const MOUNT_PREFIX_RE = /^\/tmp\/\.mount_[^/]+(\/|$)/
+
+function isAppImageEntry(entry: string, appDir: string | undefined): boolean {
+  // Empty entries in LD_LIBRARY_PATH/PATH-style lists mean "current dir" — never
+  // safe to forward, so treat them as drop-able alongside actual AppImage paths.
+  if (entry === '') return true
+  if (appDir && (entry === appDir || entry.startsWith(`${appDir}/`))) return true
+  return MOUNT_PREFIX_RE.test(entry)
+}
+
+export function sanitizeChildEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  if (env.APPIMAGE === undefined) return env
+  const out: NodeJS.ProcessEnv = { ...env }
+  const appDir = env.APPDIR
+
+  for (const key of PATH_LIST_VARS) {
+    const value = out[key]
+    if (typeof value !== 'string') continue
+    const kept = value.split(':').filter((entry) => !isAppImageEntry(entry, appDir))
+    if (kept.length === 0) {
+      delete out[key]
+    } else {
+      out[key] = kept.join(':')
+    }
+  }
+
+  for (const key of SCALAR_VARS) delete out[key]
+  for (const key of Object.keys(out)) {
+    if (key.startsWith('APPIMAGE_')) delete out[key]
+  }
+  return out
+}

--- a/src/main/appimage-env.ts
+++ b/src/main/appimage-env.ts
@@ -1,8 +1,11 @@
 const SCALAR_VARS = ['APPIMAGE', 'APPDIR', 'ARGV0', 'OWD'] as const
 
-const PATH_LIST_VARS = [
+// ld.so(8) accepts both spaces and colons as LD_PRELOAD separators with no
+// escaping, so this variable needs a wider split than the colon-only PATH-style
+// list — otherwise `"/usr/lib/libasan.so /tmp/.mount_*/libfoo.so"` survives as
+// a single non-matching entry and the AppImage preload leaks into children.
+const PATH_LIST_VARS_COLON = [
   'LD_LIBRARY_PATH',
-  'LD_PRELOAD',
   'PATH',
   'XDG_DATA_DIRS',
   'XDG_CONFIG_DIRS',
@@ -16,6 +19,8 @@ const PATH_LIST_VARS = [
   'GDK_PIXBUF_MODULE_FILE',
   'QT_PLUGIN_PATH',
 ] as const
+
+const PATH_LIST_VARS_SPACE_OR_COLON = ['LD_PRELOAD'] as const
 
 const MOUNT_PREFIX_RE = /^\/tmp\/\.mount_[^/]+(\/|$)/
 
@@ -32,7 +37,7 @@ export function sanitizeChildEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.P
   const out: NodeJS.ProcessEnv = { ...env }
   const appDir = env.APPDIR
 
-  for (const key of PATH_LIST_VARS) {
+  for (const key of PATH_LIST_VARS_COLON) {
     const value = out[key]
     if (typeof value !== 'string') continue
     const kept = value.split(':').filter((entry) => !isAppImageEntry(entry, appDir))
@@ -40,6 +45,19 @@ export function sanitizeChildEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.P
       delete out[key]
     } else {
       out[key] = kept.join(':')
+    }
+  }
+
+  for (const key of PATH_LIST_VARS_SPACE_OR_COLON) {
+    const value = out[key]
+    if (typeof value !== 'string') continue
+    // Both separators are semantically equivalent to ld.so, so normalize to
+    // single spaces on output.
+    const kept = value.split(/[ :]+/).filter((entry) => !isAppImageEntry(entry, appDir))
+    if (kept.length === 0) {
+      delete out[key]
+    } else {
+      out[key] = kept.join(' ')
     }
   }
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -12,6 +12,7 @@ import {
 } from './host-connection'
 import { classifySshExit } from './ssh-exit-parser'
 import { captureRemotePaneTexts, type RemoteSessionEntry } from './remote-thumbnail'
+import { sanitizeChildEnv } from './appimage-env'
 import type { AgentTool, Host } from '../shared/types'
 
 interface SpawnOptions {
@@ -122,7 +123,7 @@ export function createPty(sessionId: string, cwd: string, options?: SpawnOptions
   execFileSync(
     'tmux',
     ['new-session', '-d', '-s', tmuxSession, '-c', cwd, '-x', '120', '-y', '30', ...agentArgs],
-    { stdio: 'pipe' }
+    { stdio: 'pipe', env: sanitizeChildEnv() as NodeJS.ProcessEnv }
   )
 
   // Attach to it via node-pty
@@ -131,7 +132,7 @@ export function createPty(sessionId: string, cwd: string, options?: SpawnOptions
     cols: 120,
     rows: 30,
     cwd,
-    env: process.env as Record<string, string>,
+    env: sanitizeChildEnv() as Record<string, string>,
   })
 
   const entry: PtyEntry = {
@@ -189,7 +190,7 @@ export async function createRemotePty(
     name: 'xterm-256color',
     cols: 120,
     rows: 30,
-    env: process.env as Record<string, string>,
+    env: sanitizeChildEnv() as Record<string, string>,
   })
 
   retainHostConnection(host.hostId)
@@ -456,7 +457,7 @@ export function reattachPty(sessionId: string): void {
     name: 'xterm-256color',
     cols: 120,
     rows: 30,
-    env: process.env as Record<string, string>,
+    env: sanitizeChildEnv() as Record<string, string>,
   })
 
   const entry: PtyEntry = {
@@ -497,7 +498,7 @@ export async function reattachRemotePty(sessionId: string, host: Host): Promise<
     name: 'xterm-256color',
     cols: 120,
     rows: 30,
-    env: process.env as Record<string, string>,
+    env: sanitizeChildEnv() as Record<string, string>,
   })
 
   retainHostConnection(host.hostId)

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -84,7 +84,10 @@ function flushBuffers(): void {
 
 export function isTmuxAvailable(): boolean {
   try {
-    execFileSync('which', ['tmux'], { stdio: 'pipe' })
+    execFileSync('which', ['tmux'], {
+      stdio: 'pipe',
+      env: sanitizeChildEnv() as NodeJS.ProcessEnv,
+    })
     return true
   } catch {
     return false


### PR DESCRIPTION
## Summary

- Add `sanitizeChildEnv()` helper that strips `APPIMAGE`/`APPDIR`/`ARGV0`/`OWD`/`APPIMAGE_*` and filters AppImage mount paths out of `LD_LIBRARY_PATH`, `LD_PRELOAD`, `PATH`, `XDG_DATA_DIRS`, `PYTHONPATH`, GIO/GSETTINGS/GST/QT module dirs, and friends — by both `$APPDIR/` prefix and `/tmp/.mount_*` regex. No-op when `APPIMAGE` is unset, so dev runs and `.deb` installs are unaffected.
- Wire it into the load-bearing `pty-manager.ts` sites: the `tmux new-session` that becomes the tmux server (the root cause — its env became the env of every shell attached to that server), plus the four `pty.spawn` / `spawnAttach` env args.

Fixes #92.

## Why this scope

The bug is bounded to the tmux/PTY path. Other local spawns (`git`, `gh`, `ssh`) inherit `APPIMAGE` too, but those tools are not env-sensitive to AppImage vars and their stdout never surfaces in user shells, so sanitizing them would be cosmetic churn with no behavior change.

## Test plan

- [x] `npx vitest run` — 376/376 pass, including 9 new cases in `src/main/appimage-env.test.ts` covering scalar drop, `APPIMAGE_*` family, `LD_LIBRARY_PATH` partial filter preserving user entries, empty-list deletion, `/tmp/.mount_*` fallback when `APPDIR` is missing, broad-scrub of every path-list var, no-op when not under AppImage, and an end-to-end smoke test that spawns `/usr/bin/env` through `execFileSync` with a synthesized AppImage env and asserts the issue's symptoms are gone.
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean
- [x] `npx prettier --check` on touched files clean
- [ ] Manual: build the AppImage (`npm run dist:linux`), launch it, open a session terminal, verify `env | grep -E 'APPIMAGE|APPDIR'` is empty and `/usr/bin/rustup --version` works.

## Upgrade note

Existing tmux servers retain whatever env they were started with — pewpew can't fix that retroactively. After installing the fixed build, upgraders should run `tmux -L pewpew kill-server` once (or just restart) to clear any pre-existing poisoned server.