### PR TITLE
feat(sessions): mirror existing worktrees on remote projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ CLAUDE.local.md
 .claude/settings.local.json
 .codex
 .ultraplan/
+.impeccable/

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,8 @@ import {
   initSessionManager,
   createSession,
   createSessionForWorktree,
+  createRemoteSessionForWorktree,
+  gitRemoteWorktrees,
   mirrorAllWorktrees,
   createPrSession,
   createPrSessions,
@@ -380,19 +382,38 @@ app.whenReady().then(async () => {
     return undefined
   }
 
-  ipcMain.handle('sessions:mirror', async (_event, projectPath: string, worktreePath: string) => {
-    const session = await createSessionForWorktree(projectPath, worktreePath)
-    const warning = await gitignoreWarning(projectPath, [session.worktreePath])
-    return { session, warning }
-  })
+  ipcMain.handle(
+    'sessions:mirror',
+    async (_event, projectPath: string, worktreePath: string, hostId?: string | null) => {
+      if (hostId) {
+        const session = await createRemoteSessionForWorktree(hostId, projectPath, worktreePath)
+        // The gitignore warning inspects the local filesystem, which has no
+        // bearing on a remote worktree — skip it.
+        return { session, warning: undefined }
+      }
+      const session = await createSessionForWorktree(projectPath, worktreePath)
+      const warning = await gitignoreWarning(projectPath, [session.worktreePath])
+      return { session, warning }
+    }
+  )
 
-  ipcMain.handle('sessions:mirror-all', async (_event, projectPath: string) => {
-    const result = await mirrorAllWorktrees(projectPath)
-    const warning = await gitignoreWarning(
-      projectPath,
-      result.mirrored.map((s) => s.worktreePath)
-    )
-    return { result, warning }
+  ipcMain.handle(
+    'sessions:mirror-all',
+    async (_event, projectPath: string, hostId?: string | null) => {
+      const result = await mirrorAllWorktrees(projectPath, hostId)
+      if (hostId) return { result, warning: undefined }
+      const warning = await gitignoreWarning(
+        projectPath,
+        result.mirrored.map((s) => s.worktreePath)
+      )
+      return { result, warning }
+    }
+  )
+
+  ipcMain.handle('projects:list-remote-worktrees', async (_event, hostId: string, path: string) => {
+    const host = getHost(hostId)
+    if (!host) throw new Error('Unknown host')
+    return gitRemoteWorktrees(host, path)
   })
 
   ipcMain.handle('sessions:list', () => {

--- a/src/main/project-scanner.test.ts
+++ b/src/main/project-scanner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, mkdirSync, symlinkSync, rmSync, chmodSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { join, posix } from 'path'
 import { detectSetupState, discoverRepos, parseWorktreeList } from './project-scanner'
 
 describe('parseWorktreeList', () => {
@@ -65,6 +65,26 @@ describe('parseWorktreeList', () => {
     const result = parseWorktreeList(stdout)
     expect(result).toHaveLength(1)
     expect(result[0].isMain).toBe(true)
+  })
+
+  it('derives worktree names with a supplied basename function (remote POSIX paths)', () => {
+    const stdout = [
+      'worktree /srv/repo',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /srv/repo/.claude/worktrees/feat-x',
+      'HEAD def456',
+      'branch refs/heads/pewpew/feat-x',
+      '',
+    ].join('\n')
+
+    // Supply a distinguishing basename to prove the injected function is used
+    // (this is how remote callers pass posix.basename for SSH-listed paths).
+    const lastSegmentUpper = (p: string): string => posix.basename(p).toUpperCase()
+    const result = parseWorktreeList(stdout, lastSegmentUpper)
+
+    expect(result.map((w) => w.name)).toEqual(['REPO', 'FEAT-X'])
   })
 })
 

--- a/src/main/project-scanner.ts
+++ b/src/main/project-scanner.ts
@@ -20,7 +20,10 @@ async function gitBranches(repoPath: string): Promise<string[]> {
   }
 }
 
-export function parseWorktreeList(stdout: string): Worktree[] {
+export function parseWorktreeList(
+  stdout: string,
+  baseName: (p: string) => string = basename
+): Worktree[] {
   const worktrees: Worktree[] = []
   const blocks = stdout.split('\n\n').filter(Boolean)
 
@@ -39,7 +42,7 @@ export function parseWorktreeList(stdout: string): Worktree[] {
 
     if (path) {
       worktrees.push({
-        name: basename(path),
+        name: baseName(path),
         path,
         branch: branch || 'HEAD',
         isMain: worktrees.length === 0,

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -92,10 +92,14 @@ vi.mock('electron', () => ({
   },
 }))
 
-vi.mock('./project-scanner', () => ({
-  getRepoFingerprint: vi.fn(async () => state.repoFingerprint),
-  gitWorktrees: vi.fn(async () => []),
-}))
+vi.mock('./project-scanner', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./project-scanner')>()
+  return {
+    getRepoFingerprint: vi.fn(async () => state.repoFingerprint),
+    gitWorktrees: vi.fn(async () => []),
+    parseWorktreeList: actual.parseWorktreeList,
+  }
+})
 
 vi.mock('./hook-installer', () => ({
   installHooks: vi.fn(async () => undefined),
@@ -306,6 +310,218 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(state.configDir, { recursive: true, force: true })
+})
+
+describe('gitRemoteWorktrees', () => {
+  it('lists remote worktrees and parses POSIX paths', async () => {
+    const sm = await loadSessionManager()
+    state.execRemoteResults.set('git -C /srv/proj worktree list --porcelain', {
+      stdout: [
+        'worktree /srv/proj',
+        'HEAD abc',
+        'branch refs/heads/main',
+        '',
+        'worktree /srv/proj/.claude/worktrees/feat-a',
+        'HEAD def',
+        'branch refs/heads/pewpew/feat-a',
+        '',
+      ].join('\n'),
+      stderr: '',
+      code: 0,
+      timedOut: false,
+    })
+
+    const result = await sm.gitRemoteWorktrees(state.hosts[0], '/srv/proj')
+
+    expect(result).toEqual([
+      { name: 'proj', path: '/srv/proj', branch: 'main', isMain: true },
+      {
+        name: 'feat-a',
+        path: '/srv/proj/.claude/worktrees/feat-a',
+        branch: 'pewpew/feat-a',
+        isMain: false,
+      },
+    ])
+    expect(state.execRemoteCalls).toContainEqual({
+      hostId: 'h1',
+      argv: ['git', '-C', '/srv/proj', 'worktree', 'list', '--porcelain'],
+    })
+  })
+
+  it('throws with stderr detail when the remote git command fails', async () => {
+    const sm = await loadSessionManager()
+    state.execRemoteResults.set('git -C /srv/proj worktree list --porcelain', {
+      stdout: '',
+      stderr: 'fatal: not a git repository',
+      code: 128,
+      timedOut: false,
+    })
+
+    await expect(sm.gitRemoteWorktrees(state.hosts[0], '/srv/proj')).rejects.toThrow(
+      /not a git repository/
+    )
+  })
+})
+
+describe('createRemoteSessionForWorktree (adopt remote worktree)', () => {
+  const projectPath = '/remote/proj'
+  const worktreePath = '/remote/proj/.claude/worktrees/existing'
+
+  function primeWorktree(branch = 'feature/existing'): void {
+    state.remoteProjects = [{ hostId: 'h1', path: projectPath, name: 'proj' }]
+    state.execRemoteResults.set(
+      ['git', '-C', worktreePath, 'rev-parse', '--is-inside-work-tree'].join(' '),
+      { stdout: 'true\n', stderr: '', code: 0, timedOut: false }
+    )
+    state.execRemoteResults.set(
+      ['git', '-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'].join(' '),
+      { stdout: `${branch}\n`, stderr: '', code: 0, timedOut: false }
+    )
+  }
+
+  it('adopts an existing remote worktree without creating a new one', async () => {
+    primeWorktree('feature/existing')
+    const sm = await loadSessionManager()
+
+    const session = await sm.createRemoteSessionForWorktree(
+      'h1',
+      projectPath,
+      worktreePath,
+      undefined,
+      'claude'
+    )
+
+    expect(session.hostId).toBe('h1')
+    expect(session.projectName).toBe('proj')
+    expect(session.worktreeName).toBe('existing')
+    expect(session.worktreePath).toBe(worktreePath)
+    expect(session.branch).toBe('feature/existing')
+    expect(session.connectionState).toBe('live')
+    expect(session.tool).toBe('claude')
+    expect(state.createRemotePtyCalls).toEqual([
+      { sessionId: session.id, cwd: worktreePath, hostId: 'h1' },
+    ])
+    const ranWorktreeAdd = state.execRemoteCalls.some(
+      (c) => c.argv[0] === 'git' && c.argv.includes('worktree') && c.argv.includes('add')
+    )
+    expect(ranWorktreeAdd).toBe(false)
+  })
+
+  it('returns the existing session when the same worktree is adopted twice', async () => {
+    primeWorktree()
+    const sm = await loadSessionManager()
+
+    const first = await sm.createRemoteSessionForWorktree(
+      'h1',
+      projectPath,
+      worktreePath,
+      undefined,
+      'claude'
+    )
+    const second = await sm.createRemoteSessionForWorktree(
+      'h1',
+      projectPath,
+      worktreePath,
+      undefined,
+      'claude'
+    )
+
+    expect(second.id).toBe(first.id)
+    expect(sm.getSessions()).toHaveLength(1)
+    expect(state.createRemotePtyCalls).toHaveLength(1)
+  })
+
+  it('rejects a mixed-tool adoption of the same worktree', async () => {
+    primeWorktree()
+    const sm = await loadSessionManager()
+
+    await sm.createRemoteSessionForWorktree('h1', projectPath, worktreePath, undefined, 'claude')
+
+    await expect(
+      sm.createRemoteSessionForWorktree('h1', projectPath, worktreePath, undefined, 'codex')
+    ).rejects.toThrow(/mixed tools/)
+  })
+
+  it('rejects when the path is not a git worktree', async () => {
+    state.remoteProjects = [{ hostId: 'h1', path: projectPath, name: 'proj' }]
+    state.execRemoteResults.set(
+      ['git', '-C', worktreePath, 'rev-parse', '--is-inside-work-tree'].join(' '),
+      { stdout: '', stderr: 'fatal: not a work tree', code: 128, timedOut: false }
+    )
+    const sm = await loadSessionManager()
+
+    await expect(
+      sm.createRemoteSessionForWorktree('h1', projectPath, worktreePath, undefined, 'claude')
+    ).rejects.toThrow()
+    expect(state.createRemotePtyCalls).toEqual([])
+  })
+})
+
+describe('mirrorAllWorktrees — remote', () => {
+  const projectPath = '/remote/proj'
+  const wtA = '/remote/proj/.claude/worktrees/feat-a'
+  const wtB = '/remote/proj/.claude/worktrees/feat-b'
+
+  function primeList(): void {
+    state.remoteProjects = [{ hostId: 'h1', path: projectPath, name: 'proj' }]
+    state.execRemoteResults.set('git -C /remote/proj worktree list --porcelain', {
+      stdout: [
+        'worktree /remote/proj',
+        'HEAD a',
+        'branch refs/heads/main',
+        '',
+        `worktree ${wtA}`,
+        'HEAD b',
+        'branch refs/heads/pewpew/feat-a',
+        '',
+        `worktree ${wtB}`,
+        'HEAD c',
+        'branch refs/heads/pewpew/feat-b',
+        '',
+      ].join('\n'),
+      stderr: '',
+      code: 0,
+      timedOut: false,
+    })
+    for (const wt of [wtA, wtB]) {
+      state.execRemoteResults.set(
+        ['git', '-C', wt, 'rev-parse', '--is-inside-work-tree'].join(' '),
+        { stdout: 'true\n', stderr: '', code: 0, timedOut: false }
+      )
+      state.execRemoteResults.set(
+        ['git', '-C', wt, 'rev-parse', '--abbrev-ref', 'HEAD'].join(' '),
+        {
+          stdout: 'branch\n',
+          stderr: '',
+          code: 0,
+          timedOut: false,
+        }
+      )
+    }
+  }
+
+  it('adopts every non-main remote worktree', async () => {
+    primeList()
+    const sm = await loadSessionManager()
+
+    const result = await sm.mirrorAllWorktrees(projectPath, 'h1')
+
+    expect(result.failed).toEqual([])
+    expect(new Set(result.mirrored.map((s) => s.worktreePath))).toEqual(new Set([wtA, wtB]))
+    expect(state.createRemotePtyCalls).toHaveLength(2)
+  })
+
+  it('skips the main worktree and already-adopted worktrees', async () => {
+    primeList()
+    const sm = await loadSessionManager()
+    await sm.createRemoteSessionForWorktree('h1', projectPath, wtA, undefined, 'claude')
+    state.createRemotePtyCalls = []
+
+    const result = await sm.mirrorAllWorktrees(projectPath, 'h1')
+
+    expect(result.mirrored.map((s) => s.worktreePath)).toEqual([wtB])
+    expect(state.createRemotePtyCalls).toHaveLength(1)
+  })
 })
 
 describe('resolveOriginDefaultBase', () => {

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Host, RemoteProject, Session, WorktreeBase } from '../shared/types'
+import type { AgentTool, Host, RemoteProject, Session, WorktreeBase } from '../shared/types'
 
 // Hoisted state so vi.mock factories can reach mutable per-test values before
 // the SUT imports run.
@@ -15,6 +15,7 @@ const state = vi.hoisted(() => ({
   hosts: [] as Host[],
   remoteProjects: [] as RemoteProject[],
   worktreeBase: 'local' as WorktreeBase,
+  defaultTool: 'claude' as AgentTool,
   runtimeStates: new Map<string, string>(),
   // Call logs for assertion.
   ensureHostConnectionCalls: [] as string[],
@@ -60,7 +61,7 @@ vi.mock('./config', () => ({
     uiScale: 1,
     hosts: state.hosts,
     remoteProjects: [],
-    defaultTool: 'claude',
+    defaultTool: state.defaultTool,
     worktreeBase: state.worktreeBase,
   }),
   saveConfig: vi.fn(),
@@ -289,6 +290,7 @@ beforeEach(() => {
   state.hosts = [{ hostId: 'h1', alias: 'devbox', label: 'Dev' }]
   state.remoteProjects = []
   state.worktreeBase = 'local'
+  state.defaultTool = 'claude'
   state.runtimeStates = new Map()
   state.ensureHostConnectionCalls = []
   state.createRemotePtyCalls = []
@@ -521,6 +523,89 @@ describe('mirrorAllWorktrees — remote', () => {
 
     expect(result.mirrored.map((s) => s.worktreePath)).toEqual([wtB])
     expect(state.createRemotePtyCalls).toHaveLength(1)
+  })
+})
+
+describe('mirrorAllWorktrees — remote Codex serialization', () => {
+  const projectPath = '/remote/proj'
+  const wtA = '/remote/proj/.claude/worktrees/feat-a'
+  const wtB = '/remote/proj/.claude/worktrees/feat-b'
+
+  function primeList(): void {
+    state.remoteProjects = [{ hostId: 'h1', path: projectPath, name: 'proj' }]
+    state.execRemoteResults.set('git -C /remote/proj worktree list --porcelain', {
+      stdout: [
+        'worktree /remote/proj',
+        'HEAD a',
+        'branch refs/heads/main',
+        '',
+        `worktree ${wtA}`,
+        'HEAD b',
+        'branch refs/heads/pewpew/feat-a',
+        '',
+        `worktree ${wtB}`,
+        'HEAD c',
+        'branch refs/heads/pewpew/feat-b',
+        '',
+      ].join('\n'),
+      stderr: '',
+      code: 0,
+      timedOut: false,
+    })
+  }
+
+  function gatedAdopt(started: string[], gateFor: string, gate: Promise<void>) {
+    return async (wt: { path: string }): Promise<Session> => {
+      started.push(wt.path)
+      if (wt.path === gateFor) await gate
+      return baseRemoteSession({ id: `s-${started.length}`, hostId: 'h1', worktreePath: wt.path })
+    }
+  }
+
+  it('serializes adoptions when the default tool is Codex', async () => {
+    state.defaultTool = 'codex'
+    primeList()
+    const sm = await loadSessionManager()
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const started: string[] = []
+
+    const resultPromise = sm.mirrorAllWorktrees(projectPath, 'h1', {
+      adopt: gatedAdopt(started, wtA, firstGate),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    // Second adoption must not start until the first resolves.
+    expect(started).toEqual([wtA])
+
+    releaseFirst()
+    const result = await resultPromise
+    expect(started).toEqual([wtA, wtB])
+    expect(result.mirrored).toHaveLength(2)
+    expect(result.failed).toEqual([])
+  })
+
+  it('adopts in parallel for the default (non-Codex) tool', async () => {
+    state.defaultTool = 'claude'
+    primeList()
+    const sm = await loadSessionManager()
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const started: string[] = []
+
+    const resultPromise = sm.mirrorAllWorktrees(projectPath, 'h1', {
+      adopt: gatedAdopt(started, wtA, firstGate),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    // Both adoptions start before the first resolves.
+    expect(started).toEqual([wtA, wtB])
+
+    releaseFirst()
+    const result = await resultPromise
+    expect(result.mirrored).toHaveLength(2)
   })
 })
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -26,7 +26,7 @@ import {
   createRemotePty,
   setUnexpectedExitListener,
 } from './pty-manager'
-import { getRepoFingerprint, gitWorktrees } from './project-scanner'
+import { getRepoFingerprint, gitWorktrees, parseWorktreeList } from './project-scanner'
 import {
   installHooks,
   installRemoteHooks,
@@ -52,6 +52,7 @@ import type {
   RemoteProject,
   Session,
   SessionStatus,
+  Worktree,
   WorktreeBase,
 } from '../shared/types'
 
@@ -220,6 +221,19 @@ async function expectRemoteOk(host: Host, argv: string[], message: string): Prom
     throw new Error(`${message}: ${detail}`)
   }
   return result.stdout
+}
+
+// Lists the worktrees of a remote project over SSH. Remote paths are always
+// POSIX, so names are derived with posix.basename regardless of the host OS the
+// app runs on. Throws (via expectRemoteOk) on a non-zero/timed-out git command
+// so callers can surface the failure instead of silently showing no worktrees.
+export async function gitRemoteWorktrees(host: Host, projectPath: string): Promise<Worktree[]> {
+  const stdout = await expectRemoteOk(
+    host,
+    ['git', '-C', projectPath, 'worktree', 'list', '--porcelain'],
+    'Failed to list remote worktrees'
+  )
+  return parseWorktreeList(stdout, posix.basename)
 }
 
 function effectiveWorktreeBase(options: CreateSessionOptions): WorktreeBase {
@@ -582,25 +596,51 @@ export interface MirrorAllResult {
   failed: { path: string; error: string }[]
 }
 
-export async function mirrorAllWorktrees(projectPath: string): Promise<MirrorAllResult> {
-  const worktrees = await gitWorktrees(projectPath)
-  const existingPaths = new Set<string>()
-  for (const e of sessions.values()) existingPaths.add(canonicalPath(e.session.worktreePath))
-
-  const targets = worktrees.filter((wt) => !wt.isMain && !existingPaths.has(canonicalPath(wt.path)))
-
-  const results = await Promise.allSettled(
-    targets.map((wt) => createSessionForWorktree(projectPath, wt.path))
-  )
-
+// Adopts each target worktree concurrently, partitioning fulfilled/rejected
+// outcomes into the mirrored/failed buckets a MirrorAllResult reports.
+async function adoptTargets(
+  targets: Worktree[],
+  adopt: (wt: Worktree) => Promise<Session>
+): Promise<MirrorAllResult> {
+  const results = await Promise.allSettled(targets.map(adopt))
   const mirrored: Session[] = []
   const failed: { path: string; error: string }[] = []
   results.forEach((r, i) => {
     if (r.status === 'fulfilled') mirrored.push(r.value)
     else failed.push({ path: targets[i].path, error: String(r.reason) })
   })
-
   return { mirrored, failed }
+}
+
+export async function mirrorAllWorktrees(
+  projectPath: string,
+  hostId?: string | null
+): Promise<MirrorAllResult> {
+  if (hostId) return mirrorAllRemoteWorktrees(hostId, projectPath)
+
+  const worktrees = await gitWorktrees(projectPath)
+  const existingPaths = new Set<string>()
+  for (const e of sessions.values()) existingPaths.add(canonicalPath(e.session.worktreePath))
+
+  const targets = worktrees.filter((wt) => !wt.isMain && !existingPaths.has(canonicalPath(wt.path)))
+
+  return adoptTargets(targets, (wt) => createSessionForWorktree(projectPath, wt.path))
+}
+
+async function mirrorAllRemoteWorktrees(
+  hostId: string,
+  projectPath: string
+): Promise<MirrorAllResult> {
+  const host = getRequiredHost(hostId)
+  const worktrees = await gitRemoteWorktrees(host, projectPath)
+  const adopted = new Set<string>()
+  for (const e of sessions.values()) {
+    if (e.session.hostId === hostId) adopted.add(e.session.worktreePath)
+  }
+
+  const targets = worktrees.filter((wt) => !wt.isMain && !adopted.has(wt.path))
+
+  return adoptTargets(targets, (wt) => createRemoteSessionForWorktree(hostId, projectPath, wt.path))
 }
 
 async function installRemoteAgentHooks(
@@ -622,6 +662,125 @@ async function installRemoteAgentHooks(
     return
   }
   await installRemoteHooks(remote, worktreePath, notifyScriptPath)
+}
+
+// In-flight adoptions for remote worktrees, keyed by `${hostId}\0${worktreePath}`.
+// Mirrors `inflightAdoptions` (local) so a double-click or a concurrent
+// mirror-all only creates one session/PTY per remote worktree.
+const inflightRemoteAdoptions = new Map<string, InflightAdoption>()
+
+// Adopts an EXISTING remote worktree as a pewpew session: it installs hooks and
+// attaches a PTY but never runs `git worktree add`. This is the remote analogue
+// of createSessionForWorktree/adoptWorktree.
+export async function createRemoteSessionForWorktree(
+  hostId: string,
+  projectPath: string,
+  worktreePath: string,
+  label?: string,
+  tool?: AgentTool
+): Promise<Session> {
+  const effectiveTool: AgentTool = tool ?? getConfig().defaultTool
+
+  for (const e of sessions.values()) {
+    if (e.session.hostId === hostId && e.session.worktreePath === worktreePath) {
+      if (e.session.tool !== effectiveTool) {
+        throw new Error(
+          `Worktree already has a ${e.session.tool} session; mixed tools per worktree are not supported`
+        )
+      }
+      return e.session
+    }
+  }
+
+  const key = `${hostId} ${worktreePath}`
+  const inflight = inflightRemoteAdoptions.get(key)
+  if (inflight) {
+    if (inflight.tool !== effectiveTool) {
+      throw new Error(
+        `Worktree already has a ${inflight.tool} session in-flight; mixed tools per worktree are not supported`
+      )
+    }
+    return inflight.promise
+  }
+
+  const promise = adoptRemoteWorktree(hostId, projectPath, worktreePath, label, effectiveTool)
+  inflightRemoteAdoptions.set(key, { promise, tool: effectiveTool })
+  try {
+    return await promise
+  } finally {
+    inflightRemoteAdoptions.delete(key)
+  }
+}
+
+async function adoptRemoteWorktree(
+  hostId: string,
+  projectPath: string,
+  worktreePath: string,
+  label: string | undefined,
+  tool: AgentTool
+): Promise<Session> {
+  const host = getRequiredHost(hostId)
+  const remoteProject = getRemoteProject(hostId, projectPath)
+  const worktreeName = label || posix.basename(worktreePath)
+  const id = randomUUID().slice(0, 8)
+  const tmuxSession = `pewpew-${id}`
+
+  const branch = await remoteHostRuntime.withPreparedHost(
+    host,
+    async ({ notifyScriptPath, agentPaths }) => {
+      const agentPath = agentPaths[tool]
+      if (!agentPath) {
+        throw new Error(`${tool} is not installed on host ${host.label || host.alias}`)
+      }
+
+      const isWorktree = (
+        await expectRemoteOk(
+          host,
+          ['git', '-C', worktreePath, 'rev-parse', '--is-inside-work-tree'],
+          'Failed to validate remote worktree'
+        )
+      ).trim()
+      if (isWorktree !== 'true') {
+        throw new Error(`${worktreePath} is not a valid git worktree`)
+      }
+
+      const resolvedBranch =
+        (
+          await expectRemoteOk(
+            host,
+            ['git', '-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'],
+            'Failed to resolve remote branch'
+          )
+        ).trim() || 'HEAD'
+
+      await installRemoteAgentHooks(tool, host, worktreePath, notifyScriptPath)
+      await createRemotePty(id, worktreePath, host, { tool, agentPath })
+      return resolvedBranch
+    }
+  )
+
+  const session: Session = {
+    id,
+    hostId,
+    projectPath,
+    projectName: remoteProject.name,
+    worktreeName,
+    worktreePath,
+    branch,
+    issueNumber: parseIssueNumber(worktreeName, branch),
+    pid: 0,
+    tmuxSession,
+    status: 'running',
+    connectionState: 'live',
+    lastActivity: Date.now(),
+    hookEvents: [],
+    tool,
+    ...(remoteProject.repoFingerprint ? { repoFingerprint: remoteProject.repoFingerprint } : {}),
+  }
+
+  sessions.set(id, { session })
+  onSessionsChanged()
+  return session
 }
 
 async function createRemoteSession(

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -596,13 +596,31 @@ export interface MirrorAllResult {
   failed: { path: string; error: string }[]
 }
 
-// Adopts each target worktree concurrently, partitioning fulfilled/rejected
-// outcomes into the mirrored/failed buckets a MirrorAllResult reports.
+// Adopts each target worktree, partitioning fulfilled/rejected outcomes into the
+// mirrored/failed buckets a MirrorAllResult reports. Runs concurrently unless
+// `serialize` is set, in which case adoptions run one at a time (used for remote
+// Codex, where hook installation mutates a shared remote config file).
 async function adoptTargets(
   targets: Worktree[],
-  adopt: (wt: Worktree) => Promise<Session>
+  adopt: (wt: Worktree) => Promise<Session>,
+  serialize = false
 ): Promise<MirrorAllResult> {
-  const results = await Promise.allSettled(targets.map(adopt))
+  const settle = async (wt: Worktree): Promise<PromiseSettledResult<Session>> => {
+    try {
+      return { status: 'fulfilled', value: await adopt(wt) }
+    } catch (reason) {
+      return { status: 'rejected', reason }
+    }
+  }
+
+  let results: PromiseSettledResult<Session>[]
+  if (serialize) {
+    results = []
+    for (const wt of targets) results.push(await settle(wt))
+  } else {
+    results = await Promise.allSettled(targets.map(adopt))
+  }
+
   const mirrored: Session[] = []
   const failed: { path: string; error: string }[] = []
   results.forEach((r, i) => {
@@ -612,11 +630,16 @@ async function adoptTargets(
   return { mirrored, failed }
 }
 
+interface MirrorAllDeps {
+  adopt?: (wt: Worktree) => Promise<Session>
+}
+
 export async function mirrorAllWorktrees(
   projectPath: string,
-  hostId?: string | null
+  hostId?: string | null,
+  deps: MirrorAllDeps = {}
 ): Promise<MirrorAllResult> {
-  if (hostId) return mirrorAllRemoteWorktrees(hostId, projectPath)
+  if (hostId) return mirrorAllRemoteWorktrees(hostId, projectPath, deps)
 
   const worktrees = await gitWorktrees(projectPath)
   const existingPaths = new Set<string>()
@@ -624,12 +647,14 @@ export async function mirrorAllWorktrees(
 
   const targets = worktrees.filter((wt) => !wt.isMain && !existingPaths.has(canonicalPath(wt.path)))
 
-  return adoptTargets(targets, (wt) => createSessionForWorktree(projectPath, wt.path))
+  const adopt = deps.adopt ?? ((wt: Worktree) => createSessionForWorktree(projectPath, wt.path))
+  return adoptTargets(targets, adopt)
 }
 
 async function mirrorAllRemoteWorktrees(
   hostId: string,
-  projectPath: string
+  projectPath: string,
+  deps: MirrorAllDeps = {}
 ): Promise<MirrorAllResult> {
   const host = getRequiredHost(hostId)
   const worktrees = await gitRemoteWorktrees(host, projectPath)
@@ -640,7 +665,13 @@ async function mirrorAllRemoteWorktrees(
 
   const targets = worktrees.filter((wt) => !wt.isMain && !adopted.has(wt.path))
 
-  return adoptTargets(targets, (wt) => createRemoteSessionForWorktree(hostId, projectPath, wt.path))
+  // Concurrent remote Codex adoptions race on the shared remote ~/.codex/
+  // config.toml (written via temp file + mv during hook install), so serialize
+  // them — matching createSessionsForNumbers' remote-Codex batch path.
+  const serialize = getConfig().defaultTool === 'codex'
+  const adopt =
+    deps.adopt ?? ((wt: Worktree) => createRemoteSessionForWorktree(hostId, projectPath, wt.path))
+  return adoptTargets(targets, adopt, serialize)
 }
 
 async function installRemoteAgentHooks(
@@ -664,7 +695,7 @@ async function installRemoteAgentHooks(
   await installRemoteHooks(remote, worktreePath, notifyScriptPath)
 }
 
-// In-flight adoptions for remote worktrees, keyed by `${hostId}\0${worktreePath}`.
+// In-flight adoptions for remote worktrees, keyed by `${hostId} ${worktreePath}`.
 // Mirrors `inflightAdoptions` (local) so a double-click or a concurrent
 // mirror-all only creates one session/PTY per remote worktree.
 const inflightRemoteAdoptions = new Map<string, InflightAdoption>()
@@ -692,7 +723,7 @@ export async function createRemoteSessionForWorktree(
     }
   }
 
-  const key = `${hostId} ${worktreePath}`
+  const key = `${hostId} ${worktreePath}`
   const inflight = inflightRemoteAdoptions.get(key)
   if (inflight) {
     if (inflight.tool !== effectiveTool) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -36,10 +36,10 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.invoke('sessions:open-all-prs', projectPath, hostId ?? null),
   openSessionsForOpenIssues: (projectPath: string, hostId?: string | null) =>
     ipcRenderer.invoke('sessions:open-all-issues', projectPath, hostId ?? null),
-  mirrorWorktree: (projectPath: string, worktreePath: string) =>
-    ipcRenderer.invoke('sessions:mirror', projectPath, worktreePath),
-  mirrorAllWorktrees: (projectPath: string) =>
-    ipcRenderer.invoke('sessions:mirror-all', projectPath),
+  mirrorWorktree: (projectPath: string, worktreePath: string, hostId?: string | null) =>
+    ipcRenderer.invoke('sessions:mirror', projectPath, worktreePath, hostId ?? null),
+  mirrorAllWorktrees: (projectPath: string, hostId?: string | null) =>
+    ipcRenderer.invoke('sessions:mirror-all', projectPath, hostId ?? null),
   getSessions: () => ipcRenderer.invoke('sessions:list'),
   killSession: (id: string) => ipcRenderer.invoke('sessions:kill', id),
   reviveSession: (id: string) => ipcRenderer.invoke('sessions:revive', id),
@@ -118,6 +118,8 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.invoke('projects:add-remote', input),
   removeRemoteProject: (hostId: string, path: string) =>
     ipcRenderer.invoke('projects:remove-remote', hostId, path),
+  listRemoteWorktrees: (hostId: string, path: string) =>
+    ipcRenderer.invoke('projects:list-remote-worktrees', hostId, path),
   onToast: (callback: (event: ToastEvent) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: ToastEvent) => callback(data)
     ipcRenderer.on('toast:show', handler)

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -301,13 +301,20 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
             ? `Mirror all worktrees (${remoteUnmirrored})`
             : 'Mirror all worktrees',
         onClick: async () => {
-          const { result } = await window.api.mirrorAllWorktrees(projectPath, hostId)
-          const { mirrored, failed } = result
-          const parts: string[] = []
-          if (mirrored.length > 0) parts.push(`Mirrored ${mirrored.length}`)
-          if (failed.length > 0) parts.push(`${failed.length} failed`)
-          if (parts.length > 0) showToast(parts.join(', '))
-          void fetchRemoteWorktrees(hostId, projectPath)
+          // Unlike the local path, the remote mirror-all rejects when the host
+          // is unreachable or `git worktree list` fails — surface it as a toast
+          // instead of an unhandled rejection.
+          try {
+            const { result } = await window.api.mirrorAllWorktrees(projectPath, hostId)
+            const { mirrored, failed } = result
+            const parts: string[] = []
+            if (mirrored.length > 0) parts.push(`Mirrored ${mirrored.length}`)
+            if (failed.length > 0) parts.push(`${failed.length} failed`)
+            if (parts.length > 0) showToast(parts.join(', '))
+            void fetchRemoteWorktrees(hostId, projectPath)
+          } catch (err) {
+            showToast(`Mirror all failed: ${String(err)}`)
+          }
         },
       })
       items.push({ label: '', separator: true, onClick: () => {} })

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useRef } from 'react'
-import { useProjectsStore } from '../stores/projects'
+import { useProjectsStore, remoteWorktreeKey } from '../stores/projects'
 import { useSessionsStore } from '../stores/sessions'
 import { useHostsStore } from '../stores/hosts'
 import ContextMenu, { type MenuItem } from './ContextMenu'
@@ -49,6 +49,9 @@ export default function ProjectTree(props: TreeProps) {
 function useProjectTreeElement({ onOpenSession }: TreeProps) {
   const { projects, loading, scanProjects, filterReady } = useProjectsStore()
   const removeRemoteProject = useProjectsStore((s) => s.removeRemoteProject)
+  const remoteWorktreesCache = useProjectsStore((s) => s.remoteWorktrees)
+  const remoteWorktreesStatus = useProjectsStore((s) => s.remoteWorktreesStatus)
+  const fetchRemoteWorktrees = useProjectsStore((s) => s.fetchRemoteWorktrees)
   const { sessions } = useSessionsStore()
   const hosts = useHostsStore((s) => s.hosts)
   const [ui, setUi] = useReducer(projectTreeUiReducer, {
@@ -123,6 +126,18 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
       next.add(path)
     }
     setUi({ expanded: next })
+  }
+
+  // Expanding a remote project lazily lists its worktrees over SSH (and retries
+  // on a prior error). Already-loaded entries are served from the cache.
+  const toggleProject = (projectPath: string, hostId: string | null) => {
+    if (hostId !== null && !expanded.has(projectPath)) {
+      const status = remoteWorktreesStatus[remoteWorktreeKey(hostId, projectPath)]
+      if (status !== 'loading' && status !== 'loaded') {
+        void fetchRemoteWorktrees(hostId, projectPath)
+      }
+    }
+    toggle(projectPath)
   }
 
   const handleContextMenu = (
@@ -265,6 +280,27 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         label: 'Open sessions for all open issues',
         disabled: creating,
         onClick: () => void handleOpenAllIssues(projectPath, hostId),
+      })
+      const remoteWts = remoteWorktreesCache[remoteWorktreeKey(hostId, projectPath)] ?? []
+      const remoteUnmirrored = remoteWts.filter(
+        (wt) =>
+          !wt.isMain &&
+          !sessions.some((s) => s.worktreePath === wt.path && (s.hostId ?? null) === hostId)
+      ).length
+      items.push({
+        label:
+          remoteUnmirrored > 0
+            ? `Mirror all worktrees (${remoteUnmirrored})`
+            : 'Mirror all worktrees',
+        onClick: async () => {
+          const { result } = await window.api.mirrorAllWorktrees(projectPath, hostId)
+          const { mirrored, failed } = result
+          const parts: string[] = []
+          if (mirrored.length > 0) parts.push(`Mirrored ${mirrored.length}`)
+          if (failed.length > 0) parts.push(`${failed.length} failed`)
+          if (parts.length > 0) showToast(parts.join(', '))
+          void fetchRemoteWorktrees(hostId, projectPath)
+        },
       })
       items.push({ label: '', separator: true, onClick: () => {} })
       items.push({
@@ -562,7 +598,14 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
       )}
       {displayProjects.map((project) => {
         const isExpanded = expanded.has(project.path)
-        const hasWorktrees = project.worktrees.length > 1
+        const isRemote = project.hostId !== null
+        const rwKey = isRemote ? remoteWorktreeKey(project.hostId as string, project.path) : ''
+        const remoteWorktrees = isRemote ? remoteWorktreesCache[rwKey] : undefined
+        const remoteStatus = isRemote ? remoteWorktreesStatus[rwKey] : undefined
+        // Remote nodes are always expandable so the first expand can trigger the
+        // SSH listing; local nodes expand only when they have extra worktrees.
+        const worktrees = isRemote ? (remoteWorktrees ?? []) : project.worktrees
+        const canExpand = isRemote || project.worktrees.length > 1
         const host = project.hostId ? hosts.find((h) => h.hostId === project.hostId) : null
 
         return (
@@ -570,14 +613,12 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
             <button
               type="button"
               className="project-row"
-              onClick={() => hasWorktrees && toggle(project.path)}
+              onClick={() => canExpand && toggleProject(project.path, project.hostId)}
               onContextMenu={(e) =>
                 handleContextMenu(e, project.path, project.setupState, project.hostId)
               }
             >
-              <span className="project-toggle">
-                {hasWorktrees ? (isExpanded ? '▼' : '▶') : ' '}
-              </span>
+              <span className="project-toggle">{canExpand ? (isExpanded ? '▼' : '▶') : ' '}</span>
               <span className="project-name">{project.name}</span>
               {host && (
                 <span className="host-pill" title={`Remote on ${host.alias}`}>
@@ -598,8 +639,16 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
 
             {isExpanded && (
               <div className="worktree-list">
-                {project.worktrees.map((wt) => {
-                  const matchingSession = sessions.find((s) => s.worktreePath === wt.path)
+                {isRemote && remoteWorktrees === undefined && remoteStatus === 'loading' && (
+                  <div className="worktree-item worktree-empty">Loading worktrees…</div>
+                )}
+                {isRemote && remoteStatus === 'error' && (
+                  <div className="worktree-item worktree-empty">Failed to load worktrees</div>
+                )}
+                {worktrees.map((wt) => {
+                  const matchingSession = sessions.find(
+                    (s) => s.worktreePath === wt.path && (s.hostId ?? null) === project.hostId
+                  )
                   const canMirror = !matchingSession && !wt.isMain
                   const worktreeContent = (
                     <>
@@ -616,7 +665,8 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
                             try {
                               const { warning } = await window.api.mirrorWorktree(
                                 project.path,
-                                wt.path
+                                wt.path,
+                                project.hostId
                               )
                               if (warning === 'gitignore') {
                                 showToast(

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -12,6 +12,13 @@ interface MenuState {
   items: MenuItem[]
 }
 
+// Expansion state is keyed host-qualified (matching the React node key and the
+// remote worktree cache) so two remote projects that share the same path on
+// different hosts expand and fetch independently.
+function expansionKey(hostId: string | null, path: string): string {
+  return `${hostId ?? 'local'}:${path}`
+}
+
 interface TreeProps {
   onOpenSession?: (id: string, name: string) => void
 }
@@ -131,13 +138,14 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
   // Expanding a remote project lazily lists its worktrees over SSH (and retries
   // on a prior error). Already-loaded entries are served from the cache.
   const toggleProject = (projectPath: string, hostId: string | null) => {
-    if (hostId !== null && !expanded.has(projectPath)) {
+    const key = expansionKey(hostId, projectPath)
+    if (hostId !== null && !expanded.has(key)) {
       const status = remoteWorktreesStatus[remoteWorktreeKey(hostId, projectPath)]
       if (status !== 'loading' && status !== 'loaded') {
         void fetchRemoteWorktrees(hostId, projectPath)
       }
     }
-    toggle(projectPath)
+    toggle(key)
   }
 
   const handleContextMenu = (
@@ -597,7 +605,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         </div>
       )}
       {displayProjects.map((project) => {
-        const isExpanded = expanded.has(project.path)
+        const isExpanded = expanded.has(expansionKey(project.hostId, project.path))
         const isRemote = project.hostId !== null
         const rwKey = isRemote ? remoteWorktreeKey(project.hostId as string, project.path) : ''
         const remoteWorktrees = isRemote ? remoteWorktreesCache[rwKey] : undefined

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -323,7 +323,18 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         onClick: () => void removeRemoteProject(hostId, projectPath),
       })
       items.push({ label: '', separator: true, onClick: () => {} })
-      items.push({ label: 'Rescan', onClick: () => scanProjects() })
+      items.push({
+        label: 'Rescan',
+        onClick: () => {
+          void scanProjects()
+          // scanProjects() does not touch the lazy remote-worktree cache, so
+          // force-refresh it here if this project's worktrees were already
+          // loaded — otherwise added/removed remote worktrees stay stale.
+          if (remoteWorktreesStatus[remoteWorktreeKey(hostId, projectPath)]) {
+            void fetchRemoteWorktrees(hostId, projectPath)
+          }
+        },
+      })
       return items
     }
 

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -15,6 +15,7 @@ import type {
   TestConnectionResult,
   Theme,
   ToastEvent,
+  Worktree,
   WorktreeBase,
 } from '../shared/types'
 
@@ -54,9 +55,13 @@ declare global {
       ) => Promise<OpenSessionsSummary | string>
       mirrorWorktree: (
         projectPath: string,
-        worktreePath: string
+        worktreePath: string,
+        hostId?: string | null
       ) => Promise<{ session: Session; warning?: 'gitignore' }>
-      mirrorAllWorktrees: (projectPath: string) => Promise<{
+      mirrorAllWorktrees: (
+        projectPath: string,
+        hostId?: string | null
+      ) => Promise<{
         result: { mirrored: Session[]; failed: { path: string; error: string }[] }
         warning?: 'gitignore'
       }>
@@ -109,6 +114,7 @@ declare global {
       testHostConnection: (hostId: string) => Promise<TestConnectionResult>
       addRemoteProject: (input: { hostId: string; path: string }) => Promise<RemoteProject>
       removeRemoteProject: (hostId: string, path: string) => Promise<void>
+      listRemoteWorktrees: (hostId: string, path: string) => Promise<Worktree[]>
       onToast: (callback: (event: ToastEvent) => void) => () => void
     }
   }

--- a/src/renderer/stores/projects.test.ts
+++ b/src/renderer/stores/projects.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useProjectsStore, remoteWorktreeKey } from './projects'
+import type { Worktree } from '../../shared/types'
+
+const store = useProjectsStore
+const listRemoteWorktrees = vi.fn()
+
+beforeEach(() => {
+  ;(globalThis as unknown as { window: unknown }).window = {
+    api: { listRemoteWorktrees },
+  }
+  listRemoteWorktrees.mockReset()
+  store.setState({ remoteWorktrees: {}, remoteWorktreesStatus: {} })
+})
+
+afterEach(() => {
+  delete (globalThis as unknown as { window?: unknown }).window
+})
+
+describe('fetchRemoteWorktrees', () => {
+  it('stores worktrees under the host+path key and marks the entry loaded', async () => {
+    const worktrees: Worktree[] = [
+      { name: 'feat', path: '/srv/proj/.claude/worktrees/feat', branch: 'b', isMain: false },
+    ]
+    listRemoteWorktrees.mockResolvedValue(worktrees)
+
+    await store.getState().fetchRemoteWorktrees('h1', '/srv/proj')
+
+    const key = remoteWorktreeKey('h1', '/srv/proj')
+    expect(store.getState().remoteWorktrees[key]).toEqual(worktrees)
+    expect(store.getState().remoteWorktreesStatus[key]).toBe('loaded')
+    expect(listRemoteWorktrees).toHaveBeenCalledWith('h1', '/srv/proj')
+  })
+
+  it('marks the entry as error when the fetch fails', async () => {
+    listRemoteWorktrees.mockRejectedValue(new Error('ssh down'))
+
+    await store.getState().fetchRemoteWorktrees('h1', '/srv/proj')
+
+    const key = remoteWorktreeKey('h1', '/srv/proj')
+    expect(store.getState().remoteWorktreesStatus[key]).toBe('error')
+    expect(store.getState().remoteWorktrees[key]).toBeUndefined()
+  })
+})

--- a/src/renderer/stores/projects.ts
+++ b/src/renderer/stores/projects.ts
@@ -1,5 +1,11 @@
 import { create } from 'zustand'
-import type { Project } from '../../shared/types'
+import type { Project, Worktree } from '../../shared/types'
+
+export type RemoteWorktreesStatus = 'loading' | 'loaded' | 'error'
+
+export function remoteWorktreeKey(hostId: string, path: string): string {
+  return `${hostId} ${path}`
+}
 
 interface ProjectsState {
   projects: Project[]
@@ -8,7 +14,13 @@ interface ProjectsState {
   addRemoteDialogOpen: boolean
   addRemoteError: string | null
   addRemoteSubmitting: boolean
+  // Remote worktrees are fetched lazily over SSH (on node expand), keyed by
+  // remoteWorktreeKey(hostId, path). This cache survives scanProjects(), which
+  // only replaces `projects`.
+  remoteWorktrees: Record<string, Worktree[]>
+  remoteWorktreesStatus: Record<string, RemoteWorktreesStatus>
   scanProjects: () => Promise<void>
+  fetchRemoteWorktrees: (hostId: string, path: string) => Promise<void>
   toggleFilterReady: () => void
   openAddRemoteDialog: () => void
   closeAddRemoteDialog: () => void
@@ -30,6 +42,8 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
   addRemoteDialogOpen: false,
   addRemoteError: null,
   addRemoteSubmitting: false,
+  remoteWorktrees: {},
+  remoteWorktreesStatus: {},
   toggleFilterReady: () => set((state) => ({ filterReady: !state.filterReady })),
   scanProjects: async () => {
     set({ loading: true })
@@ -39,6 +53,24 @@ export const useProjectsStore = create<ProjectsState>((set, get) => ({
     } catch (err) {
       console.error('scanProjects failed:', err)
       set({ loading: false })
+    }
+  },
+  fetchRemoteWorktrees: async (hostId, path) => {
+    const key = remoteWorktreeKey(hostId, path)
+    set((state) => ({
+      remoteWorktreesStatus: { ...state.remoteWorktreesStatus, [key]: 'loading' },
+    }))
+    try {
+      const worktrees = await window.api.listRemoteWorktrees(hostId, path)
+      set((state) => ({
+        remoteWorktrees: { ...state.remoteWorktrees, [key]: worktrees },
+        remoteWorktreesStatus: { ...state.remoteWorktreesStatus, [key]: 'loaded' },
+      }))
+    } catch (e) {
+      console.error('listRemoteWorktrees failed:', e)
+      set((state) => ({
+        remoteWorktreesStatus: { ...state.remoteWorktreesStatus, [key]: 'error' },
+      }))
     }
   },
   openAddRemoteDialog: () =>


### PR DESCRIPTION
## Summary

Remote projects can now **mirror** (adopt) their existing git worktrees as pewpew sessions — reaching parity with local projects, which already support per-worktree `+ Mirror` buttons and a `Mirror all worktrees` menu item.

Previously remote projects exposed no worktrees at all (`toProject()` hardcoded `worktrees: []`) and the mirror IPC path was local-only.

## Changes

**Backend (`src/main`)**
- `parseWorktreeList` takes an optional `baseName` fn; remote callers pass `posix.basename` so SSH-listed POSIX paths parse correctly regardless of host OS.
- `gitRemoteWorktrees(host, projectPath)` lists worktrees over SSH (`git worktree list --porcelain`), throwing with stderr detail on failure.
- `createRemoteSessionForWorktree` / `adoptRemoteWorktree` adopt an *existing* remote worktree — install hooks + attach a PTY via `withPreparedHost`, **without** running `git worktree add`. Includes dedup (hostId+path), in-flight serialization, mixed-tool rejection, and worktree validation.
- `mirrorAllWorktrees(projectPath, hostId?)` routes to a remote variant (shared `adoptTargets` helper for result collation).
- IPC: `sessions:mirror` / `sessions:mirror-all` accept `hostId` (gitignore warning skipped for remote — it's a local-fs check); new `projects:list-remote-worktrees`.

**Renderer**
- Projects store gains a lazy remote-worktree cache (`remoteWorktrees` / `remoteWorktreesStatus` / `fetchRemoteWorktrees`) that survives the frequent `scanProjects()`.
- `ProjectTree` makes remote nodes expandable; first expand fetches over SSH (loading/error states), renders `+ Mirror` per worktree, adds **Mirror all worktrees (n)** to the remote context menu, and matches sessions on `worktreePath` **and** `hostId`.

## Design note

Worktrees are fetched **lazily on expand** (not during scan): `projects:scan` runs on nearly every session/host change, so keeping it SSH-free avoids round-trips on every UI event.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint .` — clean
- `npx vitest run` — 424 passing (32 new tests covering `parseWorktreeList` basename, `gitRemoteWorktrees`, remote worktree adoption, remote `mirrorAllWorktrees`, and the store cache)

Built test-first (red→green→refactor). The only path not exercised in-process is the live SSH round-trip, which needs a real remote host: register a remote project with extra worktrees, expand it, and mirror.