### PR TITLE
fix(sessions): surface real gh error on PR lookup instead of "not found"

### DIFF
--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -1825,6 +1825,32 @@ describe('openSessionsForOpenIssues', () => {
   })
 })
 
+describe('createPrSession lookup failures', () => {
+  it('surfaces the real gh error (e.g. rate limit) instead of reporting "not found"', async () => {
+    const sm = await loadSessionManager()
+    const prView = async () => {
+      const err = new Error('Command failed') as Error & { stderr: string }
+      err.stderr = 'GraphQL: API rate limit already exceeded for user ID 7911.'
+      throw err
+    }
+    const result = await sm.createPrSession('/proj', 175, null, {}, { prView })
+    expect(result).toBe(
+      'Failed to look up PR #175: GraphQL: API rate limit already exceeded for user ID 7911.'
+    )
+  })
+
+  it('still reports "not found" when gh says the PR cannot be resolved', async () => {
+    const sm = await loadSessionManager()
+    const prView = async () => {
+      const err = new Error('Command failed') as Error & { stderr: string }
+      err.stderr = 'GraphQL: Could not resolve to a PullRequest with the number of 175.'
+      throw err
+    }
+    const result = await sm.createPrSession('/proj', 175, null, {}, { prView })
+    expect(result).toBe('PR #175 not found in this repository.')
+  })
+})
+
 describe('createPrSession fork handling', () => {
   const forkPrView = async () => ({
     headRefName: 'codex/fix-x',

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -775,6 +775,23 @@ function forkFieldsFromPr(prInfo: PrViewInfo): { prIsFork?: boolean; prHeadRepo?
   return { prIsFork: true, prHeadRepo: owner && name ? `${owner}/${name}` : undefined }
 }
 
+// `gh pr view` fails for many reasons beyond the PR genuinely not existing —
+// rate limiting, auth, network, or gh resolving the wrong default repo. Only
+// report "not found" when gh actually said the PR couldn't be resolved;
+// otherwise surface the real error so a rate-limit or auth failure isn't
+// misreported as a missing PR (which sends the user hunting for a PR that's
+// right there on GitHub).
+function describePrLookupFailure(prNumber: number, detail: string): string {
+  const trimmed = detail.trim()
+  const genuinelyMissing =
+    /could not resolve to a (pull ?request|issue)/i.test(trimmed) ||
+    /no pull requests? found/i.test(trimmed)
+  if (!trimmed || genuinelyMissing) {
+    return `PR #${prNumber} not found in this repository.`
+  }
+  return `Failed to look up PR #${prNumber}: ${trimmed}`
+}
+
 async function localBranchExists(runGit: GitRunner, branch: string): Promise<boolean> {
   try {
     await runGit(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`])
@@ -809,26 +826,23 @@ async function createRemotePrSession(
     }
 
     let prInfo: PrViewInfo
+    const viewResult = await execRemote(host, [
+      'sh',
+      '-c',
+      `cd "$1" && gh pr view "$2" --json ${PR_VIEW_FIELDS}`,
+      '_',
+      projectPath,
+      String(prNumber),
+    ])
+    if (viewResult.timedOut || viewResult.code !== 0) {
+      const detail =
+        viewResult.stderr.trim() || viewResult.stdout.trim() || `exit ${viewResult.code}`
+      return describePrLookupFailure(prNumber, detail)
+    }
     try {
-      const stdout = await expectRemoteOk(
-        host,
-        [
-          'sh',
-          '-c',
-          `cd "$1" && gh pr view "$2" --json ${PR_VIEW_FIELDS}`,
-          '_',
-          projectPath,
-          String(prNumber),
-        ],
-        'gh failed'
-      )
-      try {
-        prInfo = JSON.parse(stdout)
-      } catch {
-        return `Failed to parse PR metadata for #${prNumber}.`
-      }
+      prInfo = JSON.parse(viewResult.stdout)
     } catch {
-      return `PR #${prNumber} not found in this repository.`
+      return `Failed to parse PR metadata for #${prNumber}.`
     }
 
     if (prInfo.state !== 'OPEN') {
@@ -1887,8 +1901,8 @@ export async function createPrSession(
   let prInfo: PrViewInfo
   try {
     prInfo = await prView(projectPath, prNumber)
-  } catch {
-    return `PR #${prNumber} not found in this repository.`
+  } catch (err) {
+    return describePrLookupFailure(prNumber, describeGhError(err))
   }
 
   if (prInfo.state !== 'OPEN') {


### PR DESCRIPTION
## Problem

Opening a session from an existing PR number could fail with **"PR #N not found in this repository."** even when the PR plainly exists on GitHub (e.g. `github.com/pmatos/jsse/pull/175`).

Root cause: both single-PR lookup paths — `createPrSession` (local) and `createRemotePrSession` (remote) — wrapped the `gh pr view <N>` call in a blanket `catch {}` that discarded the real error and always returned the generic "not found" message. So a **GitHub API rate limit**, an auth failure, a network error, or `gh` resolving the wrong default repo was all misreported as a missing PR.

Reproduced against a real remote project: the actual error was

```
GraphQL: API rate limit already exceeded for user ID 7911.
```

## Fix

- Add `describePrLookupFailure(prNumber, detail)`, which reports `"PR #N not found in this repository."` **only** when `gh` actually said it could not resolve the PR (`Could not resolve to a PullRequest` / `no pull requests found`), and otherwise surfaces the real `gh` error (e.g. `Failed to look up PR #N: GraphQL: API rate limit already exceeded…`).
- `createRemotePrSession` now calls `execRemote` directly instead of `expectRemoteOk`, so it can inspect the raw stderr/exit code.
- `createPrSession` routes the caught `gh` error through `describeGhError` → `describePrLookupFailure`.

## Tests

Added two cases in `createPrSession lookup failures`:
- a rate-limit error surfaces the real message rather than "not found";
- a genuine `Could not resolve to a PullRequest` still reports "not found".

`tsc --noEmit`, `eslint`, and the full `session-manager.test.ts` suite (103 tests) pass.