### PR TITLE
ci: switch to official millionco/react-doctor action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:
@@ -41,15 +39,6 @@ jobs:
 
       - name: ESLint
         run: npx eslint .
-
-      - name: react-doctor (diff vs base, PR only)
-        if: github.event_name == 'pull_request'
-        run: |
-          npx --yes react-doctor@0.1.6 \
-            --diff "origin/${{ github.base_ref }}" \
-            --annotations \
-            --fail-on error \
-            --offline
 
       - name: TypeScript (noEmit)
         run: npx tsc --noEmit

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -21,4 +21,5 @@ jobs:
       - uses: millionco/react-doctor@main
         with:
           diff: main
+          offline: true # do not POST diagnostics to the react.doctor score API
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,24 @@
+name: React Doctor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write # required to post PR comments
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # required for `diff`
+
+      - uses: millionco/react-doctor@main
+        with:
+          diff: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled `npx --yes react-doctor@0.1.6 --diff …` step in `ci.yml`'s `quality` job with the upstream [`millionco/react-doctor@main`](https://github.com/millionco/react-doctor) action, configured in its own workflow file (`.github/workflows/react-doctor.yml`).
- Drops `fetch-depth: 0` from the `quality` job's checkout — no remaining step in that job needs git history.
- Keeps the `npm run doctor` script as the local convenience entry point.

## Why
The official action handles the diff base resolution, posts PR comments via `secrets.GITHUB_TOKEN`, and tracks upstream improvements as they ship. The hand-rolled step needs maintenance every time react-doctor's CLI flags change.

## Trade-off worth noting
The action is pinned to `@main` per react-doctor's published example. That's a moving target; if upstream lands a breaking change we'll see it before users do. If we want to stabilise, we can repin to a specific commit SHA (or tag, once they cut one). Happy to do that in a follow-up.

## Test plan
- [ ] CI's React Doctor workflow runs on this PR and reports clean (or annotates only on changed files)
- [ ] CI's `quality` job still passes without the react-doctor step