### PR TITLE
fix(sessions): reuse existing session when PR branch is already checked out

### DIFF
--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1899,8 +1899,35 @@ describe('createPrSessions', () => {
     const createPrSession = vi.fn()
     const result = await sm.createPrSessions('/proj', [], null, {}, { createPrSession })
     if (typeof result === 'string') throw new Error(result)
-    expect(result).toEqual({ created: [], skipped: [], failed: [] })
+    expect(result).toEqual({ created: [], reused: [], skipped: [], failed: [] })
     expect(createPrSession).not.toHaveBeenCalled()
+  })
+
+  it('classifies a returned pre-existing session as reused, not created', async () => {
+    const sm = await loadSessionManager()
+    const existing = baseLocalSession({
+      id: 's-issue504',
+      projectPath: '/proj',
+      branch: 'vow/issue504',
+      issueNumber: 504,
+    })
+    writeSessionsJson([existing])
+    sm.restoreSessions()
+
+    // Mirrors the real createPrSession reuse path: when the PR's head branch is
+    // already checked out it returns the existing session tagged with the PR.
+    const createPrSession = vi.fn(
+      async (_projectPath: string, prNumber: number, _hostId: string | null) =>
+        ({ ...existing, prNumber }) as Session | string
+    )
+
+    const result = await sm.createPrSessions('/proj', [545], null, {}, { createPrSession })
+    if (typeof result === 'string') throw new Error(result)
+
+    expect(result.created).toEqual([])
+    expect(result.reused.map((s) => s.id)).toEqual(['s-issue504'])
+    expect(result.reused[0].prNumber).toBe(545)
+    expect(result.failed).toEqual([])
   })
 
   it('forwards the selected tool through options to createPrSession', async () => {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1790,7 +1790,11 @@ export async function createPrSession(
   // reuse it: tag it with the PR number instead of failing on `worktree add`.
   const existingForBranch = findSessionByBranch(projectPath, hostId, branch)
   if (existingForBranch) {
-    if (existingForBranch.prNumber === undefined) existingForBranch.prNumber = prNumber
+    // `gh pr view <prNumber>` just confirmed this branch belongs to the
+    // requested PR, so overwrite any stale prNumber rather than only filling
+    // an empty one — otherwise the requested PR is reported as linked but the
+    // session keeps a different number and the PR gets offered again.
+    existingForBranch.prNumber = prNumber
     if (existingForBranch.issueNumber === undefined) {
       existingForBranch.issueNumber = parseIssueNumber(prInfo.title)
     }

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1620,6 +1620,24 @@ async function listOpenIssues(
     : listRemoteOpenGhItems(projectPath, hostId, 'issue')
 }
 
+function findSessionByBranch(
+  projectPath: string,
+  hostId: string | null,
+  branch: string
+): Session | undefined {
+  for (const entry of sessions.values()) {
+    const session = entry.session
+    if (
+      session.hostId === hostId &&
+      session.projectPath === projectPath &&
+      session.branch === branch
+    ) {
+      return session
+    }
+  }
+  return undefined
+}
+
 async function createSessionsForNumbers(
   projectPath: string,
   hostId: string | null,
@@ -1635,11 +1653,18 @@ async function createSessionsForNumbers(
     if (number !== undefined) existing.add(number)
   }
 
+  // Snapshot ids that already exist so we can tell a freshly-created session
+  // apart from one that createSession reused (it returns a pre-existing session
+  // when the requested branch is already checked out).
+  const preexistingIds = new Set<string>()
+  for (const entry of sessions.values()) preexistingIds.add(entry.session.id)
+
   const { toCreate, toSkip } = selectNumbersToOpen(
     numbers.map((n) => ({ number: n })),
     existing
   )
   const created: Session[] = []
+  const reused: Session[] = []
   const failed: { number: number; error: string }[] = []
   type CreateSessionResult = { session: Session } | { number: number; error: string }
   const createOne = async (item: { number: number }): Promise<CreateSessionResult> => {
@@ -1672,13 +1697,17 @@ async function createSessionsForNumbers(
 
   for (const result of results) {
     if ('session' in result) {
-      created.push(result.session)
+      if (preexistingIds.has(result.session.id)) {
+        reused.push(result.session)
+      } else {
+        created.push(result.session)
+      }
     } else {
       failed.push(result)
     }
   }
 
-  return { created, skipped: toSkip, failed }
+  return { created, reused, skipped: toSkip, failed }
 }
 
 async function openSessionsForNumberedItems(
@@ -1755,6 +1784,20 @@ export async function createPrSession(
   }
 
   const branch = prInfo.headRefName
+
+  // A branch can only live in one worktree, so if a session already has this
+  // PR's head branch checked out (e.g. opened earlier as an issue session),
+  // reuse it: tag it with the PR number instead of failing on `worktree add`.
+  const existingForBranch = findSessionByBranch(projectPath, hostId, branch)
+  if (existingForBranch) {
+    if (existingForBranch.prNumber === undefined) existingForBranch.prNumber = prNumber
+    if (existingForBranch.issueNumber === undefined) {
+      existingForBranch.issueNumber = parseIssueNumber(prInfo.title)
+    }
+    onSessionsChanged()
+    return existingForBranch
+  }
+
   const worktreeName = `pr-${prNumber}`
   const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
 

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -182,9 +182,15 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         `Opened ${result.created.length} PR session${result.created.length === 1 ? '' : 's'}`
       )
     }
+    if (result.reused.length > 0) parts.push(`linked ${result.reused.length} existing`)
     if (result.skipped.length > 0) parts.push(`skipped ${result.skipped.length}`)
     if (result.failed.length > 0) parts.push(`${result.failed.length} failed`)
     return parts.length > 0 ? parts.join(', ') : 'No PR sessions created'
+  }
+
+  const formatPrSpecErrors = (result: OpenSessionsSummary): string => {
+    const lines = result.failed.map((f) => `#${f.number}: ${f.error}`)
+    return ['No PR sessions opened.', ...lines].join('\n')
   }
 
   const formatOpenAllSummary = (result: OpenSessionsSummary, label: 'PR' | 'issue'): string => {
@@ -414,8 +420,16 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         setUi({ pendingPrPath: null, pendingPrHostId: null, prNumberInput: '' })
         return
       }
+      // Multiple PRs: if nothing was opened or linked, keep the dialog open and
+      // surface the per-PR reasons instead of a fleeting count-only toast.
+      if (result.created.length === 0 && result.reused.length === 0) {
+        setUi({ prError: formatPrSpecErrors(result) })
+        return
+      }
       showToast(formatPrSpecSummary(result))
       setUi({ pendingPrPath: null, pendingPrHostId: null, prNumberInput: '' })
+    } catch (err) {
+      setUi({ prError: describeCreateError(err) })
     } finally {
       setUi({ creating: false })
     }

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -202,6 +202,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         `Opened ${result.created.length} ${sessionLabel}${result.created.length === 1 ? '' : 's'}`
       )
     }
+    if (result.reused.length > 0) parts.push(`linked ${result.reused.length} existing`)
     if (result.skipped.length > 0) parts.push(`skipped ${result.skipped.length}`)
     if (result.failed.length > 0) parts.push(`${result.failed.length} failed`)
     return parts.length > 0

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -980,6 +980,8 @@ body,
   color: var(--accent-red);
   font-size: 12px;
   padding: 4px 0;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .detail-pane {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -56,6 +56,7 @@ export interface Session {
 
 export interface OpenSessionsSummary {
   created: Session[]
+  reused: Session[]
   skipped: number[]
   failed: { number: number; error: string }[]
 }


### PR DESCRIPTION
## Problem

Opening PR sessions for a range (e.g. `545-550`) appeared to do **nothing**. Root cause: a PR session is created via `git worktree add .claude/worktrees/pr-<N> <pr-head-branch>`, but git refuses to check out a branch that's already checked out in another worktree. When the PRs' head branches were already open as other sessions (e.g. issue worktrees), every create failed into the `failed` bucket and the only feedback was a count-only toast that auto-dismisses after 5s — and `handleCreatePrSession` had no `catch`, so an IPC rejection produced no UI at all.

## Fix

- **Reuse instead of fail.** `createPrSession` now looks up an existing session already on the PR's head branch (new `findSessionByBranch` helper) and tags it with the PR number (and issue number if missing) instead of failing on `git worktree add`.
- **Classify reused vs created.** `createSessionsForNumbers` snapshots pre-existing session ids and buckets returned sessions accordingly; `OpenSessionsSummary` gains a `reused: Session[]` field.
- **Honest feedback.** The PR dialog now reports linked/reused counts (e.g. *"linked 5 existing, 1 failed"*), and when a multi-PR request opens **and** links nothing it keeps the dialog open and shows the per-PR reasons instead of a vanishing toast. Added a `catch` so IPC rejections surface. `.pr-error` wraps multi-line text.

## Behavior change

Re-running `545-550` now links the matching existing sessions to their PRs (they display the PR number) and reports any genuinely-missing/closed PRs, rather than silently doing nothing.

## Not included

Canvas pan/auto-focus to the linked sessions (no pan-to-session action exists today; deferred).

## Verification

`tsc`, `eslint`, `prettier`, and the full vitest suite (**403 passed**, incl. a new reuse-classification test) all green.