### PR TITLE
fix: only prompt worktree cleanup on real SessionEnd reasons

### DIFF
--- a/src/main/session-state-machine.test.ts
+++ b/src/main/session-state-machine.test.ts
@@ -125,12 +125,16 @@ describe('applyHookEvent — session.activity', () => {
 })
 
 describe('applyHookEvent — session.end', () => {
-  it('emits promptCleanup intent and returns state unchanged', () => {
+  it('emits promptCleanup intent and returns state unchanged when reason is prompt_input_exit', () => {
     const session = makeSession({ id: 's1', status: 'running', lastActivity: 0 })
     const original = stateOf(session)
     const result = applyHookEvent(
       original,
-      { method: 'session.end', params: { cwd: '/p/w' }, originHostId: null },
+      {
+        method: 'session.end',
+        params: { cwd: '/p/w', reason: 'prompt_input_exit' },
+        originHostId: null,
+      },
       99
     )
     expect(result.matched).toBe(true)
@@ -138,6 +142,50 @@ describe('applyHookEvent — session.end', () => {
     // State must be unchanged — promptCleanup runs async and removeSession will
     // reduce state separately. The reducer must not pre-emptively mutate.
     expect(result.state.get('s1')).toEqual(session)
+  })
+
+  it.each(['clear', 'resume', 'bypass_permissions_disabled', 'other', 'unrecognised'])(
+    'does not emit promptCleanup when reason is %p (session still alive)',
+    (reason) => {
+      const session = makeSession({ id: 's1', status: 'running' })
+      const result = applyHookEvent(
+        stateOf(session),
+        {
+          method: 'session.end',
+          params: { cwd: '/p/w', reason },
+          originHostId: null,
+        },
+        1
+      )
+      expect(result.matched).toBe(true)
+      expect(result.intents).toEqual([])
+    }
+  )
+
+  it('emits promptCleanup when reason is "logout"', () => {
+    const session = makeSession({ id: 's1', status: 'running' })
+    const result = applyHookEvent(
+      stateOf(session),
+      {
+        method: 'session.end',
+        params: { cwd: '/p/w', reason: 'logout' },
+        originHostId: null,
+      },
+      1
+    )
+    expect(result.matched).toBe(true)
+    expect(result.intents).toContainEqual({ kind: 'promptCleanup', sessionId: 's1' })
+  })
+
+  it('does not emit promptCleanup when reason is absent (treat as ambiguous)', () => {
+    const session = makeSession({ id: 's1', status: 'running' })
+    const result = applyHookEvent(
+      stateOf(session),
+      { method: 'session.end', params: { cwd: '/p/w' }, originHostId: null },
+      1
+    )
+    expect(result.matched).toBe(true)
+    expect(result.intents).toEqual([])
   })
 })
 

--- a/src/main/session-state-machine.ts
+++ b/src/main/session-state-machine.ts
@@ -71,7 +71,13 @@ export function applyHookEvent(
       // mean the agent process is gone.
       // https://code.claude.com/docs/en/hooks (SessionEnd matcher values).
       const reason = typeof event.params.reason === 'string' ? event.params.reason : undefined
-      console.info(`[session.end] sessionId=${target.id} reason=${reason ?? '<absent>'}`)
+      // JSON.stringify escapes control characters and the slice caps length so a
+      // misbehaving (or hostile) hook payload cannot forge log lines or flood
+      // the console with megabytes of attacker-chosen text. CodeQL flagged the
+      // raw interpolation as log-injection — this is the minimal sanitisation
+      // that keeps the diagnostic value of seeing the actual reason string.
+      const safeReason = reason === undefined ? '<absent>' : JSON.stringify(reason).slice(0, 64)
+      console.info(`[session.end] sessionId=${target.id} reason=${safeReason}`)
       const triggersCleanup = reason === 'prompt_input_exit' || reason === 'logout'
       if (!triggersCleanup) {
         return { state, intents: [], matched: true }

--- a/src/main/session-state-machine.ts
+++ b/src/main/session-state-machine.ts
@@ -62,12 +62,26 @@ export function applyHookEvent(
       next.lastActivity = now
       if (event.originHostId) next.connectionState = 'live'
       break
-    case 'session.end':
+    case 'session.end': {
+      // Claude Code fires SessionEnd for several reasons, not all of which mean
+      // the user is done with the worktree. /clear, --continue/--resume, and
+      // bypass_permissions_disabled all fire SessionEnd while the session
+      // remains alive — treating them as "user wants cleanup" produces a
+      // disruptive false-positive dialog. Only fire on reasons that genuinely
+      // mean the agent process is gone.
+      // https://code.claude.com/docs/en/hooks (SessionEnd matcher values).
+      const reason = typeof event.params.reason === 'string' ? event.params.reason : undefined
+      console.info(`[session.end] sessionId=${target.id} reason=${reason ?? '<absent>'}`)
+      const triggersCleanup = reason === 'prompt_input_exit' || reason === 'logout'
+      if (!triggersCleanup) {
+        return { state, intents: [], matched: true }
+      }
       return {
         state,
         intents: [{ kind: 'promptCleanup', sessionId: target.id }],
         matched: true,
       }
+    }
     case 'session.notification': {
       const incoming = (event.params.session_id ?? event.params.sessionId) as string | undefined
       next.hookEvents = [


### PR DESCRIPTION
## Summary

Claude Code's `SessionEnd` hook fires with a `reason` field whose value is one of `clear`, `resume`, `logout`, `prompt_input_exit`, `bypass_permissions_disabled`, or `other` ([docs](https://code.claude.com/docs/en/hooks)). Only `prompt_input_exit` and `logout` actually mean the agent process exited — the rest fire while the session is alive (`/clear` resets context, `--continue` / `--resume` reattaches the worktree, etc.).

Until now, `applyHookEvent` emitted `promptCleanup` on every `session.end`, so running `/clear` (or sometimes just letting a subagent finish, depending on the flow) surfaced a "remove worktree?" dialog whose default button could nuke a still-active worktree. This is the same false-positive class that #84 tried to address from the PTY side; that approach hit the symmetric problem (PTY EOF fires on tmux detach, not only on real exits) and was reverted in 605289e.

This PR keeps the SessionEnd-based detection but filters by `reason`:

- `prompt_input_exit`, `logout` → emit `promptCleanup` (existing behaviour)
- `clear`, `resume`, `bypass_permissions_disabled`, `other`, absent — silently no-op

Conservative on purpose: an unrecognised reason leaves the card on the canvas rather than risk another spurious delete prompt. Every `session.end` also logs the resolved reason so we have ongoing visibility into which values arrive in practice.

Codex still has no `SessionEnd` hook, so codex cards continue to need manual removal after `/exit`. That's the original motivation for #84 and stays open for a follow-up that doesn't share the PTY-EOF-as-exit-signal pitfall.

## Test plan
- [x] `npx vitest run` — 389 tests pass (added 6 new cases parameterised over the documented `reason` values plus an absent-reason case)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/main/session-state-machine.ts src/main/session-state-machine.test.ts` clean
- [x] `npx prettier --check` clean
- [ ] Local Claude `/clear` → no dialog, card stays alive
- [ ] Local Claude `/exit` → cleanup dialog appears, all three buttons behave as before
- [ ] Local Claude `--continue` reattach → no dialog on the previous session.end