### PR TITLE
fix: lazy-restore local sessions to prevent OOM on startup

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,6 +42,7 @@ import {
   killSession,
   reviveSession,
   reconnectRemoteSession,
+  attachLocalSession,
   removeWorktree,
   removeSession,
   removeSessionsForHost,
@@ -424,6 +425,15 @@ app.whenReady().then(async () => {
       await reconnectRemoteSession(id)
     } catch (err) {
       console.error(`Failed to reconnect session ${id}:`, err)
+      throw err
+    }
+  })
+
+  ipcMain.handle('sessions:attach', async (_event, id: string) => {
+    try {
+      await attachLocalSession(id)
+    } catch (err) {
+      console.error(`Failed to attach session ${id}:`, err)
       throw err
     }
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,6 +43,7 @@ import {
   reviveSession,
   reconnectRemoteSession,
   attachLocalSession,
+  attachPendingLocalSessions,
   removeWorktree,
   removeSession,
   removeSessionsForHost,
@@ -491,7 +492,8 @@ app.whenReady().then(async () => {
     writePty(sessionId, data)
   })
 
-  ipcMain.handle('pty:write-batch', (_event, ids: string[], data: string) => {
+  ipcMain.handle('pty:write-batch', async (_event, ids: string[], data: string) => {
+    await attachPendingLocalSessions(ids)
     for (const id of ids) writePty(id, data)
   })
 

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1359,6 +1359,45 @@ describe('attachPendingLocalSessions', () => {
   })
 })
 
+describe('kill/revive clears stale connectionState=pending', () => {
+  // Regression: a lazy-restored local session sits in connectionState='pending'.
+  // If the user kills it (or kill→revive in one app run), the prior `pending`
+  // flag must not leak — otherwise a subsequent card/detail mount-effect
+  // attachSession would replace the live node-pty (reviveSession case) or
+  // attempt to attach a dead entry (killSession case).
+  it('killSession clears connectionState on a pending local session', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    mkdirSync(local.worktreePath, { recursive: true })
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    expect(sm.getSessions()[0].connectionState).toBe('pending')
+
+    await sm.killSession('l1')
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('dead')
+    expect(got.connectionState).toBeUndefined()
+  })
+
+  it('reviveSession clears connectionState before creating the pty', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    mkdirSync(local.worktreePath, { recursive: true })
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    await sm.killSession('l1')
+    state.createPtyCalls = []
+
+    await sm.reviveSession('l1')
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('idle')
+    expect(got.connectionState).toBeUndefined()
+    expect(state.createPtyCalls.map((c) => c.sessionId)).toEqual(['l1'])
+  })
+})
+
 describe('unexpected pty exit listener', () => {
   it('flips a local session to dead when its pty dies on its own', async () => {
     const local = baseLocalSession({ id: 'l1', status: 'idle' })

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1294,6 +1294,34 @@ describe('attachLocalSession', () => {
   })
 })
 
+describe('attachPendingLocalSessions', () => {
+  it('materializes pending local sessions and leaves remote pending sessions alone', async () => {
+    const l1 = baseLocalSession({
+      id: 'l1',
+      status: 'idle',
+      worktreePath: join(state.configDir, 'local-wt-1'),
+    })
+    const l2 = baseLocalSession({
+      id: 'l2',
+      status: 'needs_input',
+      worktreePath: join(state.configDir, 'local-wt-2'),
+    })
+    const remote = baseRemoteSession({ id: 'r1', status: 'idle' })
+    mkdirSync(l1.worktreePath, { recursive: true })
+    mkdirSync(l2.worktreePath, { recursive: true })
+    writeSessionsJson([l1, remote, l2])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.attachPendingLocalSessions(['l1', 'r1', 'l2'])
+
+    expect(state.createPtyCalls.map((c) => c.sessionId)).toEqual(['l1', 'l2'])
+    expect(sm.getSessions().find((s) => s.id === 'l1')?.connectionState).toBeUndefined()
+    expect(sm.getSessions().find((s) => s.id === 'l2')?.connectionState).toBeUndefined()
+    expect(sm.getSessions().find((s) => s.id === 'r1')?.connectionState).toBe('pending')
+  })
+})
+
 describe('unexpected pty exit listener', () => {
   it('flips a local session to dead when its pty dies on its own', async () => {
     const local = baseLocalSession({ id: 'l1', status: 'idle' })

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1214,6 +1214,43 @@ describe('restoreSessions — local lazy materialization', () => {
     expect(state.createPtyCalls).toEqual([])
   })
 
+  // Regression: a prior run can persist connectionState='pending'. If the
+  // next restore marks the session 'dead' (worktree gone, tmux unavailable,
+  // or terminal-state without live tmux), the stale pending flag must not
+  // survive — otherwise the renderer mount effects + attachLocalSession
+  // would try to materialize a session that's supposed to stay dead.
+  it('clears stale connectionState=pending when restoring to dead', async () => {
+    const local = baseLocalSession({
+      id: 'l1',
+      status: 'idle',
+      connectionState: 'pending',
+    })
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('dead')
+    expect(got.connectionState).toBeUndefined()
+  })
+
+  it('clears stale connectionState=pending for terminal-state sessions with no live tmux', async () => {
+    const local = baseLocalSession({
+      id: 'l1',
+      status: 'completed',
+      connectionState: 'pending',
+    })
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('dead')
+    expect(got.connectionState).toBeUndefined()
+  })
+
   it('marks dead when tmux is unavailable', async () => {
     const local = baseLocalSession({ id: 'l1', status: 'idle' })
     mkdirSync(local.worktreePath, { recursive: true })

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1166,6 +1166,134 @@ describe('restoreSessions — local path unchanged (AC #10 regression)', () => {
   })
 })
 
+describe('restoreSessions — local lazy materialization', () => {
+  // Spawning every persisted local session up-front cost ~1 GB per claude
+  // process and OOM'd the box when many sessions existed. The fix mirrors
+  // the remote path: mark pending and let attachLocalSession do the work
+  // on first open.
+  it('defers spawn when tmux is gone but worktree survives', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    mkdirSync(local.worktreePath, { recursive: true })
+    state.liveTmuxIds = []
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('idle')
+    expect(got.connectionState).toBe('pending')
+    expect(state.createPtyCalls).toEqual([])
+    expect(state.reattachPtyCalls).toEqual([])
+  })
+
+  it('preserves needs_input on lazy-restored sessions', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'needs_input' })
+    mkdirSync(local.worktreePath, { recursive: true })
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('needs_input')
+    expect(got.connectionState).toBe('pending')
+    expect(state.createPtyCalls).toEqual([])
+  })
+
+  it('marks dead when worktree is missing', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('dead')
+    expect(got.connectionState).toBeUndefined()
+    expect(state.createPtyCalls).toEqual([])
+  })
+
+  it('marks dead when tmux is unavailable', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    mkdirSync(local.worktreePath, { recursive: true })
+    state.tmuxAvailable = false
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+
+    sm.restoreSessions()
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('dead')
+    expect(got.connectionState).toBeUndefined()
+    expect(state.createPtyCalls).toEqual([])
+  })
+})
+
+describe('attachLocalSession', () => {
+  it('spawns the pty when tmux is gone', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    mkdirSync(local.worktreePath, { recursive: true })
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    expect(sm.getSessions()[0].connectionState).toBe('pending')
+
+    await sm.attachLocalSession('l1')
+
+    const got = sm.getSessions()[0]
+    expect(got.connectionState).toBeUndefined()
+    expect(got.status).toBe('idle')
+    expect(state.createPtyCalls.map((c) => c.sessionId)).toEqual(['l1'])
+  })
+
+  it('is a no-op when the session is not pending', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    state.liveTmuxIds = ['l1']
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    state.createPtyCalls = []
+    state.reattachPtyCalls = []
+
+    await sm.attachLocalSession('l1')
+
+    expect(state.createPtyCalls).toEqual([])
+    expect(state.reattachPtyCalls).toEqual([])
+  })
+
+  it('is a no-op on remote sessions even if pending', async () => {
+    const remote = baseRemoteSession({ id: 'r1', status: 'idle' })
+    writeSessionsJson([remote])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    expect(sm.getSessions()[0].connectionState).toBe('pending')
+
+    await sm.attachLocalSession('r1')
+
+    expect(state.createPtyCalls).toEqual([])
+    expect(state.reattachPtyCalls).toEqual([])
+    // connectionState must remain pending so reconnectRemoteSession can drive it.
+    expect(sm.getSessions()[0].connectionState).toBe('pending')
+  })
+
+  it('marks dead and clears pending when worktree disappears', async () => {
+    const local = baseLocalSession({ id: 'l1', status: 'idle' })
+    mkdirSync(local.worktreePath, { recursive: true })
+    writeSessionsJson([local])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    rmSync(local.worktreePath, { recursive: true, force: true })
+
+    await sm.attachLocalSession('l1')
+
+    const got = sm.getSessions()[0]
+    expect(got.status).toBe('dead')
+    expect(got.connectionState).toBeUndefined()
+    expect(state.createPtyCalls).toEqual([])
+  })
+})
+
 describe('unexpected pty exit listener', () => {
   it('flips a local session to dead when its pty dies on its own', async () => {
     const local = baseLocalSession({ id: 'l1', status: 'idle' })

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -2166,6 +2166,14 @@ export function restoreSessions(): void {
         continue
       }
 
+      // Drop any persisted `connectionState`; the lazy-restore branch below
+      // will set it back to 'pending'. Without this, a session that ended up
+      // 'dead' on a later run (worktree gone, tmux unavailable, or completed/
+      // error with no live tmux) would still carry the previous run's
+      // 'pending', causing the renderer mount effects + attachLocalSession to
+      // try to materialize an entry that's supposed to stay terminated.
+      session.connectionState = undefined
+
       if (
         session.status === 'running' ||
         session.status === 'idle' ||

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1298,6 +1298,48 @@ function canResumeAgent(session: Session): boolean {
   return hasClaudeConversationHistory(session.worktreePath)
 }
 
+// On-demand local attach for sessions deferred during restoreSessions().
+// Idempotent: if the pty is already live (or the session is remote/dead),
+// it's a no-op. Renderer calls this when the user opens a pending card so
+// startup doesn't fan out N concurrent agent processes.
+export async function attachLocalSession(id: string): Promise<void> {
+  const entry = sessions.get(id)
+  if (!entry) return
+  const session = entry.session
+  if (session.hostId) return
+  if (session.connectionState !== 'pending') return
+
+  if (!existsSync(session.worktreePath)) {
+    session.connectionState = undefined
+    updateSession(id, 'dead')
+    return
+  }
+
+  try {
+    if (hasTmuxSession(id)) {
+      reattachPty(id)
+    } else {
+      const canResume = canResumeAgent(session)
+      if (!canResume) {
+        console.warn(
+          `Session ${id} (${session.tool}) has no prior conversation; spawning fresh instead of resuming`
+        )
+      }
+      createPty(id, session.worktreePath, {
+        continueSession: canResume,
+        tool: session.tool,
+        agentSessionId: session.agentSessionId,
+      })
+    }
+    session.connectionState = undefined
+    onSessionsChanged()
+  } catch (err) {
+    session.connectionState = undefined
+    updateSession(id, 'dead')
+    throw err
+  }
+}
+
 export async function removeWorktree(id: string): Promise<void> {
   const entry = sessions.get(id)
   if (!entry) return
@@ -2091,7 +2133,7 @@ export function restoreSessions(): void {
     // One-time tmux precheck so we don't fire a blocking error modal per
     // session on startup when tmux is missing from PATH.
     const tmuxAvailable = isTmuxAvailable()
-    let recoveredCount = 0
+    let deferredCount = 0
     let skippedForNoTmux = 0
 
     for (const session of data) {
@@ -2132,26 +2174,14 @@ export function restoreSessions(): void {
           session.status = 'dead'
           skippedForNoTmux++
         } else {
-          // tmux server lost the session (e.g., PC reboot) but the worktree
-          // survives — auto-recreate and resume the agent conversation.
-          try {
-            const canResume = canResumeAgent(session)
-            if (!canResume) {
-              console.warn(
-                `Session ${session.id} (${session.tool}) has no prior conversation; spawning fresh instead of resuming`
-              )
-            }
-            createPty(session.id, session.worktreePath, {
-              continueSession: canResume,
-              tool: session.tool,
-              agentSessionId: session.agentSessionId,
-            })
-            session.status = resumedStatus
-            recoveredCount++
-          } catch (err) {
-            console.error(`Failed to auto-recover session ${session.id}:`, err)
-            session.status = 'dead'
-          }
+          // Lazy restore (mirrors the remote arm above): mark the session
+          // 'pending' and defer the tmux + agent spawn until the user opens
+          // the card. Spawning all persisted sessions up-front cost ~1 GB
+          // each (claude RSS) and OOM'd the box when many sessions existed.
+          // attachLocalSession() drives the on-demand spawn.
+          session.status = resumedStatus
+          session.connectionState = 'pending'
+          deferredCount++
         }
       } else if (session.status === 'completed' || session.status === 'error') {
         // Terminal states: if the tmux session is gone, the card shouldn't
@@ -2176,8 +2206,8 @@ export function restoreSessions(): void {
       )
     }
 
-    // Reattach ptys after all sessions are in the map. Sessions we just
-    // recovered already have a node-pty spawned by createPty, so the
+    // Reattach ptys after all sessions are in the map. Local sessions
+    // without a live tmux were deferred (connectionState='pending'); the
     // liveTmuxIds filter here correctly skips them.
     for (const session of data) {
       if (
@@ -2192,8 +2222,8 @@ export function restoreSessions(): void {
       }
     }
 
-    if (recoveredCount > 0) {
-      console.log(`Auto-recovered ${recoveredCount} session(s) after reboot`)
+    if (deferredCount > 0) {
+      console.log(`Deferred ${deferredCount} session(s) — will attach on demand`)
     }
 
     // Lazily resolve PR numbers for any restored session that doesn't have one

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -989,6 +989,9 @@ export async function killSession(id: string): Promise<void> {
     return
   }
   detachPty(id)
+  // Clear any lazy-restore `pending` flag so the renderer mount effects
+  // don't fire attachSession against a dead entry once kill broadcasts.
+  entry.session.connectionState = undefined
   updateSession(id, 'dead')
 }
 
@@ -1271,6 +1274,11 @@ export async function reviveSession(id: string): Promise<void> {
     return
   }
 
+  // Clear any lazy-restore `pending` flag BEFORE we (re)create the pty —
+  // otherwise a concurrent renderer mount effect could see pending+live pty
+  // and fire attachLocalSession, whose reattachPty would replace the
+  // just-created node-pty and leak the original exit handler.
+  session.connectionState = undefined
   if (hasTmuxSession(id)) {
     reattachPty(id)
   } else {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1340,6 +1340,16 @@ export async function attachLocalSession(id: string): Promise<void> {
   }
 }
 
+export async function attachPendingLocalSessions(ids: string[]): Promise<void> {
+  for (const id of ids) {
+    try {
+      await attachLocalSession(id)
+    } catch (err) {
+      console.error(`Failed to attach session ${id}:`, err)
+    }
+  }
+}
+
 export async function removeWorktree(id: string): Promise<void> {
   const entry = sessions.get(id)
   if (!entry) return

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -44,6 +44,7 @@ contextBridge.exposeInMainWorld('api', {
   killSession: (id: string) => ipcRenderer.invoke('sessions:kill', id),
   reviveSession: (id: string) => ipcRenderer.invoke('sessions:revive', id),
   reconnectSession: (id: string) => ipcRenderer.invoke('sessions:reconnect', id),
+  attachSession: (id: string) => ipcRenderer.invoke('sessions:attach', id),
   removeWorktree: (id: string) => ipcRenderer.invoke('sessions:remove-worktree', id),
   removeSession: (id: string) => ipcRenderer.invoke('sessions:remove', id),
   killSessionBatch: (ids: string[]) => ipcRenderer.invoke('sessions:kill-batch', ids),

--- a/src/renderer/SwimLanesApp.tsx
+++ b/src/renderer/SwimLanesApp.tsx
@@ -36,6 +36,19 @@ export default function SwimLanesApp() {
     return unsub
   }, [sessionIds])
 
+  // Local sessions deferred by restoreSessions() materialize their pty on
+  // first open (mirrors DetailPane). Without this, swim lanes opened from
+  // multi-selected restored sessions render inert empty terminals because
+  // there's no tmux/pty yet. attachLocalSession is idempotent on the main
+  // side, so re-firing across sessions updates is safe.
+  useEffect(() => {
+    for (const s of sessions) {
+      if (!s.hostId && s.connectionState === 'pending') {
+        void window.api.attachSession(s.id).catch(() => undefined)
+      }
+    }
+  }, [sessions])
+
   const toggleReview = useCallback((laneId: string) => {
     setLaneFlipCounts((prev) => {
       const next = new Map(prev)

--- a/src/renderer/components/DetailPane.tsx
+++ b/src/renderer/components/DetailPane.tsx
@@ -92,6 +92,16 @@ export default function DetailPane({ sessionId, sessionName, onClose }: Props) {
     return () => document.removeEventListener('keydown', handler, true)
   }, [])
 
+  // Local sessions deferred by restoreSessions() materialize their pty on
+  // first open. SessionCard.openOrSelectSession also fires this, but the
+  // pane can be opened via the `sessions:open-detail` IPC or keyboard, so
+  // we cover that path here too. attachLocalSession is idempotent.
+  useEffect(() => {
+    if (!isRemote && connectionState === 'pending') {
+      void window.api.attachSession(sessionId).catch(() => undefined)
+    }
+  }, [sessionId, isRemote, connectionState])
+
   const handleRevive = async () => {
     setReviving(true)
     try {

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -57,6 +57,12 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
     if (session.hostId && connectionState === 'pending') {
       void window.api.reconnectSession(session.id).catch(() => undefined)
     }
+    // Local sessions deferred during restoreSessions() also boot lazily so
+    // startup doesn't spawn N concurrent agent processes (which OOM'd on
+    // hosts with many sessions).
+    if (!session.hostId && connectionState === 'pending') {
+      void window.api.attachSession(session.id).catch(() => undefined)
+    }
     if (onOpenSession && session.status !== 'dead' && session.status !== 'error') {
       onOpenSession(session.id, sessionName)
     }

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -64,6 +64,7 @@ declare global {
       killSession: (id: string) => Promise<void>
       reviveSession: (id: string) => Promise<void>
       reconnectSession: (id: string) => Promise<void>
+      attachSession: (id: string) => Promise<void>
       removeWorktree: (id: string) => Promise<void>
       removeSession: (id: string) => Promise<void>
       killSessionBatch: (ids: string[]) => Promise<void>


### PR DESCRIPTION
## Summary

- `restoreSessions()` was respawning every persisted local agent up-front. Each `claude` process took ~1 GB RSS, so on machines with many sessions the cumulative spawn cost triggered a global OOM that killed Electron and the launching terminal together.
- Mirror the existing remote-restore arm for local sessions: mark them `connectionState='pending'` and defer the tmux + agent spawn until first open.
- Add `attachLocalSession(id)` (idempotent on-demand materializer), expose it via a new `sessions:attach` IPC, and fire it from `SessionCard.openOrSelectSession` and `DetailPane`'s mount effect so click, keyboard, and `sessions:open-detail` open paths are all covered.

## Behavior after the fix

On startup with N persisted local sessions, 0 agent processes spawn. The first user open of a card spawns that single pty (reattach if tmux survived, else `createPty` with the existing `canResumeAgent` check). Renamed the `recoveredCount` log line to ``Deferred ${n} session(s) — will attach on demand``.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` clean on changed files
- [x] `npx vitest run` — 767/767 passing, including 9 new cases:
  - `restoreSessions` defers spawn when tmux is gone but worktree survives
  - preserves `needs_input` on lazy-restored sessions
  - still marks `dead` on missing worktree / no tmux available
  - `attachLocalSession` spawns the pty on pending; no-ops on non-pending / remote sessions; flips to dead and clears pending when the worktree disappears
- [ ] Manual: `npm run dev` against an OOM-sized `sessions.json` (was the original repro); confirm no fan-out spawn and that opening a card materializes its terminal correctly.