### PR TITLE
feat: surface remote dependency status in host connection test

### DIFF
--- a/src/main/host-bootstrap.test.ts
+++ b/src/main/host-bootstrap.test.ts
@@ -3,7 +3,9 @@ import {
   bootstrapHost,
   HostBootstrapError,
   NOTIFY_SCRIPT_VERSION,
+  probeMissingDeps,
   resolveRemoteAgents,
+  STRICT_DEPS,
   type AgentResolution,
   type HostBootstrapConnection,
 } from './host-bootstrap'
@@ -209,6 +211,37 @@ describe('bootstrapHost', () => {
     await expect(
       bootstrapHost('host-probe-nonzero', failingConn, '/tmp/ipc')
     ).rejects.toMatchObject({ kind: 'install-failed' })
+  })
+})
+
+describe('probeMissingDeps', () => {
+  it('returns an empty array when every dep is present', async () => {
+    const conn: HostBootstrapConnection = { exec: async () => ok('\n') }
+    expect(await probeMissingDeps(conn)).toEqual([])
+  })
+
+  it('returns only the deps the probe reports missing, filtered to the requested set', async () => {
+    const conn: HostBootstrapConnection = { exec: async () => ok(' socat jq\n') }
+    expect(await probeMissingDeps(conn)).toEqual(['jq', 'socat'])
+  })
+
+  it('passes the requested deps to the probe as positional args', async () => {
+    const calls: string[][] = []
+    const conn: HostBootstrapConnection = {
+      exec: async (argv) => {
+        calls.push(argv)
+        return ok('\n')
+      },
+    }
+    await probeMissingDeps(conn)
+    expect(calls[0].slice(-STRICT_DEPS.length)).toEqual([...STRICT_DEPS])
+  })
+
+  it('throws missing-deps when the probe itself fails to run', async () => {
+    const conn: HostBootstrapConnection = {
+      exec: async () => ({ stdout: '', stderr: 'boom', code: 1, timedOut: false }),
+    }
+    await expect(probeMissingDeps(conn)).rejects.toMatchObject({ kind: 'missing-deps' })
   })
 })
 

--- a/src/main/host-bootstrap.ts
+++ b/src/main/host-bootstrap.ts
@@ -4,8 +4,11 @@ import type { AgentTool } from '../shared/types'
 
 export const NOTIFY_SCRIPT_VERSION = 1
 
-const STRICT_DEPS = ['tmux', 'git', 'jq', 'socat'] as const
-const AGENT_TOOLS: readonly AgentTool[] = ['claude', 'codex'] as const
+// Tools pewpew strictly requires on a remote host for sessions and the notify
+// hook to work. Exported so the connection-test flow can surface missing ones
+// up front instead of letting a session/mirror fail deep in bootstrap.
+export const STRICT_DEPS = ['tmux', 'git', 'jq', 'socat'] as const
+export const AGENT_TOOLS: readonly AgentTool[] = ['claude', 'codex'] as const
 
 const notifyScript = `#!/usr/bin/env bash
 # pewpew notify script v${NOTIFY_SCRIPT_VERSION}
@@ -148,6 +151,22 @@ export function invalidateBootstrap(hostId: string): void {
   bootstrapped.delete(hostId)
 }
 
+// Probe the remote for which of `deps` are missing, in a single ssh round
+// trip. Returns the subset of `deps` not found on PATH (empty = all present).
+// Throws HostBootstrapError('missing-deps') only when the probe itself fails to
+// run (timeout / non-zero), never for a tool simply being absent.
+export async function probeMissingDeps(
+  connection: HostBootstrapConnection,
+  deps: readonly string[] = STRICT_DEPS
+): Promise<string[]> {
+  const depProbe =
+    'missing=""; for dep in "$@"; do command -v "$dep" >/dev/null 2>&1 || missing="$missing $dep"; done; printf "%s\\n" "$missing"'
+  const result = await connection.exec(['sh', '-c', depProbe, '_', ...deps], { timeoutMs: 15000 })
+  await expectOk(result, 'missing-deps', 'Dependency probe failed')
+  const missing = new Set(result.stdout.trim().split(/\s+/).filter(Boolean))
+  return deps.filter((d) => missing.has(d))
+}
+
 async function expectOk(
   result: ExecResult,
   kind: HostBootstrapErrorKind,
@@ -176,14 +195,7 @@ export async function bootstrapHost(
     return { ...cached, agentPaths }
   }
 
-  const depProbe =
-    'missing=""; for dep in "$@"; do command -v "$dep" >/dev/null 2>&1 || missing="$missing $dep"; done; printf "%s\\n" "$missing"'
-  const deps = await connection.exec(['sh', '-c', depProbe, '_', ...STRICT_DEPS], {
-    timeoutMs: 15000,
-  })
-  await expectOk(deps, 'missing-deps', 'Dependency probe failed')
-  const missing = new Set(deps.stdout.trim().split(/\s+/).filter(Boolean))
-  const missingStrict = STRICT_DEPS.filter((d) => missing.has(d))
+  const missingStrict = await probeMissingDeps(connection)
   if (missingStrict.length > 0) {
     throw new HostBootstrapError(
       'missing-deps',

--- a/src/main/host-connection.test.ts
+++ b/src/main/host-connection.test.ts
@@ -85,6 +85,7 @@ import {
   ensureHostConnection,
   stopHostConnection,
   runtimeStateFor,
+  testConnection,
 } from './host-connection'
 
 const HOST: Host = { hostId: 'h1', alias: 'dev', label: 'Devbox' }
@@ -372,5 +373,86 @@ describe('ensureHostConnection / startRuntime', () => {
     await expect(promise).rejects.toThrow(/Permission denied/)
     expect(runtimeStateFor(HOST.hostId)).toBe('auth-failed')
     await stopHostConnection(HOST.hostId)
+  })
+})
+
+describe('testConnection', () => {
+  const okResult = (stdout = ''): FakeResult => ({ stdout, stderr: '', error: null, exitCode: 0 })
+  const failResult = (stderr: string, code: number): FakeResult => ({
+    stdout: '',
+    stderr,
+    error: { name: 'Error', message: 'x', code } as unknown as NodeJS.ErrnoException,
+    exitCode: code,
+  })
+
+  it('returns network when the connectivity probe times out', async () => {
+    nextResult = {
+      stdout: '',
+      stderr: '',
+      error: Object.assign(new Error('timeout'), { killed: true }) as NodeJS.ErrnoException & {
+        killed?: boolean
+      },
+      exitCode: null,
+    }
+    const result = await testConnection('dev')
+    expect(result).toEqual({ ok: false, reason: 'network', message: 'ssh timed out' })
+  })
+
+  it('returns auth-failed without probing deps when auth is rejected', async () => {
+    nextResult = failResult('Permission denied (publickey).', 255)
+    const result = await testConnection('dev')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('auth-failed')
+    // Only the connectivity probe ran — no dep/agent probes follow a failure.
+    expect(execFileCalls).toHaveLength(1)
+  })
+
+  it('reports all required tools present and agents resolved on a healthy host', async () => {
+    resultResolver = (args) => {
+      const joined = args.join(' ')
+      if (joined.includes('resolve_one claude'))
+        return okResult('/usr/bin/claude\n/usr/bin/codex\n')
+      if (joined.includes('command -v') && joined.includes('missing=')) return okResult('\n')
+      return okResult() // connectivity `true`
+    }
+    const result = await testConnection('dev')
+    expect(result.ok).toBe(true)
+    expect(result.requiredDeps).toEqual([
+      { name: 'tmux', installed: true },
+      { name: 'git', installed: true },
+      { name: 'jq', installed: true },
+      { name: 'socat', installed: true },
+    ])
+    expect(result.agentTools).toEqual([
+      { name: 'claude', installed: true },
+      { name: 'codex', installed: true },
+    ])
+  })
+
+  it('flags a missing required tool (socat) while staying connected', async () => {
+    resultResolver = (args) => {
+      const joined = args.join(' ')
+      if (joined.includes('resolve_one claude')) return okResult('/usr/bin/claude\n\n')
+      if (joined.includes('command -v') && joined.includes('missing=')) return okResult(' socat\n')
+      return okResult()
+    }
+    const result = await testConnection('dev')
+    expect(result.ok).toBe(true)
+    expect(result.requiredDeps?.filter((d) => !d.installed).map((d) => d.name)).toEqual(['socat'])
+    expect(result.agentTools).toEqual([
+      { name: 'claude', installed: true },
+      { name: 'codex', installed: false },
+    ])
+  })
+
+  it('leaves dep fields undefined when probes error but the host is reachable', async () => {
+    resultResolver = (args) => {
+      const joined = args.join(' ')
+      if (joined.includes('resolve_one claude')) return failResult('boom', 1)
+      if (joined.includes('command -v') && joined.includes('missing=')) return failResult('boom', 1)
+      return okResult()
+    }
+    const result = await testConnection('dev')
+    expect(result).toEqual({ ok: true, requiredDeps: undefined, agentTools: undefined })
   })
 })

--- a/src/main/host-connection.ts
+++ b/src/main/host-connection.ts
@@ -12,6 +12,13 @@ import { homedir, userInfo } from 'os'
 import * as pty from 'node-pty'
 import type { IPty, IPtyForkOptions } from 'node-pty'
 import { shellQuote } from './shell-quote'
+import {
+  STRICT_DEPS,
+  AGENT_TOOLS,
+  probeMissingDeps,
+  resolveRemoteAgents,
+  type HostBootstrapConnection,
+} from './host-bootstrap'
 import { classifySshExit } from './ssh-exit-parser'
 import { recordSshInvocation } from './ssh-log-buffer'
 import { emitToast } from './notifications'
@@ -19,6 +26,7 @@ import { getHost } from './host-registry'
 import { CONFIG_DIR } from './config'
 import { sanitizeHostIdForPath } from './host-id'
 import type {
+  DependencyStatus,
   Host,
   HostId,
   SshInvocationKind,
@@ -498,11 +506,43 @@ export async function testConnection(
   if (timedOut) {
     return { ok: false, reason: 'network', message: 'ssh timed out' }
   }
-  if (code === 0) {
-    return { ok: true }
+  if (code !== 0) {
+    const { reason, message } = classifySshExit({ exitCode: code, stderr })
+    return { ok: false, reason, message }
   }
-  const { reason, message } = classifySshExit({ exitCode: code, stderr })
-  return { ok: false, reason, message }
+
+  // Connection works — probe the required tools and agent CLIs so the user
+  // sees exactly what's missing (e.g. socat) before a session or mirror fails
+  // deep in host bootstrap. Probes are best-effort: a probe that errors leaves
+  // its field undefined rather than failing the whole test.
+  const connection: HostBootstrapConnection = { exec: (a, o) => exec(alias, a, o) }
+  const [requiredDeps, agentTools] = await Promise.all([
+    probeRequiredDeps(connection),
+    probeAgentTools(connection),
+  ])
+  return { ok: true, requiredDeps, agentTools }
+}
+
+async function probeRequiredDeps(
+  connection: HostBootstrapConnection
+): Promise<DependencyStatus[] | undefined> {
+  try {
+    const missing = new Set(await probeMissingDeps(connection))
+    return STRICT_DEPS.map((name) => ({ name, installed: !missing.has(name) }))
+  } catch {
+    return undefined
+  }
+}
+
+async function probeAgentTools(
+  connection: HostBootstrapConnection
+): Promise<DependencyStatus[] | undefined> {
+  try {
+    const resolved = await resolveRemoteAgents(connection)
+    return AGENT_TOOLS.map((name) => ({ name, installed: Boolean(resolved[name]) }))
+  } catch {
+    return undefined
+  }
 }
 
 function aliasOf(aliasOrHost: string | Host): string {

--- a/src/renderer/components/ManageHostsDialog.tsx
+++ b/src/renderer/components/ManageHostsDialog.tsx
@@ -15,6 +15,47 @@ function reasonToLabel(reason: TestConnectionResult['reason']): string {
   }
 }
 
+function HostTestResult({ result }: { result: TestConnectionResult }) {
+  if (!result.ok) {
+    return (
+      <div className="host-test-result err">
+        {reasonToLabel(result.reason)}
+        {result.message ? `: ${result.message}` : ''}
+      </div>
+    )
+  }
+
+  const missing = (result.requiredDeps ?? []).filter((d) => !d.installed).map((d) => d.name)
+  const headlineClass = missing.length > 0 ? 'warn' : 'ok'
+
+  return (
+    <div className={`host-test-result ${headlineClass}`}>
+      <div className="host-test-headline">
+        {missing.length > 0 ? `Connected — missing: ${missing.join(', ')}` : 'Connected'}
+      </div>
+      {result.requiredDeps && (
+        <div className="host-test-deps">
+          {result.requiredDeps.map((d) => (
+            <span key={d.name} className={`host-dep ${d.installed ? 'ok' : 'err'}`}>
+              {d.installed ? '✓' : '✗'} {d.name}
+            </span>
+          ))}
+        </div>
+      )}
+      {result.agentTools && result.agentTools.length > 0 && (
+        <div className="host-test-deps agents">
+          <span className="host-dep-label">Agents:</span>
+          {result.agentTools.map((d) => (
+            <span key={d.name} className={`host-dep ${d.installed ? 'ok' : 'muted'}`}>
+              {d.installed ? '✓' : '–'} {d.name}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 interface HostFormProps {
   initialAlias?: string
   initialLabel?: string
@@ -193,13 +234,7 @@ function HostRow({ host, testing, result, onTest, onEdit, onDelete }: HostRowPro
       <div className="hosts-row-main">
         <div className="host-label">{host.label}</div>
         <div className="host-alias">{host.alias}</div>
-        {result && (
-          <div className={`host-test-result ${result.ok ? 'ok' : 'err'}`}>
-            {result.ok
-              ? 'OK'
-              : `${reasonToLabel(result.reason)}${result.message ? `: ${result.message}` : ''}`}
-          </div>
-        )}
+        {result && <HostTestResult result={result} />}
       </div>
       <div className="host-actions">
         <button className="create-btn" onClick={onTest} disabled={testing}>

--- a/src/renderer/stores/hosts.ts
+++ b/src/renderer/stores/hosts.ts
@@ -71,9 +71,12 @@ export const useHostsStore = create<HostsState>((set, get) => ({
 
   addHost: async (alias, label) => {
     try {
-      await window.api.addHost(alias, label)
+      const host = await window.api.addHost(alias, label)
       set({ addingNew: false, error: null })
       await get().fetchHosts()
+      // Immediately probe the new host so the user sees connectivity + missing
+      // tools (e.g. socat) right after setting it up, not when a session fails.
+      void get().testHost(host.hostId)
     } catch (e) {
       set({ error: errorMessage(e) })
       throw e

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1259,12 +1259,49 @@ body,
   margin-top: 2px;
 }
 
-.host-test-result.ok {
+.host-test-result.ok .host-test-headline {
   color: var(--accent-green);
+}
+
+.host-test-result.warn .host-test-headline {
+  color: var(--accent-orange);
 }
 
 .host-test-result.err {
   color: var(--accent-error);
+}
+
+.host-test-headline {
+  font-weight: 600;
+}
+
+.host-test-deps {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.host-dep-label {
+  color: var(--text-secondary);
+}
+
+.host-dep {
+  font-family: monospace;
+  white-space: nowrap;
+}
+
+.host-dep.ok {
+  color: var(--accent-green);
+}
+
+.host-dep.err {
+  color: var(--accent-error);
+}
+
+.host-dep.muted {
+  color: var(--text-secondary);
 }
 
 .host-actions {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -134,10 +134,21 @@ export interface Host {
 
 export type SshExitReason = 'auth-failed' | 'network' | 'dep-missing' | 'bind-unlink' | 'unknown'
 
+// One probed tool on a remote host and whether it was found on PATH.
+export interface DependencyStatus {
+  name: string
+  installed: boolean
+}
+
 export interface TestConnectionResult {
   ok: boolean
   reason?: SshExitReason
   message?: string
+  // Populated when the connection succeeds and the host could be probed.
+  // requiredDeps are the tools pewpew strictly needs (tmux, git, jq, socat);
+  // agentTools are the optional agent CLIs (claude, codex), shown for info.
+  requiredDeps?: DependencyStatus[]
+  agentTools?: DependencyStatus[]
 }
 
 export interface RemoteProject {


### PR DESCRIPTION
## Problem

Setting up a remote didn't verify its dependencies. A missing tool only surfaced later — when mirroring a worktree or creating a session — as a raw, unhandled error:

```
Error occurred in handler for 'sessions:mirror': HostBootstrapError: Remote host is missing required tools: socat
  ... kind: 'missing-deps', missingDeps: [ 'socat' ]
```

## Change

The remote **Test** now checks connectivity **and** dependencies. After the SSH connection succeeds, `testConnection` probes the required tools (`tmux`, `git`, `jq`, `socat`) and the agent CLIs (`claude`, `codex`) and reports their status in the UI — so a missing `socat` is shown up front instead of failing deep in host bootstrap.

### Main process
- `host-bootstrap.ts`: export `STRICT_DEPS`/`AGENT_TOOLS` and extract the inline strict-deps probe into a reusable `probeMissingDeps()`; `bootstrapHost` now calls it (probe script text unchanged, so behavior is identical).
- `host-connection.ts`: after a successful connect, `testConnection` probes `requiredDeps` and `agentTools`. Probes are best-effort — a probe that errors leaves its field `undefined` rather than failing the whole test. Auth/network failures short-circuit before probing.
- `types.ts`: add `DependencyStatus` and extend `TestConnectionResult` with `requiredDeps` / `agentTools`.

### Renderer
- Manage Hosts dialog: a successful test shows a green **Connected** with a per-tool ✓/✗ breakdown, or an orange **Connected — missing: \<tools\>** warning, plus an informational `Agents:` line. Failures render as before.
- Adding a host auto-runs the check, so missing tools surface at setup time.

## Verification
- `npx tsc --noEmit`, `npx eslint`, `npx prettier --check`: clean
- `npx vitest run`: **435 passed** (added `probeMissingDeps` unit tests and a `testConnection` suite covering all-present, missing-socat, auth-failed-no-probe, timeout, and probe-error tolerance)
- Visually verified via CDP against the real Manage Hosts dialog: healthy hosts show the green breakdown with real data; the warning state renders **Connected — missing: socat** (`✓ tmux ✓ git ✓ jq ✗ socat`); the error state renders **Auth failed: Permission denied (publickey).**