### PR TITLE
fix(sessions): support creating sessions from fork (cross-repo) PRs

### DIFF
--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1840,9 +1840,10 @@ describe('createPrSession fork handling', () => {
     const runGit = vi.fn(async (argv: string[]) => {
       const key = argv.join(' ')
       // A fork PR head is fetched straight from the pull ref into a PR-scoped
-      // local branch (pr-335) — origin/<branch> is never fetched, since the
-      // fork's head branch name could collide with a base-repo branch.
-      if (key === 'fetch origin pull/335/head:pr-335') return { stdout: '' }
+      // local branch (pr-335) with a FORCED refspec — origin/<branch> is never
+      // fetched, since the fork's head branch name could collide with a
+      // base-repo branch.
+      if (key === 'fetch origin +pull/335/head:pr-335') return { stdout: '' }
       if (key === 'worktree add /proj/.claude/worktrees/pr-335 pr-335') return { stdout: '' }
       throw new Error(`unexpected git ${key}`)
     })
@@ -1873,9 +1874,9 @@ describe('createPrSession fork handling', () => {
     expect(result.prNumber).toBe(335)
     expect(result.prIsFork).toBe(true)
     expect(result.prHeadRepo).toBe('contributor/s11')
-    // The pull ref was fetched into a PR-scoped local branch, and the worktree
-    // was added from it.
-    expect(runGit).toHaveBeenCalledWith(['fetch', 'origin', 'pull/335/head:pr-335'])
+    // The pull ref was force-fetched into a PR-scoped local branch, and the
+    // worktree was added from it.
+    expect(runGit).toHaveBeenCalledWith(['fetch', 'origin', '+pull/335/head:pr-335'])
     expect(runGit).toHaveBeenCalledWith([
       'worktree',
       'add',
@@ -2087,6 +2088,93 @@ describe('createPrSession fork handling', () => {
       // branch that shares the name).
       expect(worktreeTip).toBe(forkHead)
       expect(worktreeTip).not.toBe(baseSharedTip)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  gitIt('force-refreshes a stale pr-<n> branch after a PR force-push', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'fork-pr-forcepush-'))
+    try {
+      const source = join(root, 'source')
+      const remote = join(root, 'remote.git')
+      const project = join(root, 'project')
+      mkdirSync(source)
+      git(source, ['init'])
+      git(source, ['config', 'user.email', 'test@example.com'])
+      git(source, ['config', 'user.name', 'Test User'])
+      writeFileSync(join(source, 'file.txt'), 'one\n')
+      git(source, ['add', 'file.txt'])
+      git(source, ['commit', '-m', 'one'])
+      git(source, ['branch', '-M', 'main'])
+
+      // Two divergent fork-head commits (siblings off main): the old PR head and
+      // the force-pushed new head. `newHead` is NOT a descendant of `oldHead`,
+      // so a non-forced fetch into an existing pr-<n> at oldHead would reject.
+      git(source, ['checkout', '-b', 'old'])
+      writeFileSync(join(source, 'file.txt'), 'OLD head\n')
+      git(source, ['commit', '-am', 'old head'])
+      const oldHead = git(source, ['rev-parse', 'HEAD']).trim()
+      git(source, ['checkout', 'main'])
+      git(source, ['checkout', '-b', 'new'])
+      writeFileSync(join(source, 'file.txt'), 'NEW head\n')
+      git(source, ['commit', '-am', 'new head'])
+      const newHead = git(source, ['rev-parse', 'HEAD']).trim()
+      git(source, ['checkout', 'main'])
+
+      execFileSync('git', ['clone', '--bare', source, remote], { stdio: 'ignore' })
+      execFileSync('git', ['-C', remote, 'update-ref', 'refs/pull/601/head', oldHead], {
+        stdio: 'ignore',
+      })
+      execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
+      mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
+
+      // Simulate a previously-removed session: a leftover pr-601 branch at the
+      // OLD head, with no worktree checked out.
+      execFileSync('git', ['-C', project, 'fetch', 'origin', 'pull/601/head:pr-601'], {
+        stdio: 'ignore',
+      })
+      expect(git(project, ['rev-parse', 'pr-601']).trim()).toBe(oldHead)
+
+      // The contributor force-pushes: the PR head now points at the divergent
+      // new commit.
+      execFileSync('git', ['-C', remote, 'update-ref', 'refs/pull/601/head', newHead], {
+        stdio: 'ignore',
+      })
+
+      const sm = await loadSessionManager()
+      const result = await sm.createPrSession(
+        project,
+        601,
+        null,
+        {},
+        {
+          prView: async () => ({
+            headRefName: 'feature',
+            state: 'OPEN',
+            title: 'fork pr',
+            isCrossRepository: true,
+            headRepositoryOwner: { login: 'contributor' },
+            headRepository: { name: 'proj' },
+          }),
+          createSessionForWorktree: async (p, worktreePath, label, tool) =>
+            baseLocalSession({
+              id: 'pr-601',
+              projectPath: p,
+              worktreeName: label ?? 'pr-601',
+              worktreePath,
+              branch: 'pr-601',
+              tool: tool ?? 'claude',
+            }),
+        }
+      )
+
+      expect(typeof result).not.toBe('string')
+      if (typeof result === 'string') throw new Error(result)
+      // The worktree must hold the force-pushed head, not the stale old commit.
+      const worktreeTip = git(result.worktreePath, ['rev-parse', 'HEAD']).trim()
+      expect(worktreeTip).toBe(newHead)
+      expect(worktreeTip).not.toBe(oldHead)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -1844,6 +1844,8 @@ describe('createPrSession fork handling', () => {
       // fetched, since the fork's head branch name could collide with a
       // base-repo branch.
       if (key === 'fetch origin +pull/335/head:pr-335') return { stdout: '' }
+      // The PR-scoped branch is verified to exist before `worktree add`.
+      if (key === 'rev-parse --verify --quiet refs/heads/pr-335') return { stdout: 'abc123\n' }
       if (key === 'worktree add /proj/.claude/worktrees/pr-335 pr-335') return { stdout: '' }
       throw new Error(`unexpected git ${key}`)
     })
@@ -1894,6 +1896,38 @@ describe('createPrSession fork handling', () => {
       'pr-335',
       'origin/codex/fix-x',
     ])
+  })
+
+  it('errors without running worktree add when the fork pull-ref fetch fails', async () => {
+    const sm = await loadSessionManager()
+    const runGit = vi.fn(async (argv: string[]) => {
+      const key = argv.join(' ')
+      // The pull ref can't be fetched (offline / transient), so the PR-scoped
+      // branch is never created.
+      if (key === 'fetch origin +pull/335/head:pr-335') throw new Error('network down')
+      if (key === 'rev-parse --verify --quiet refs/heads/pr-335') throw new Error('no such ref')
+      throw new Error(`unexpected git ${key}`)
+    })
+    const createSessionForWorktree = vi.fn()
+
+    const result = await sm.createPrSession(
+      '/proj',
+      335,
+      null,
+      {},
+      { runGit, prView: forkPrView, createSessionForWorktree }
+    )
+
+    // No local pr-335 exists, so we must fail explicitly rather than let
+    // `git worktree add pr-335` DWIM to a remote-tracking origin/pr-335.
+    expect(typeof result).toBe('string')
+    expect(runGit).not.toHaveBeenCalledWith([
+      'worktree',
+      'add',
+      '/proj/.claude/worktrees/pr-335',
+      'pr-335',
+    ])
+    expect(createSessionForWorktree).not.toHaveBeenCalled()
   })
 
   it('does not fetch the pull ref for a same-repo PR', async () => {
@@ -2179,6 +2213,66 @@ describe('createPrSession fork handling', () => {
       rmSync(root, { recursive: true, force: true })
     }
   })
+
+  gitIt(
+    'fails a fork PR rather than DWIM to origin/pr-<n> when the pull ref is missing',
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), 'fork-pr-dwim-'))
+      try {
+        const source = join(root, 'source')
+        const remote = join(root, 'remote.git')
+        const project = join(root, 'project')
+        mkdirSync(source)
+        git(source, ['init'])
+        git(source, ['config', 'user.email', 'test@example.com'])
+        git(source, ['config', 'user.name', 'Test User'])
+        writeFileSync(join(source, 'file.txt'), 'one\n')
+        git(source, ['add', 'file.txt'])
+        git(source, ['commit', '-m', 'one'])
+        git(source, ['branch', '-M', 'main'])
+        // The base repo has a branch literally named "pr-808" (unrelated commits).
+        // There is NO refs/pull/808/head, so the fork pull-ref fetch will fail.
+        git(source, ['checkout', '-b', 'pr-808'])
+        writeFileSync(join(source, 'file.txt'), 'WRONG base pr-808 branch\n')
+        git(source, ['commit', '-am', 'base pr-808'])
+        const baseBranchTip = git(source, ['rev-parse', 'HEAD']).trim()
+        git(source, ['checkout', 'main'])
+
+        execFileSync('git', ['clone', '--bare', source, remote], { stdio: 'ignore' })
+        execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
+        mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
+        // origin/pr-808 now exists as a remote-tracking branch in the clone.
+        expect(git(project, ['rev-parse', 'origin/pr-808']).trim()).toBe(baseBranchTip)
+
+        const sm = await loadSessionManager()
+        const result = await sm.createPrSession(
+          project,
+          808,
+          null,
+          {},
+          {
+            prView: async () => ({
+              headRefName: 'feature',
+              state: 'OPEN',
+              title: 'fork pr',
+              isCrossRepository: true,
+              headRepositoryOwner: { login: 'contributor' },
+              headRepository: { name: 'proj' },
+            }),
+            createSessionForWorktree: async (p, worktreePath) =>
+              baseLocalSession({ id: 'pr-808', projectPath: p, worktreePath }),
+          }
+        )
+
+        // The pull ref is missing, so creation must fail explicitly — not DWIM a
+        // worktree onto origin/pr-808 (the unrelated base branch).
+        expect(typeof result).toBe('string')
+        expect(existsSync(join(project, '.claude', 'worktrees', 'pr-808'))).toBe(false)
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
 
   gitIt('does not let two fork PRs sharing a head branch name collide', async () => {
     const root = mkdtempSync(join(tmpdir(), 'fork-pr-collide-'))

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1841,8 +1841,10 @@ describe('createPrSession fork handling', () => {
       const key = argv.join(' ')
       // Same-repo fetch fails: a fork PR head is not on origin/<branch>.
       if (key === 'fetch origin codex/fix-x') throw new Error('couldn’t find remote ref')
-      if (key === 'fetch origin pull/335/head:codex/fix-x') return { stdout: '' }
-      if (key === 'worktree add /proj/.claude/worktrees/pr-335 codex/fix-x') return { stdout: '' }
+      // The pull ref is fetched into a PR-scoped local branch (pr-335), not the
+      // fork's head branch name (which isn't unique across forks).
+      if (key === 'fetch origin pull/335/head:pr-335') return { stdout: '' }
+      if (key === 'worktree add /proj/.claude/worktrees/pr-335 pr-335') return { stdout: '' }
       throw new Error(`unexpected git ${key}`)
     })
     const createSessionForWorktree = vi.fn(async () =>
@@ -1851,7 +1853,7 @@ describe('createPrSession fork handling', () => {
         projectPath: '/proj',
         worktreeName: 'pr-335',
         worktreePath: '/proj/.claude/worktrees/pr-335',
-        branch: 'codex/fix-x',
+        branch: 'pr-335',
       })
     )
 
@@ -1872,21 +1874,21 @@ describe('createPrSession fork handling', () => {
     expect(result.prNumber).toBe(335)
     expect(result.prIsFork).toBe(true)
     expect(result.prHeadRepo).toBe('contributor/s11')
-    // The pull ref was fetched into a local branch, and the worktree was added
-    // from that branch — never from the non-existent origin/<branch>.
-    expect(runGit).toHaveBeenCalledWith(['fetch', 'origin', 'pull/335/head:codex/fix-x'])
+    // The pull ref was fetched into a PR-scoped local branch, and the worktree
+    // was added from it — never from the non-existent origin/<branch>.
+    expect(runGit).toHaveBeenCalledWith(['fetch', 'origin', 'pull/335/head:pr-335'])
     expect(runGit).toHaveBeenCalledWith([
       'worktree',
       'add',
       '/proj/.claude/worktrees/pr-335',
-      'codex/fix-x',
+      'pr-335',
     ])
     expect(runGit).not.toHaveBeenCalledWith([
       'worktree',
       'add',
       '/proj/.claude/worktrees/pr-335',
       '-b',
-      'codex/fix-x',
+      'pr-335',
       'origin/codex/fix-x',
     ])
   })
@@ -1988,7 +1990,7 @@ describe('createPrSession fork handling', () => {
               projectPath: p,
               worktreeName: label ?? 'pr-335',
               worktreePath,
-              branch: 'codex/fix-x',
+              branch: 'pr-335',
               tool: tool ?? 'claude',
             }),
         }
@@ -1999,6 +2001,85 @@ describe('createPrSession fork handling', () => {
       expect(result.prIsFork).toBe(true)
       const worktreeTip = git(result.worktreePath, ['rev-parse', 'HEAD']).trim()
       expect(worktreeTip).toBe(prHead)
+      // Fork PRs check out under a PR-scoped local branch, not the fork's head
+      // branch name (which isn't unique across forks).
+      const worktreeBranch = git(result.worktreePath, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()
+      expect(worktreeBranch).toBe('pr-335')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  gitIt('does not let two fork PRs sharing a head branch name collide', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'fork-pr-collide-'))
+    try {
+      const source = join(root, 'source')
+      const remote = join(root, 'remote.git')
+      const project = join(root, 'project')
+      mkdirSync(source)
+      git(source, ['init'])
+      git(source, ['config', 'user.email', 'test@example.com'])
+      git(source, ['config', 'user.name', 'Test User'])
+      writeFileSync(join(source, 'file.txt'), 'one\n')
+      git(source, ['add', 'file.txt'])
+      git(source, ['commit', '-m', 'one'])
+      git(source, ['branch', '-M', 'main'])
+
+      // Two different fork heads that happen to share the branch name
+      // "shared-fix": alice's PR #401 and bob's PR #402 point at different tips.
+      git(source, ['checkout', '-b', 'alice'])
+      writeFileSync(join(source, 'file.txt'), 'alice\n')
+      git(source, ['commit', '-am', 'alice head'])
+      const aliceHead = git(source, ['rev-parse', 'HEAD']).trim()
+      git(source, ['checkout', 'main'])
+      git(source, ['checkout', '-b', 'bob'])
+      writeFileSync(join(source, 'file.txt'), 'bob\n')
+      git(source, ['commit', '-am', 'bob head'])
+      const bobHead = git(source, ['rev-parse', 'HEAD']).trim()
+      git(source, ['checkout', 'main'])
+
+      execFileSync('git', ['clone', '--bare', source, remote], { stdio: 'ignore' })
+      execFileSync('git', ['-C', remote, 'update-ref', 'refs/pull/401/head', aliceHead], {
+        stdio: 'ignore',
+      })
+      execFileSync('git', ['-C', remote, 'update-ref', 'refs/pull/402/head', bobHead], {
+        stdio: 'ignore',
+      })
+      execFileSync('git', ['-C', remote, 'branch', '-D', 'alice'], { stdio: 'ignore' })
+      execFileSync('git', ['-C', remote, 'branch', '-D', 'bob'], { stdio: 'ignore' })
+      execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
+      mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
+
+      const forkView = (owner: string) => async () => ({
+        headRefName: 'shared-fix',
+        state: 'OPEN',
+        title: `fix from ${owner}`,
+        isCrossRepository: true,
+        headRepositoryOwner: { login: owner },
+        headRepository: { name: 'proj' },
+      })
+
+      // Real adopt (no createSessionForWorktree stub) so sessions register in
+      // the internal map and the reuse lookups can see the first session.
+      const sm = await loadSessionManager()
+      const a = await sm.createPrSession(project, 401, null, {}, { prView: forkView('alice') })
+      const b = await sm.createPrSession(project, 402, null, {}, { prView: forkView('bob') })
+
+      expect(typeof a).not.toBe('string')
+      expect(typeof b).not.toBe('string')
+      if (typeof a === 'string') throw new Error(a)
+      if (typeof b === 'string') throw new Error(b)
+
+      // Distinct sessions — the second PR must not hijack the first.
+      expect(a.id).not.toBe(b.id)
+      expect(a.prNumber).toBe(401)
+      expect(b.prNumber).toBe(402)
+      expect(a.prHeadRepo).toBe('alice/proj')
+      expect(b.prHeadRepo).toBe('bob/proj')
+      expect(a.worktreePath).not.toBe(b.worktreePath)
+      // Each worktree points at its own PR head, not the other's.
+      expect(git(a.worktreePath, ['rev-parse', 'HEAD']).trim()).toBe(aliceHead)
+      expect(git(b.worktreePath, ['rev-parse', 'HEAD']).trim()).toBe(bobHead)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1835,14 +1835,13 @@ describe('createPrSession fork handling', () => {
     headRepository: { name: 's11' },
   })
 
-  it('falls back to refs/pull/<n>/head for a cross-repository (fork) PR', async () => {
+  it('fetches refs/pull/<n>/head for a fork PR and never touches origin/<branch>', async () => {
     const sm = await loadSessionManager()
     const runGit = vi.fn(async (argv: string[]) => {
       const key = argv.join(' ')
-      // Same-repo fetch fails: a fork PR head is not on origin/<branch>.
-      if (key === 'fetch origin codex/fix-x') throw new Error('couldn’t find remote ref')
-      // The pull ref is fetched into a PR-scoped local branch (pr-335), not the
-      // fork's head branch name (which isn't unique across forks).
+      // A fork PR head is fetched straight from the pull ref into a PR-scoped
+      // local branch (pr-335) — origin/<branch> is never fetched, since the
+      // fork's head branch name could collide with a base-repo branch.
       if (key === 'fetch origin pull/335/head:pr-335') return { stdout: '' }
       if (key === 'worktree add /proj/.claude/worktrees/pr-335 pr-335') return { stdout: '' }
       throw new Error(`unexpected git ${key}`)
@@ -1875,7 +1874,7 @@ describe('createPrSession fork handling', () => {
     expect(result.prIsFork).toBe(true)
     expect(result.prHeadRepo).toBe('contributor/s11')
     // The pull ref was fetched into a PR-scoped local branch, and the worktree
-    // was added from it — never from the non-existent origin/<branch>.
+    // was added from it.
     expect(runGit).toHaveBeenCalledWith(['fetch', 'origin', 'pull/335/head:pr-335'])
     expect(runGit).toHaveBeenCalledWith([
       'worktree',
@@ -1883,6 +1882,9 @@ describe('createPrSession fork handling', () => {
       '/proj/.claude/worktrees/pr-335',
       'pr-335',
     ])
+    // origin/<branch> is never fetched or used for a fork PR — the fork's head
+    // branch name could collide with a base-repo branch of the same name.
+    expect(runGit).not.toHaveBeenCalledWith(['fetch', 'origin', 'codex/fix-x'])
     expect(runGit).not.toHaveBeenCalledWith([
       'worktree',
       'add',
@@ -2005,6 +2007,86 @@ describe('createPrSession fork handling', () => {
       // branch name (which isn't unique across forks).
       const worktreeBranch = git(result.worktreePath, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()
       expect(worktreeBranch).toBe('pr-335')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  gitIt('checks out the fork PR head, not the base branch, on a name collision', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'fork-pr-namecollide-'))
+    try {
+      const source = join(root, 'source')
+      const remote = join(root, 'remote.git')
+      const project = join(root, 'project')
+      mkdirSync(source)
+      git(source, ['init'])
+      git(source, ['config', 'user.email', 'test@example.com'])
+      git(source, ['config', 'user.name', 'Test User'])
+      writeFileSync(join(source, 'file.txt'), 'one\n')
+      git(source, ['add', 'file.txt'])
+      git(source, ['commit', '-m', 'one'])
+      git(source, ['branch', '-M', 'main'])
+
+      // The base repo HAS a branch named "shared" (the fork PR's head branch
+      // name collides with it) pointing at different commits than the PR head.
+      git(source, ['checkout', '-b', 'shared'])
+      writeFileSync(join(source, 'file.txt'), 'BASE shared branch\n')
+      git(source, ['commit', '-am', 'base shared'])
+      const baseSharedTip = git(source, ['rev-parse', 'HEAD']).trim()
+      // The actual fork PR head, on its own branch, with different content.
+      git(source, ['checkout', 'main'])
+      git(source, ['checkout', '-b', 'fork-head'])
+      writeFileSync(join(source, 'file.txt'), 'FORK pr head\n')
+      git(source, ['commit', '-am', 'fork head'])
+      const forkHead = git(source, ['rev-parse', 'HEAD']).trim()
+      git(source, ['checkout', 'main'])
+
+      execFileSync('git', ['clone', '--bare', source, remote], { stdio: 'ignore' })
+      // Keep refs/heads/shared on origin (the collision); expose the fork PR head
+      // only through refs/pull/501/head and drop its branch.
+      execFileSync('git', ['-C', remote, 'update-ref', 'refs/pull/501/head', forkHead], {
+        stdio: 'ignore',
+      })
+      execFileSync('git', ['-C', remote, 'branch', '-D', 'fork-head'], { stdio: 'ignore' })
+      execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
+      mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
+
+      const sm = await loadSessionManager()
+      const result = await sm.createPrSession(
+        project,
+        501,
+        null,
+        {},
+        {
+          // The fork PR's head branch is named "shared" — the same name as the
+          // base-repo branch that exists on origin.
+          prView: async () => ({
+            headRefName: 'shared',
+            state: 'OPEN',
+            title: 'fork pr',
+            isCrossRepository: true,
+            headRepositoryOwner: { login: 'contributor' },
+            headRepository: { name: 'proj' },
+          }),
+          createSessionForWorktree: async (p, worktreePath, label, tool) =>
+            baseLocalSession({
+              id: 'pr-501',
+              projectPath: p,
+              worktreeName: label ?? 'pr-501',
+              worktreePath,
+              branch: 'pr-501',
+              tool: tool ?? 'claude',
+            }),
+        }
+      )
+
+      expect(typeof result).not.toBe('string')
+      if (typeof result === 'string') throw new Error(result)
+      const worktreeTip = git(result.worktreePath, ['rev-parse', 'HEAD']).trim()
+      // The worktree must hold the fork PR head, NOT origin/shared (the base
+      // branch that shares the name).
+      expect(worktreeTip).toBe(forkHead)
+      expect(worktreeTip).not.toBe(baseSharedTip)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1825,6 +1825,186 @@ describe('openSessionsForOpenIssues', () => {
   })
 })
 
+describe('createPrSession fork handling', () => {
+  const forkPrView = async () => ({
+    headRefName: 'codex/fix-x',
+    state: 'OPEN',
+    title: 'docs: fix x',
+    isCrossRepository: true,
+    headRepositoryOwner: { login: 'contributor' },
+    headRepository: { name: 's11' },
+  })
+
+  it('falls back to refs/pull/<n>/head for a cross-repository (fork) PR', async () => {
+    const sm = await loadSessionManager()
+    const runGit = vi.fn(async (argv: string[]) => {
+      const key = argv.join(' ')
+      // Same-repo fetch fails: a fork PR head is not on origin/<branch>.
+      if (key === 'fetch origin codex/fix-x') throw new Error('couldn’t find remote ref')
+      if (key === 'fetch origin pull/335/head:codex/fix-x') return { stdout: '' }
+      if (key === 'worktree add /proj/.claude/worktrees/pr-335 codex/fix-x') return { stdout: '' }
+      throw new Error(`unexpected git ${key}`)
+    })
+    const createSessionForWorktree = vi.fn(async () =>
+      baseLocalSession({
+        id: 'pr-335',
+        projectPath: '/proj',
+        worktreeName: 'pr-335',
+        worktreePath: '/proj/.claude/worktrees/pr-335',
+        branch: 'codex/fix-x',
+      })
+    )
+
+    const result = await sm.createPrSession(
+      '/proj',
+      335,
+      null,
+      {},
+      {
+        runGit,
+        prView: forkPrView,
+        createSessionForWorktree,
+      }
+    )
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result === 'string') throw new Error(result)
+    expect(result.prNumber).toBe(335)
+    expect(result.prIsFork).toBe(true)
+    expect(result.prHeadRepo).toBe('contributor/s11')
+    // The pull ref was fetched into a local branch, and the worktree was added
+    // from that branch — never from the non-existent origin/<branch>.
+    expect(runGit).toHaveBeenCalledWith(['fetch', 'origin', 'pull/335/head:codex/fix-x'])
+    expect(runGit).toHaveBeenCalledWith([
+      'worktree',
+      'add',
+      '/proj/.claude/worktrees/pr-335',
+      'codex/fix-x',
+    ])
+    expect(runGit).not.toHaveBeenCalledWith([
+      'worktree',
+      'add',
+      '/proj/.claude/worktrees/pr-335',
+      '-b',
+      'codex/fix-x',
+      'origin/codex/fix-x',
+    ])
+  })
+
+  it('does not fetch the pull ref for a same-repo PR', async () => {
+    const sm = await loadSessionManager()
+    const runGit = vi.fn(async (argv: string[]) => {
+      const key = argv.join(' ')
+      if (key === 'fetch origin feat-y') return { stdout: '' }
+      if (key === 'worktree add /proj/.claude/worktrees/pr-7 feat-y') return { stdout: '' }
+      throw new Error(`unexpected git ${key}`)
+    })
+    const createSessionForWorktree = vi.fn(async () =>
+      baseLocalSession({
+        id: 'pr-7',
+        projectPath: '/proj',
+        worktreeName: 'pr-7',
+        worktreePath: '/proj/.claude/worktrees/pr-7',
+        branch: 'feat-y',
+      })
+    )
+
+    const result = await sm.createPrSession(
+      '/proj',
+      7,
+      null,
+      {},
+      {
+        runGit,
+        prView: async () => ({ headRefName: 'feat-y', state: 'OPEN', title: 'feat' }),
+        createSessionForWorktree,
+      }
+    )
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result === 'string') throw new Error(result)
+    expect(result.prNumber).toBe(7)
+    expect(result.prIsFork).toBeUndefined()
+    expect(result.prHeadRepo).toBeUndefined()
+    expect(runGit).not.toHaveBeenCalledWith(['fetch', 'origin', 'pull/7/head:feat-y'])
+  })
+
+  const gitIt = canRunGit ? it : it.skip
+
+  function git(cwd: string, args: string[]): string {
+    return execFileSync('git', args, { cwd, encoding: 'utf-8' })
+  }
+
+  gitIt('checks out a fork PR head end-to-end via the pull ref (real git)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'fork-pr-'))
+    try {
+      const source = join(root, 'source')
+      const remote = join(root, 'remote.git')
+      const project = join(root, 'project')
+      mkdirSync(source)
+      git(source, ['init'])
+      git(source, ['config', 'user.email', 'test@example.com'])
+      git(source, ['config', 'user.name', 'Test User'])
+      writeFileSync(join(source, 'file.txt'), 'one\n')
+      git(source, ['add', 'file.txt'])
+      git(source, ['commit', '-m', 'one'])
+      git(source, ['branch', '-M', 'main'])
+      // The PR head lives on its own branch (stands in for the fork). Capture
+      // its tip, then keep main where it is.
+      git(source, ['checkout', '-b', 'pr-src'])
+      writeFileSync(join(source, 'file.txt'), 'two\n')
+      git(source, ['commit', '-am', 'pr head'])
+      const prHead = git(source, ['rev-parse', 'HEAD']).trim()
+      git(source, ['checkout', 'main'])
+
+      execFileSync('git', ['clone', '--bare', source, remote], { stdio: 'ignore' })
+      // Expose the head only through GitHub's refs/pull/<n>/head, then drop the
+      // branch so origin has no refs/heads/<branch> — exactly a fork PR.
+      execFileSync('git', ['-C', remote, 'update-ref', 'refs/pull/335/head', prHead], {
+        stdio: 'ignore',
+      })
+      execFileSync('git', ['-C', remote, 'branch', '-D', 'pr-src'], { stdio: 'ignore' })
+      execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
+      mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
+
+      const sm = await loadSessionManager()
+      const result = await sm.createPrSession(
+        project,
+        335,
+        null,
+        {},
+        {
+          prView: async () => ({
+            headRefName: 'codex/fix-x',
+            state: 'OPEN',
+            title: 'docs: fix x',
+            isCrossRepository: true,
+            headRepositoryOwner: { login: 'contributor' },
+            headRepository: { name: 's11' },
+          }),
+          createSessionForWorktree: async (p, worktreePath, label, tool) =>
+            baseLocalSession({
+              id: 'pr-335',
+              projectPath: p,
+              worktreeName: label ?? 'pr-335',
+              worktreePath,
+              branch: 'codex/fix-x',
+              tool: tool ?? 'claude',
+            }),
+        }
+      )
+
+      expect(typeof result).not.toBe('string')
+      if (typeof result === 'string') throw new Error(result)
+      expect(result.prIsFork).toBe(true)
+      const worktreeTip = git(result.worktreePath, ['rev-parse', 'HEAD']).trim()
+      expect(worktreeTip).toBe(prHead)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('createPrSessions', () => {
   it('skips numbers that already have a session and creates the rest', async () => {
     const sm = await loadSessionManager()

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1840,13 +1840,13 @@ describe('createPrSession fork handling', () => {
     const runGit = vi.fn(async (argv: string[]) => {
       const key = argv.join(' ')
       // A fork PR head is fetched straight from the pull ref into a PR-scoped
-      // local branch (pr-335) with a FORCED refspec — origin/<branch> is never
-      // fetched, since the fork's head branch name could collide with a
-      // base-repo branch.
-      if (key === 'fetch origin +pull/335/head:pr-335') return { stdout: '' }
+      // local branch namespaced under pewpew/ with a FORCED refspec —
+      // origin/<branch> is never fetched, and the pewpew/ namespace keeps the
+      // forced fetch from clobbering an unrelated user branch named pr-335.
+      if (key === 'fetch origin +pull/335/head:pewpew/pr-335') return { stdout: '' }
       // The PR-scoped branch is verified to exist before `worktree add`.
-      if (key === 'rev-parse --verify --quiet refs/heads/pr-335') return { stdout: 'abc123\n' }
-      if (key === 'worktree add /proj/.claude/worktrees/pr-335 pr-335') return { stdout: '' }
+      if (key === 'rev-parse --verify --quiet refs/heads/pewpew/pr-335') return { stdout: 'abc\n' }
+      if (key === 'worktree add /proj/.claude/worktrees/pr-335 pewpew/pr-335') return { stdout: '' }
       throw new Error(`unexpected git ${key}`)
     })
     const createSessionForWorktree = vi.fn(async () =>
@@ -1855,7 +1855,7 @@ describe('createPrSession fork handling', () => {
         projectPath: '/proj',
         worktreeName: 'pr-335',
         worktreePath: '/proj/.claude/worktrees/pr-335',
-        branch: 'pr-335',
+        branch: 'pewpew/pr-335',
       })
     )
 
@@ -1876,14 +1876,14 @@ describe('createPrSession fork handling', () => {
     expect(result.prNumber).toBe(335)
     expect(result.prIsFork).toBe(true)
     expect(result.prHeadRepo).toBe('contributor/s11')
-    // The pull ref was force-fetched into a PR-scoped local branch, and the
-    // worktree was added from it.
-    expect(runGit).toHaveBeenCalledWith(['fetch', 'origin', '+pull/335/head:pr-335'])
+    // The pull ref was force-fetched into a pewpew-namespaced PR-scoped local
+    // branch, and the worktree was added from it.
+    expect(runGit).toHaveBeenCalledWith(['fetch', 'origin', '+pull/335/head:pewpew/pr-335'])
     expect(runGit).toHaveBeenCalledWith([
       'worktree',
       'add',
       '/proj/.claude/worktrees/pr-335',
-      'pr-335',
+      'pewpew/pr-335',
     ])
     // origin/<branch> is never fetched or used for a fork PR — the fork's head
     // branch name could collide with a base-repo branch of the same name.
@@ -1893,7 +1893,7 @@ describe('createPrSession fork handling', () => {
       'add',
       '/proj/.claude/worktrees/pr-335',
       '-b',
-      'pr-335',
+      'pewpew/pr-335',
       'origin/codex/fix-x',
     ])
   })
@@ -1904,8 +1904,9 @@ describe('createPrSession fork handling', () => {
       const key = argv.join(' ')
       // The pull ref can't be fetched (offline / transient), so the PR-scoped
       // branch is never created.
-      if (key === 'fetch origin +pull/335/head:pr-335') throw new Error('network down')
-      if (key === 'rev-parse --verify --quiet refs/heads/pr-335') throw new Error('no such ref')
+      if (key === 'fetch origin +pull/335/head:pewpew/pr-335') throw new Error('network down')
+      if (key === 'rev-parse --verify --quiet refs/heads/pewpew/pr-335')
+        throw new Error('no such ref')
       throw new Error(`unexpected git ${key}`)
     })
     const createSessionForWorktree = vi.fn()
@@ -1918,14 +1919,14 @@ describe('createPrSession fork handling', () => {
       { runGit, prView: forkPrView, createSessionForWorktree }
     )
 
-    // No local pr-335 exists, so we must fail explicitly rather than let
-    // `git worktree add pr-335` DWIM to a remote-tracking origin/pr-335.
+    // No local pewpew/pr-335 exists, so we must fail explicitly rather than let
+    // `git worktree add` DWIM to a remote-tracking origin/pewpew/pr-335.
     expect(typeof result).toBe('string')
     expect(runGit).not.toHaveBeenCalledWith([
       'worktree',
       'add',
       '/proj/.claude/worktrees/pr-335',
-      'pr-335',
+      'pewpew/pr-335',
     ])
     expect(createSessionForWorktree).not.toHaveBeenCalled()
   })
@@ -2027,7 +2028,7 @@ describe('createPrSession fork handling', () => {
               projectPath: p,
               worktreeName: label ?? 'pr-335',
               worktreePath,
-              branch: 'pr-335',
+              branch: 'pewpew/pr-335',
               tool: tool ?? 'claude',
             }),
         }
@@ -2038,10 +2039,11 @@ describe('createPrSession fork handling', () => {
       expect(result.prIsFork).toBe(true)
       const worktreeTip = git(result.worktreePath, ['rev-parse', 'HEAD']).trim()
       expect(worktreeTip).toBe(prHead)
-      // Fork PRs check out under a PR-scoped local branch, not the fork's head
-      // branch name (which isn't unique across forks).
+      // Fork PRs check out under a pewpew-namespaced PR-scoped local branch, not
+      // the fork's head branch name (which isn't unique across forks) and not a
+      // bare pr-<n> (which could clobber a user branch).
       const worktreeBranch = git(result.worktreePath, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()
-      expect(worktreeBranch).toBe('pr-335')
+      expect(worktreeBranch).toBe('pewpew/pr-335')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -2109,7 +2111,7 @@ describe('createPrSession fork handling', () => {
               projectPath: p,
               worktreeName: label ?? 'pr-501',
               worktreePath,
-              branch: 'pr-501',
+              branch: 'pewpew/pr-501',
               tool: tool ?? 'claude',
             }),
         }
@@ -2144,7 +2146,7 @@ describe('createPrSession fork handling', () => {
 
       // Two divergent fork-head commits (siblings off main): the old PR head and
       // the force-pushed new head. `newHead` is NOT a descendant of `oldHead`,
-      // so a non-forced fetch into an existing pr-<n> at oldHead would reject.
+      // so a non-forced fetch into an existing pewpew/pr-<n> at oldHead rejects.
       git(source, ['checkout', '-b', 'old'])
       writeFileSync(join(source, 'file.txt'), 'OLD head\n')
       git(source, ['commit', '-am', 'old head'])
@@ -2163,12 +2165,12 @@ describe('createPrSession fork handling', () => {
       execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
       mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
 
-      // Simulate a previously-removed session: a leftover pr-601 branch at the
-      // OLD head, with no worktree checked out.
-      execFileSync('git', ['-C', project, 'fetch', 'origin', 'pull/601/head:pr-601'], {
+      // Simulate a previously-removed session: a leftover pewpew/pr-601 branch
+      // at the OLD head, with no worktree checked out.
+      execFileSync('git', ['-C', project, 'fetch', 'origin', 'pull/601/head:pewpew/pr-601'], {
         stdio: 'ignore',
       })
-      expect(git(project, ['rev-parse', 'pr-601']).trim()).toBe(oldHead)
+      expect(git(project, ['rev-parse', 'pewpew/pr-601']).trim()).toBe(oldHead)
 
       // The contributor force-pushes: the PR head now points at the divergent
       // new commit.
@@ -2197,7 +2199,7 @@ describe('createPrSession fork handling', () => {
               projectPath: p,
               worktreeName: label ?? 'pr-601',
               worktreePath,
-              branch: 'pr-601',
+              branch: 'pewpew/pr-601',
               tool: tool ?? 'claude',
             }),
         }
@@ -2215,7 +2217,7 @@ describe('createPrSession fork handling', () => {
   })
 
   gitIt(
-    'fails a fork PR rather than DWIM to origin/pr-<n> when the pull ref is missing',
+    'fails a fork PR rather than DWIM to origin/pewpew/pr-<n> when the pull ref is missing',
     async () => {
       const root = mkdtempSync(join(tmpdir(), 'fork-pr-dwim-'))
       try {
@@ -2230,19 +2232,21 @@ describe('createPrSession fork handling', () => {
         git(source, ['add', 'file.txt'])
         git(source, ['commit', '-m', 'one'])
         git(source, ['branch', '-M', 'main'])
-        // The base repo has a branch literally named "pr-808" (unrelated commits).
-        // There is NO refs/pull/808/head, so the fork pull-ref fetch will fail.
-        git(source, ['checkout', '-b', 'pr-808'])
-        writeFileSync(join(source, 'file.txt'), 'WRONG base pr-808 branch\n')
-        git(source, ['commit', '-am', 'base pr-808'])
+        // The base repo has a branch matching pewpew's namespaced fork branch
+        // name (unrelated commits). There is NO refs/pull/808/head, so the fork
+        // pull-ref fetch will fail and `git worktree add <path> pewpew/pr-808`
+        // would otherwise DWIM onto origin/pewpew/pr-808.
+        git(source, ['checkout', '-b', 'pewpew/pr-808'])
+        writeFileSync(join(source, 'file.txt'), 'WRONG base branch\n')
+        git(source, ['commit', '-am', 'base pewpew/pr-808'])
         const baseBranchTip = git(source, ['rev-parse', 'HEAD']).trim()
         git(source, ['checkout', 'main'])
 
         execFileSync('git', ['clone', '--bare', source, remote], { stdio: 'ignore' })
         execFileSync('git', ['clone', remote, project], { stdio: 'ignore' })
         mkdirSync(join(project, '.claude', 'worktrees'), { recursive: true })
-        // origin/pr-808 now exists as a remote-tracking branch in the clone.
-        expect(git(project, ['rev-parse', 'origin/pr-808']).trim()).toBe(baseBranchTip)
+        // origin/pewpew/pr-808 now exists as a remote-tracking branch.
+        expect(git(project, ['rev-parse', 'origin/pewpew/pr-808']).trim()).toBe(baseBranchTip)
 
         const sm = await loadSessionManager()
         const result = await sm.createPrSession(
@@ -2265,7 +2269,7 @@ describe('createPrSession fork handling', () => {
         )
 
         // The pull ref is missing, so creation must fail explicitly — not DWIM a
-        // worktree onto origin/pr-808 (the unrelated base branch).
+        // worktree onto origin/pewpew/pr-808 (the unrelated base branch).
         expect(typeof result).toBe('string')
         expect(existsSync(join(project, '.claude', 'worktrees', 'pr-808'))).toBe(false)
       } finally {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -844,19 +844,13 @@ async function createRemotePrSession(
     // branch name so pushes update the PR via origin/<branch>.
     const localBranch = isFork ? worktreeName : branch
 
-    // Fetch the PR head. execRemote resolves (rather than rejecting) on a
-    // non-zero git exit, so probe result.code to decide whether to fall back
-    // to GitHub's refs/pull/<n>/head — the only origin ref a cross-repository
-    // (fork) PR head is reachable through. Fetch it into the local branch.
-    const fetched = await execRemote(host, [
-      'git',
-      '-C',
-      projectPath,
-      'fetch',
-      'origin',
-      branch,
-    ]).catch(() => ({ code: 1 }))
-    if (fetched.code !== 0) {
+    // Fetch the PR head into the local branch we'll check out. A fork PR head
+    // is ONLY authoritative via GitHub's refs/pull/<n>/head: never fetch
+    // origin/<branch>, because if the fork's head branch name also exists on
+    // the base repo (e.g. a fork whose head branch is `main`) that fetch would
+    // succeed and we'd check out the base repo's branch instead of the PR's
+    // commits. A same-repo PR head lives on origin/<branch>, so fetch that.
+    if (isFork) {
       await execRemote(host, [
         'git',
         '-C',
@@ -865,6 +859,10 @@ async function createRemotePrSession(
         'origin',
         `pull/${prNumber}/head:${localBranch}`,
       ]).catch(() => undefined)
+    } else {
+      await execRemote(host, ['git', '-C', projectPath, 'fetch', 'origin', branch]).catch(
+        () => undefined
+      )
     }
 
     // Pick the worktree-add form by probing for the local branch first instead
@@ -872,6 +870,11 @@ async function createRemotePrSession(
     // already checked out in a stale worktree) by surfacing the second
     // attempt's misleading "branch already exists" error.
     const branchExistsLocally = await remoteBranchExists(host, projectPath, localBranch)
+    if (isFork && !branchExistsLocally) {
+      // The pull-ref fetch should have created pr-<n>; if it didn't there's no
+      // valid origin fallback for a fork (origin/<branch> isn't the PR head).
+      return `Failed to create worktree for branch "${branch}": could not fetch refs/pull/${prNumber}/head`
+    }
     const addArgv = branchExistsLocally
       ? ['git', '-C', projectPath, 'worktree', 'add', worktreePath, localBranch]
       : [
@@ -1915,31 +1918,39 @@ export async function createPrSession(
   // origin/<branch>.
   const localBranch = isFork ? worktreeName : branch
 
-  // Fetch the PR head. A same-repo PR head lives on origin/<branch>; a
-  // cross-repository (fork) PR head only exists on origin as GitHub's
-  // refs/pull/<n>/head. Try the branch first and, when origin has no such
-  // branch, fall back to the pull ref — fetching it into the local branch we
-  // can then check out. This is failure-driven rather than keyed off
-  // isCrossRepository so it stays correct even if that flag is unavailable.
-  try {
-    await runGit(['fetch', 'origin', branch])
-  } catch {
+  // Fetch the PR head into the local branch we'll check out. A fork PR head is
+  // ONLY authoritative via GitHub's refs/pull/<n>/head: we must not fetch
+  // origin/<branch>, because if the fork's head branch name also exists on the
+  // base repo (e.g. a fork whose head branch is `main`) that fetch would
+  // succeed and we'd later check out the base repo's branch instead of the
+  // PR's commits. A same-repo PR head lives on origin/<branch>, so fetch that.
+  if (isFork) {
     try {
       await runGit(['fetch', 'origin', `pull/${prNumber}/head:${localBranch}`])
     } catch {
-      // Offline, or the branch is already present locally — fall through.
+      // Offline, or the PR-scoped branch is already present locally.
+    }
+  } else {
+    try {
+      await runGit(['fetch', 'origin', branch])
+    } catch {
+      // May already be available locally.
     }
   }
 
   // Create worktree from the PR branch
   try {
     await runGit(['worktree', 'add', worktreePath, localBranch])
-  } catch {
-    // Branch may already be checked out — try tracking remote
+  } catch (err) {
+    // A fork PR has no valid origin fallback — origin/<branch> is not its head.
+    if (isFork) {
+      return `Failed to create worktree for branch "${branch}": ${(err as Error).message}`
+    }
+    // Same-repo branch may not exist locally yet — create it tracking origin.
     try {
       await runGit(['worktree', 'add', worktreePath, '-b', localBranch, `origin/${branch}`])
-    } catch (err) {
-      return `Failed to create worktree for branch "${branch}": ${(err as Error).message}`
+    } catch (fallbackErr) {
+      return `Failed to create worktree for branch "${branch}": ${(fallbackErr as Error).message}`
     }
   }
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -775,6 +775,15 @@ function forkFieldsFromPr(prInfo: PrViewInfo): { prIsFork?: boolean; prHeadRepo?
   return { prIsFork: true, prHeadRepo: owner && name ? `${owner}/${name}` : undefined }
 }
 
+async function localBranchExists(runGit: GitRunner, branch: string): Promise<boolean> {
+  try {
+    await runGit(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`])
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function createRemotePrSession(
   hostId: string,
   projectPath: string,
@@ -1939,6 +1948,14 @@ export async function createPrSession(
       await runGit(['fetch', 'origin', `+pull/${prNumber}/head:${localBranch}`])
     } catch {
       // Offline, or the PR-scoped branch is already present locally.
+    }
+    // The pull ref must have produced refs/heads/pr-<n>. If the fetch failed
+    // and it doesn't exist, do NOT run `git worktree add <path> pr-<n>`: with
+    // no local branch, git DWIMs the name to a remote-tracking origin/pr-<n>
+    // (if the base repo has a branch named pr-<n>) and silently checks out the
+    // wrong commits. Fail explicitly instead, mirroring the remote path.
+    if (!(await localBranchExists(runGit, localBranch))) {
+      return `Failed to create worktree for branch "${branch}": could not fetch refs/pull/${prNumber}/head`
     }
   } else {
     try {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -851,13 +851,18 @@ async function createRemotePrSession(
     // succeed and we'd check out the base repo's branch instead of the PR's
     // commits. A same-repo PR head lives on origin/<branch>, so fetch that.
     if (isFork) {
+      // Forced refspec (`+`): a removed session can leave refs/heads/pr-<n>
+      // behind, and a later PR force-push makes a non-forced fetch reject as
+      // non-fast-forward, so remoteBranchExists would see the stale branch and
+      // the worktree would check out old commits. pr-<n> is a pewpew-owned
+      // PR-scoped branch that must track the current PR head.
       await execRemote(host, [
         'git',
         '-C',
         projectPath,
         'fetch',
         'origin',
-        `pull/${prNumber}/head:${localBranch}`,
+        `+pull/${prNumber}/head:${localBranch}`,
       ]).catch(() => undefined)
     } else {
       await execRemote(host, ['git', '-C', projectPath, 'fetch', 'origin', branch]).catch(
@@ -1925,8 +1930,13 @@ export async function createPrSession(
   // succeed and we'd later check out the base repo's branch instead of the
   // PR's commits. A same-repo PR head lives on origin/<branch>, so fetch that.
   if (isFork) {
+    // Forced refspec (`+`): a removed session leaves refs/heads/pr-<n> behind,
+    // and a later PR force-push makes a non-forced fetch reject as
+    // non-fast-forward — silently reopening stale commits. pr-<n> is a
+    // pewpew-owned PR-scoped branch that must always track the current PR head,
+    // and same-PR reuse already returned above, so it isn't checked out here.
     try {
-      await runGit(['fetch', 'origin', `pull/${prNumber}/head:${localBranch}`])
+      await runGit(['fetch', 'origin', `+pull/${prNumber}/head:${localBranch}`])
     } catch {
       // Offline, or the PR-scoped branch is already present locally.
     }

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -834,13 +834,20 @@ async function createRemotePrSession(
 
     const branch = prInfo.headRefName
     const forkFields = forkFieldsFromPr(prInfo)
+    const isFork = forkFields.prIsFork === true
     const id = randomUUID().slice(0, 8)
     const tmuxSession = `pewpew-${id}`
+
+    // A fork PR's head branch name isn't unique across forks, so check it out
+    // under a PR-scoped local branch (the worktree name) to avoid colliding
+    // with a different fork that shares the name. Same-repo PRs keep the real
+    // branch name so pushes update the PR via origin/<branch>.
+    const localBranch = isFork ? worktreeName : branch
 
     // Fetch the PR head. execRemote resolves (rather than rejecting) on a
     // non-zero git exit, so probe result.code to decide whether to fall back
     // to GitHub's refs/pull/<n>/head — the only origin ref a cross-repository
-    // (fork) PR head is reachable through. Fetch it into a local branch.
+    // (fork) PR head is reachable through. Fetch it into the local branch.
     const fetched = await execRemote(host, [
       'git',
       '-C',
@@ -856,7 +863,7 @@ async function createRemotePrSession(
         projectPath,
         'fetch',
         'origin',
-        `pull/${prNumber}/head:${branch}`,
+        `pull/${prNumber}/head:${localBranch}`,
       ]).catch(() => undefined)
     }
 
@@ -864,9 +871,9 @@ async function createRemotePrSession(
     // of try-then-fallback. The fallback masked real failures (e.g. branch
     // already checked out in a stale worktree) by surfacing the second
     // attempt's misleading "branch already exists" error.
-    const branchExistsLocally = await remoteBranchExists(host, projectPath, branch)
+    const branchExistsLocally = await remoteBranchExists(host, projectPath, localBranch)
     const addArgv = branchExistsLocally
-      ? ['git', '-C', projectPath, 'worktree', 'add', worktreePath, branch]
+      ? ['git', '-C', projectPath, 'worktree', 'add', worktreePath, localBranch]
       : [
           'git',
           '-C',
@@ -875,7 +882,7 @@ async function createRemotePrSession(
           'add',
           worktreePath,
           '-b',
-          branch,
+          localBranch,
           `origin/${branch}`,
         ]
     try {
@@ -1692,6 +1699,24 @@ function findSessionByBranch(
   return undefined
 }
 
+function findSessionByPrNumber(
+  projectPath: string,
+  hostId: string | null,
+  prNumber: number
+): Session | undefined {
+  for (const entry of sessions.values()) {
+    const session = entry.session
+    if (
+      session.hostId === hostId &&
+      session.projectPath === projectPath &&
+      session.prNumber === prNumber
+    ) {
+      return session
+    }
+  }
+  return undefined
+}
+
 async function createSessionsForNumbers(
   projectPath: string,
   hostId: string | null,
@@ -1853,40 +1878,54 @@ export async function createPrSession(
 
   const branch = prInfo.headRefName
   const forkFields = forkFieldsFromPr(prInfo)
+  const isFork = forkFields.prIsFork === true
 
-  // A branch can only live in one worktree, so if a session already has this
-  // PR's head branch checked out (e.g. opened earlier as an issue session),
-  // reuse it: tag it with the PR number instead of failing on `worktree add`.
-  const existingForBranch = findSessionByBranch(projectPath, hostId, branch)
-  if (existingForBranch) {
+  const worktreeName = `pr-${prNumber}`
+
+  // Reuse an existing session for this PR. First match by PR number (the only
+  // globally-unique key), then — for a same-repo PR whose head branch name
+  // uniquely identifies it — by branch, so a session opened earlier as an issue
+  // gets tagged instead of failing on `worktree add`. A fork PR's head branch
+  // name is NOT unique (two forks can share `fix`), so we never reuse a fork PR
+  // by branch: that would hijack a different fork's session.
+  const existing =
+    findSessionByPrNumber(projectPath, hostId, prNumber) ??
+    (isFork ? undefined : findSessionByBranch(projectPath, hostId, branch))
+  if (existing) {
     // `gh pr view <prNumber>` just confirmed this branch belongs to the
     // requested PR, so overwrite any stale prNumber rather than only filling
     // an empty one — otherwise the requested PR is reported as linked but the
     // session keeps a different number and the PR gets offered again.
-    existingForBranch.prNumber = prNumber
-    existingForBranch.prIsFork = forkFields.prIsFork
-    existingForBranch.prHeadRepo = forkFields.prHeadRepo
-    if (existingForBranch.issueNumber === undefined) {
-      existingForBranch.issueNumber = parseIssueNumber(prInfo.title)
+    existing.prNumber = prNumber
+    existing.prIsFork = forkFields.prIsFork
+    existing.prHeadRepo = forkFields.prHeadRepo
+    if (existing.issueNumber === undefined) {
+      existing.issueNumber = parseIssueNumber(prInfo.title)
     }
     onSessionsChanged()
-    return existingForBranch
+    return existing
   }
 
-  const worktreeName = `pr-${prNumber}`
   const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
+
+  // The local branch to check out. A fork PR's head branch name isn't unique
+  // across forks, so give it a PR-scoped local branch (the worktree name) to
+  // avoid colliding with a different fork that shares the name. Same-repo PRs
+  // keep the real branch name so pushes from the worktree update the PR via
+  // origin/<branch>.
+  const localBranch = isFork ? worktreeName : branch
 
   // Fetch the PR head. A same-repo PR head lives on origin/<branch>; a
   // cross-repository (fork) PR head only exists on origin as GitHub's
   // refs/pull/<n>/head. Try the branch first and, when origin has no such
-  // branch, fall back to the pull ref — fetching it into a local branch we
+  // branch, fall back to the pull ref — fetching it into the local branch we
   // can then check out. This is failure-driven rather than keyed off
   // isCrossRepository so it stays correct even if that flag is unavailable.
   try {
     await runGit(['fetch', 'origin', branch])
   } catch {
     try {
-      await runGit(['fetch', 'origin', `pull/${prNumber}/head:${branch}`])
+      await runGit(['fetch', 'origin', `pull/${prNumber}/head:${localBranch}`])
     } catch {
       // Offline, or the branch is already present locally — fall through.
     }
@@ -1894,11 +1933,11 @@ export async function createPrSession(
 
   // Create worktree from the PR branch
   try {
-    await runGit(['worktree', 'add', worktreePath, branch])
+    await runGit(['worktree', 'add', worktreePath, localBranch])
   } catch {
     // Branch may already be checked out — try tracking remote
     try {
-      await runGit(['worktree', 'add', worktreePath, '-b', branch, `origin/${branch}`])
+      await runGit(['worktree', 'add', worktreePath, '-b', localBranch, `origin/${branch}`])
     } catch (err) {
       return `Failed to create worktree for branch "${branch}": ${(err as Error).message}`
     }

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -753,6 +753,28 @@ async function createRemoteSession(
   return session
 }
 
+// Fields gh returns for a PR. Beyond head branch/state/title we read the
+// cross-repository flag and the head repo identity so a fork PR can be both
+// checked out (via refs/pull/<n>/head) and marked as such on the session.
+interface PrViewInfo {
+  headRefName: string
+  state: string
+  title: string
+  isCrossRepository?: boolean
+  headRepositoryOwner?: { login?: string } | null
+  headRepository?: { name?: string } | null
+}
+
+const PR_VIEW_FIELDS =
+  'headRefName,state,title,isCrossRepository,headRepositoryOwner,headRepository'
+
+function forkFieldsFromPr(prInfo: PrViewInfo): { prIsFork?: boolean; prHeadRepo?: string } {
+  if (prInfo.isCrossRepository !== true) return {}
+  const owner = prInfo.headRepositoryOwner?.login
+  const name = prInfo.headRepository?.name
+  return { prIsFork: true, prHeadRepo: owner && name ? `${owner}/${name}` : undefined }
+}
+
 async function createRemotePrSession(
   hostId: string,
   projectPath: string,
@@ -777,14 +799,14 @@ async function createRemotePrSession(
       return ghProbe.error
     }
 
-    let prInfo: { headRefName: string; state: string; title: string }
+    let prInfo: PrViewInfo
     try {
       const stdout = await expectRemoteOk(
         host,
         [
           'sh',
           '-c',
-          'cd "$1" && gh pr view "$2" --json headRefName,state,title',
+          `cd "$1" && gh pr view "$2" --json ${PR_VIEW_FIELDS}`,
           '_',
           projectPath,
           String(prNumber),
@@ -811,12 +833,32 @@ async function createRemotePrSession(
     }
 
     const branch = prInfo.headRefName
+    const forkFields = forkFieldsFromPr(prInfo)
     const id = randomUUID().slice(0, 8)
     const tmuxSession = `pewpew-${id}`
 
-    await execRemote(host, ['git', '-C', projectPath, 'fetch', 'origin', branch]).catch(
-      () => undefined
-    )
+    // Fetch the PR head. execRemote resolves (rather than rejecting) on a
+    // non-zero git exit, so probe result.code to decide whether to fall back
+    // to GitHub's refs/pull/<n>/head — the only origin ref a cross-repository
+    // (fork) PR head is reachable through. Fetch it into a local branch.
+    const fetched = await execRemote(host, [
+      'git',
+      '-C',
+      projectPath,
+      'fetch',
+      'origin',
+      branch,
+    ]).catch(() => ({ code: 1 }))
+    if (fetched.code !== 0) {
+      await execRemote(host, [
+        'git',
+        '-C',
+        projectPath,
+        'fetch',
+        'origin',
+        `pull/${prNumber}/head:${branch}`,
+      ]).catch(() => undefined)
+    }
 
     // Pick the worktree-add form by probing for the local branch first instead
     // of try-then-fallback. The fallback masked real failures (e.g. branch
@@ -863,6 +905,7 @@ async function createRemotePrSession(
       worktreePath,
       branch: resolvedBranch,
       prNumber,
+      ...forkFields,
       issueNumber: parseIssueNumber(worktreeName, resolvedBranch, prInfo.title),
       pid: 0,
       tmuxSession,
@@ -1511,6 +1554,17 @@ interface CreateIssueSessionDeps {
   ) => Promise<Session>
 }
 
+interface CreatePrSessionDeps {
+  runGit?: GitRunner
+  prView?: (projectPath: string, prNumber: number) => Promise<PrViewInfo>
+  createSessionForWorktree?: (
+    projectPath: string,
+    worktreePath: string,
+    label?: string,
+    tool?: AgentTool
+  ) => Promise<Session>
+}
+
 function describeGhError(err: unknown): string {
   const detail =
     typeof err === 'object' && err !== null && 'stderr' in err
@@ -1762,19 +1816,33 @@ export async function createPrSession(
   projectPath: string,
   prNumber: number,
   hostId: string | null = null,
-  options: CreateSessionOptions = {}
+  options: CreateSessionOptions = {},
+  deps: CreatePrSessionDeps = {}
 ): Promise<Session | string> {
   if (hostId !== null) return createRemotePrSession(hostId, projectPath, prNumber, options)
 
+  const runGit =
+    deps.runGit ??
+    (async (argv: string[]) => {
+      const { stdout } = await execFileAsync('git', ['-C', projectPath, ...argv])
+      return { stdout: String(stdout) }
+    })
+  const prView =
+    deps.prView ??
+    (async (cwd: string, number: number): Promise<PrViewInfo> => {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['pr', 'view', String(number), '--json', PR_VIEW_FIELDS],
+        { cwd }
+      )
+      return JSON.parse(stdout)
+    })
+  const adopt = deps.createSessionForWorktree ?? createSessionForWorktree
+
   // Look up PR via gh CLI
-  let prInfo: { headRefName: string; state: string; title: string }
+  let prInfo: PrViewInfo
   try {
-    const { stdout } = await execFileAsync(
-      'gh',
-      ['pr', 'view', String(prNumber), '--json', 'headRefName,state,title'],
-      { cwd: projectPath }
-    )
-    prInfo = JSON.parse(stdout)
+    prInfo = await prView(projectPath, prNumber)
   } catch {
     return `PR #${prNumber} not found in this repository.`
   }
@@ -1784,6 +1852,7 @@ export async function createPrSession(
   }
 
   const branch = prInfo.headRefName
+  const forkFields = forkFieldsFromPr(prInfo)
 
   // A branch can only live in one worktree, so if a session already has this
   // PR's head branch checked out (e.g. opened earlier as an issue session),
@@ -1795,6 +1864,8 @@ export async function createPrSession(
     // an empty one — otherwise the requested PR is reported as linked but the
     // session keeps a different number and the PR gets offered again.
     existingForBranch.prNumber = prNumber
+    existingForBranch.prIsFork = forkFields.prIsFork
+    existingForBranch.prHeadRepo = forkFields.prHeadRepo
     if (existingForBranch.issueNumber === undefined) {
       existingForBranch.issueNumber = parseIssueNumber(prInfo.title)
     }
@@ -1805,43 +1876,40 @@ export async function createPrSession(
   const worktreeName = `pr-${prNumber}`
   const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
 
-  // Fetch the PR branch
+  // Fetch the PR head. A same-repo PR head lives on origin/<branch>; a
+  // cross-repository (fork) PR head only exists on origin as GitHub's
+  // refs/pull/<n>/head. Try the branch first and, when origin has no such
+  // branch, fall back to the pull ref — fetching it into a local branch we
+  // can then check out. This is failure-driven rather than keyed off
+  // isCrossRepository so it stays correct even if that flag is unavailable.
   try {
-    await execFileAsync('git', ['-C', projectPath, 'fetch', 'origin', branch])
+    await runGit(['fetch', 'origin', branch])
   } catch {
-    // May already be available locally
+    try {
+      await runGit(['fetch', 'origin', `pull/${prNumber}/head:${branch}`])
+    } catch {
+      // Offline, or the branch is already present locally — fall through.
+    }
   }
 
   // Create worktree from the PR branch
   try {
-    await execFileAsync('git', ['-C', projectPath, 'worktree', 'add', worktreePath, branch])
+    await runGit(['worktree', 'add', worktreePath, branch])
   } catch {
     // Branch may already be checked out — try tracking remote
     try {
-      await execFileAsync('git', [
-        '-C',
-        projectPath,
-        'worktree',
-        'add',
-        worktreePath,
-        '-b',
-        branch,
-        `origin/${branch}`,
-      ])
+      await runGit(['worktree', 'add', worktreePath, '-b', branch, `origin/${branch}`])
     } catch (err) {
       return `Failed to create worktree for branch "${branch}": ${(err as Error).message}`
     }
   }
 
-  const session = await createSessionForWorktree(
-    projectPath,
-    worktreePath,
-    worktreeName,
-    options.tool
-  )
+  const session = await adopt(projectPath, worktreePath, worktreeName, options.tool)
   // We already know the PR number; set it directly so it shows immediately
   // (the async lookup fired by adoptWorktree will no-op since prNumber is set).
   session.prNumber = prNumber
+  session.prIsFork = forkFields.prIsFork
+  session.prHeadRepo = forkFields.prHeadRepo
   // Prefer an issue number parsed from the PR title if the name/branch didn't yield one.
   if (session.issueNumber === undefined) {
     session.issueNumber = parseIssueNumber(prInfo.title)

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -848,10 +848,12 @@ async function createRemotePrSession(
     const tmuxSession = `pewpew-${id}`
 
     // A fork PR's head branch name isn't unique across forks, so check it out
-    // under a PR-scoped local branch (the worktree name) to avoid colliding
-    // with a different fork that shares the name. Same-repo PRs keep the real
-    // branch name so pushes update the PR via origin/<branch>.
-    const localBranch = isFork ? worktreeName : branch
+    // under a PR-scoped local branch namespaced under `pewpew/` — both to avoid
+    // colliding with a different fork that shares the name and so the forced
+    // fetch below can't clobber an unrelated user branch named `pr-<n>`. Same-
+    // repo PRs keep the real branch name so pushes update the PR via
+    // origin/<branch>.
+    const localBranch = isFork ? `pewpew/${worktreeName}` : branch
 
     // Fetch the PR head into the local branch we'll check out. A fork PR head
     // is ONLY authoritative via GitHub's refs/pull/<n>/head: never fetch
@@ -860,11 +862,11 @@ async function createRemotePrSession(
     // succeed and we'd check out the base repo's branch instead of the PR's
     // commits. A same-repo PR head lives on origin/<branch>, so fetch that.
     if (isFork) {
-      // Forced refspec (`+`): a removed session can leave refs/heads/pr-<n>
+      // Forced refspec (`+`): a removed session can leave the pewpew/ branch
       // behind, and a later PR force-push makes a non-forced fetch reject as
       // non-fast-forward, so remoteBranchExists would see the stale branch and
-      // the worktree would check out old commits. pr-<n> is a pewpew-owned
-      // PR-scoped branch that must track the current PR head.
+      // the worktree would check out old commits. The pewpew/ branch is
+      // pewpew-owned and must track the current PR head.
       await execRemote(host, [
         'git',
         '-C',
@@ -1926,11 +1928,12 @@ export async function createPrSession(
   const worktreePath = join(projectPath, '.claude', 'worktrees', worktreeName)
 
   // The local branch to check out. A fork PR's head branch name isn't unique
-  // across forks, so give it a PR-scoped local branch (the worktree name) to
-  // avoid colliding with a different fork that shares the name. Same-repo PRs
-  // keep the real branch name so pushes from the worktree update the PR via
-  // origin/<branch>.
-  const localBranch = isFork ? worktreeName : branch
+  // across forks, so give it a PR-scoped local branch. We namespace it under
+  // `pewpew/` (rather than a bare `pr-<n>`) so the forced fetch below can never
+  // clobber an unrelated user branch that happens to be named `pr-<n>`. Same-
+  // repo PRs keep the real branch name so pushes from the worktree update the
+  // PR via origin/<branch>.
+  const localBranch = isFork ? `pewpew/${worktreeName}` : branch
 
   // Fetch the PR head into the local branch we'll check out. A fork PR head is
   // ONLY authoritative via GitHub's refs/pull/<n>/head: we must not fetch
@@ -1939,21 +1942,21 @@ export async function createPrSession(
   // succeed and we'd later check out the base repo's branch instead of the
   // PR's commits. A same-repo PR head lives on origin/<branch>, so fetch that.
   if (isFork) {
-    // Forced refspec (`+`): a removed session leaves refs/heads/pr-<n> behind,
-    // and a later PR force-push makes a non-forced fetch reject as
-    // non-fast-forward — silently reopening stale commits. pr-<n> is a
-    // pewpew-owned PR-scoped branch that must always track the current PR head,
-    // and same-PR reuse already returned above, so it isn't checked out here.
+    // Forced refspec (`+`): a removed session leaves refs/heads/pewpew/pr-<n>
+    // behind, and a later PR force-push makes a non-forced fetch reject as
+    // non-fast-forward — silently reopening stale commits. The pewpew/ branch
+    // is pewpew-owned and must always track the current PR head, and same-PR
+    // reuse already returned above, so it isn't checked out here.
     try {
       await runGit(['fetch', 'origin', `+pull/${prNumber}/head:${localBranch}`])
     } catch {
-      // Offline, or the PR-scoped branch is already present locally.
+      // Offline, or the namespaced branch is already present locally.
     }
-    // The pull ref must have produced refs/heads/pr-<n>. If the fetch failed
-    // and it doesn't exist, do NOT run `git worktree add <path> pr-<n>`: with
-    // no local branch, git DWIMs the name to a remote-tracking origin/pr-<n>
-    // (if the base repo has a branch named pr-<n>) and silently checks out the
-    // wrong commits. Fail explicitly instead, mirroring the remote path.
+    // The pull ref must have produced the local branch. If the fetch failed and
+    // it doesn't exist, do NOT run `git worktree add <path> <localBranch>`:
+    // with no local branch, git DWIMs the name to a remote-tracking
+    // origin/<localBranch> (if one exists) and silently checks out the wrong
+    // commits. Fail explicitly instead, mirroring the remote path.
     if (!(await localBranchExists(runGit, localBranch))) {
       return `Failed to create worktree for branch "${branch}": could not fetch refs/pull/${prNumber}/head`
     }

--- a/src/renderer/components/SessionCard.tsx
+++ b/src/renderer/components/SessionCard.tsx
@@ -213,6 +213,19 @@ export default function SessionCard({ session, thumbnail, style, onOpenSession, 
               PR #{session.prNumber}
             </span>
           )}
+          {session.prIsFork && (
+            <span
+              className="session-card-chip chip-fork"
+              title={
+                session.prHeadRepo
+                  ? `fork PR — head in ${session.prHeadRepo} (pushes won't update the PR)`
+                  : "fork PR — head in a forked repo (pushes won't update the PR)"
+              }
+            >
+              <span className="chip-icon">⑂</span>
+              fork
+            </span>
+          )}
         </div>
         <div className="session-card-status">
           <span className={`status-dot ${statusClass}`} />

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -27,6 +27,7 @@
   --accent-red: #f87171;
   --accent-blue: #60a5fa;
   --accent-orange: #f59e0b;
+  --accent-purple: #c084fc;
   --accent-error: #e07070;
 
   --shadow-md: rgba(0, 0, 0, 0.4);
@@ -67,6 +68,7 @@
   --accent-red: #dc2626;
   --accent-blue: #1d4ed8;
   --accent-orange: #c2410c;
+  --accent-purple: #7e22ce;
   --accent-error: #b91c1c;
 
   --shadow-md: rgba(15, 23, 42, 0.14);
@@ -497,6 +499,13 @@ body,
   background: rgba(74, 222, 128, 0.1);
   border-color: rgba(74, 222, 128, 0.35);
   color: var(--accent-green);
+  flex: 0 0 auto;
+}
+
+.session-card-chip.chip-fork {
+  background: rgba(192, 132, 252, 0.12);
+  border-color: rgba(192, 132, 252, 0.4);
+  color: var(--accent-purple);
   flex: 0 0 auto;
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -41,6 +41,12 @@ export interface Session {
   worktreePath: string
   branch: string
   prNumber?: number
+  // Set when the PR head lives in a different repository (a fork). The head
+  // branch is then only reachable via GitHub's refs/pull/<n>/head, and pushes
+  // from this worktree won't update the PR (origin has no such branch).
+  prIsFork?: boolean
+  // "owner/name" of the fork the PR head lives in, when known (display only).
+  prHeadRepo?: string
   issueNumber?: number
   pid: number
   tmuxSession: string


### PR DESCRIPTION
## Problem

Creating a session for a fork PR (e.g. `pmatos/s11` #335) failed with:

```
fatal: invalid reference: origin/codex/fix-mutants-summary-unittest-command
```

`createPrSession` assumed every PR head is reachable as `origin/<branch>`. That only holds for same-repo PRs — a **cross-repository (fork)** PR's head branch lives in the contributor's fork, so `git fetch origin <branch>` fails and the `origin/<branch>` fallback is an invalid ref.

## Fix

GitHub exposes every PR head at `refs/pull/<n>/head` on the **base** repo (verified: `git ls-remote origin refs/pull/335/head` resolves even though `origin/<branch>` does not). When the `origin/<branch>` fetch fails, fetch the pull ref into a local branch and check that out.

- **Failure-driven**, not keyed off `isCrossRepository`, so it stays correct even if that flag is unavailable.
- **Same-repo PRs are unchanged** — they still branch from `origin/<branch>`, so pushes from the worktree update the PR.
- Both the local (`createPrSession`) and remote (`createRemotePrSession`) paths are fixed. The remote path checks `execRemote().code` since `execRemote` resolves (rather than rejecting) on a non-zero git exit.

## Fork marker

- New optional `Session.prIsFork` / `prHeadRepo` fields, set from `gh pr view` (`isCrossRepository`, `headRepositoryOwner`, `headRepository`).
- A purple **fork** chip on the session card, tooltip noting the head repo and that pushes won't update the PR.

> Known limitation (inherent to fork PRs): the checked-out branch has no `origin` upstream, so `git push` won't update the PR — you'd need the contributor's fork as a remote. The marker makes this visible.

## Tests

`createPrSession` now accepts injectable deps (`runGit`, `prView`, `createSessionForWorktree`), mirroring `createIssueSession`:
- fork PR falls back to `pull/<n>/head` and never uses `origin/<branch>`;
- same-repo PR does **not** fetch the pull ref;
- real-git integration test checks out a synthetic fork PR head end-to-end.

`tsc`, `eslint`, `prettier`, and the full suite (406 tests) pass.