### PR TITLE
fix: spawn fresh remote session when there's no conversation to continue

### DIFF
--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -19,7 +19,12 @@ const state = vi.hoisted(() => ({
   runtimeStates: new Map<string, string>(),
   // Call logs for assertion.
   ensureHostConnectionCalls: [] as string[],
-  createRemotePtyCalls: [] as { sessionId: string; cwd: string; hostId: string }[],
+  createRemotePtyCalls: [] as {
+    sessionId: string
+    cwd: string
+    hostId: string
+    continueSession?: boolean
+  }[],
   reattachRemotePtyCalls: [] as { sessionId: string; hostId: string }[],
   createPtyCalls: [] as { sessionId: string; cwd: string }[],
   reattachPtyCalls: [] as string[],
@@ -40,6 +45,10 @@ const state = vi.hoisted(() => ({
     string,
     { stdout: string; stderr: string; code: number; timedOut: boolean }
   >(),
+  // Keyed by worktreePath: controls the remote `claude --continue` history probe
+  // (hasRemoteClaudeConversationHistory). true → directory present (resume),
+  // false → absent (spawn fresh). Unset falls through to the default code 0.
+  claudeHistoryProbeResult: new Map<string, boolean>(),
   // Toggle to simulate ensureHostConnection throwing.
   ensureHostConnectionThrows: null as null | { message: string; runtimeStateAfter: string },
   // When set, delays next ensureHostConnection resolution (used for idempotency
@@ -172,8 +181,18 @@ vi.mock('./pty-manager', () => ({
     // PTY's lifetime so the runtime survives the caller's release.
     state.runtimeRefs.set(host.hostId, (state.runtimeRefs.get(host.hostId) ?? 0) + 1)
   },
-  createRemotePty: async (sessionId: string, cwd: string, host: Host) => {
-    state.createRemotePtyCalls.push({ sessionId, cwd, hostId: host.hostId })
+  createRemotePty: async (
+    sessionId: string,
+    cwd: string,
+    host: Host,
+    options?: { continueSession?: boolean }
+  ) => {
+    state.createRemotePtyCalls.push({
+      sessionId,
+      cwd,
+      hostId: host.hostId,
+      continueSession: options?.continueSession,
+    })
     state.runtimeRefs.set(host.hostId, (state.runtimeRefs.get(host.hostId) ?? 0) + 1)
   },
   setUnexpectedExitListener: (fn: null | ((sessionId: string) => void)) => {
@@ -196,6 +215,15 @@ vi.mock('./host-connection', () => ({
   exec: async (hostOrAlias: Host | string, argv: string[]) => {
     const hostId = typeof hostOrAlias === 'string' ? hostOrAlias : hostOrAlias.hostId
     state.execRemoteCalls.push({ hostId, argv })
+    // Conversation-history probe: matched by the recognizable `.claude/projects`
+    // substring in its script so the test doesn't reproduce the exact (escaped,
+    // multi-segment) probe command. The probed worktree path is the last arg.
+    if (argv[0] === 'sh' && typeof argv[2] === 'string' && argv[2].includes('.claude/projects')) {
+      const present = state.claudeHistoryProbeResult.get(argv[argv.length - 1])
+      if (present !== undefined) {
+        return { stdout: '', stderr: '', code: present ? 0 : 1, timedOut: false }
+      }
+    }
     const configured = state.execRemoteResults.get(argv.join(' '))
     if (configured) return configured
     return { stdout: '', stderr: '', code: 0, timedOut: false }
@@ -305,6 +333,7 @@ beforeEach(() => {
   state.probeSideEffect = new Map()
   state.execRemoteCalls = []
   state.execRemoteResults = new Map()
+  state.claudeHistoryProbeResult = new Map()
   state.ensureHostConnectionThrows = null
   state.ensureHostConnectionGate = null
   state.unexpectedExitListener = null
@@ -1696,6 +1725,54 @@ describe('kill/revive clears stale connectionState=pending', () => {
     expect(got.status).toBe('idle')
     expect(got.connectionState).toBeUndefined()
     expect(state.createPtyCalls.map((c) => c.sessionId)).toEqual(['l1'])
+  })
+})
+
+describe('reviveSession — remote resume fallback', () => {
+  // Regression: the remote branch hardcoded `--continue`, so reviving a remote
+  // session with no prior conversation (e.g. a freshly mirrored worktree)
+  // spawned `claude --continue`, which prints "No conversation found to
+  // continue" and collapses the pane. It must spawn fresh instead.
+  it('spawns fresh when the remote has no claude conversation history', async () => {
+    const remote = baseRemoteSession({ id: 'r1', status: 'dead' })
+    writeSessionsJson([remote])
+    state.claudeHistoryProbeResult.set(remote.worktreePath, false)
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.reviveSession('r1')
+
+    expect(state.createRemotePtyCalls).toEqual([
+      { sessionId: 'r1', cwd: remote.worktreePath, hostId: 'h1', continueSession: false },
+    ])
+    expect(sm.getSessions()[0].status).toBe('idle')
+  })
+
+  it('resumes when the remote has claude conversation history', async () => {
+    const remote = baseRemoteSession({ id: 'r1', status: 'dead' })
+    writeSessionsJson([remote])
+    state.claudeHistoryProbeResult.set(remote.worktreePath, true)
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.reviveSession('r1')
+
+    expect(state.createRemotePtyCalls).toEqual([
+      { sessionId: 'r1', cwd: remote.worktreePath, hostId: 'h1', continueSession: true },
+    ])
+  })
+
+  it('spawns fresh for codex without a captured agentSessionId', async () => {
+    const remote = baseRemoteSession({ id: 'r1', status: 'dead', tool: 'codex' })
+    writeSessionsJson([remote])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    await sm.reviveSession('r1')
+
+    expect(state.createRemotePtyCalls).toEqual([
+      { sessionId: 'r1', cwd: remote.worktreePath, hostId: 'h1', continueSession: false },
+    ])
   })
 })
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1529,8 +1529,14 @@ export async function reviveSession(id: string): Promise<void> {
           if (!agentPath) {
             throw new Error(`${session.tool} is not installed on host ${host.label || host.alias}`)
           }
+          const canResume = await canResumeRemoteAgent(session, host)
+          if (!canResume) {
+            console.warn(
+              `Session ${id} (${session.tool}) has no prior conversation on host ${host.alias}; spawning fresh instead of resuming`
+            )
+          }
           await createRemotePty(id, session.worktreePath, host, {
-            continueSession: true,
+            continueSession: canResume,
             tool: session.tool,
             agentSessionId: session.agentSessionId,
             agentPath,
@@ -1577,6 +1583,17 @@ export async function reviveSession(id: string): Promise<void> {
 function canResumeAgent(session: Session): boolean {
   if (session.tool === 'codex') return !!session.agentSessionId
   return hasClaudeConversationHistory(session.worktreePath)
+}
+
+// Remote analogue of canResumeAgent. The remote branch of reviveSession used to
+// hardcode `--continue`, so reviving a remote session with no prior
+// conversation (e.g. a freshly mirrored worktree that was never talked to) made
+// `claude --continue` print "No conversation found to continue" and collapse
+// the pane on spawn. Probe the remote first and spawn fresh when there's
+// nothing to resume, matching the local guard.
+async function canResumeRemoteAgent(session: Session, host: Host): Promise<boolean> {
+  if (session.tool === 'codex') return !!session.agentSessionId
+  return hasRemoteClaudeConversationHistory(host, session.worktreePath)
 }
 
 // On-demand local attach for sessions deferred during restoreSessions().
@@ -2514,6 +2531,31 @@ export async function relocateProject(
 function hasClaudeConversationHistory(worktreePath: string): boolean {
   const encoded = canonicalPath(worktreePath).replace(/[^a-zA-Z0-9-]/g, '-')
   return existsSync(join(homedir(), '.claude', 'projects', encoded))
+}
+
+// Remote analogue of hasClaudeConversationHistory. Claude keys the per-worktree
+// directory off the *canonical* path, so we `readlink -f` on the remote before
+// applying the same `[^a-zA-Z0-9-]` → '-' encoding, then test for the directory
+// under the remote $HOME. Runs as a single positional-arg `sh -c` so paths with
+// shell metacharacters stay inert. Any SSH/probe failure returns false, so
+// revival falls back to a fresh spawn rather than risk `claude --continue`
+// exiting immediately.
+async function hasRemoteClaudeConversationHistory(
+  host: Host,
+  worktreePath: string
+): Promise<boolean> {
+  const script =
+    'p=$(readlink -f -- "$1" 2>/dev/null); [ -n "$p" ] || p="$1"; ' +
+    "enc=$(printf '%s' \"$p\" | sed 's/[^a-zA-Z0-9-]/-/g'); " +
+    '[ -d "$HOME/.claude/projects/$enc" ]'
+  try {
+    const result = await execRemote(host, ['sh', '-c', script, '_', worktreePath], {
+      timeoutMs: 10000,
+    })
+    return !result.timedOut && result.code === 0
+  } catch {
+    return false
+  }
 }
 
 // Backfill / reconcile fields added in later versions. For local sessions

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -2534,18 +2534,21 @@ function hasClaudeConversationHistory(worktreePath: string): boolean {
 }
 
 // Remote analogue of hasClaudeConversationHistory. Claude keys the per-worktree
-// directory off the *canonical* path, so we `readlink -f` on the remote before
-// applying the same `[^a-zA-Z0-9-]` → '-' encoding, then test for the directory
-// under the remote $HOME. Runs as a single positional-arg `sh -c` so paths with
-// shell metacharacters stay inert. Any SSH/probe failure returns false, so
-// revival falls back to a fresh spawn rather than risk `claude --continue`
-// exiting immediately.
+// directory off the *canonical* path, so we resolve symlinks on the remote
+// before applying the same `[^a-zA-Z0-9-]` → '-' encoding, then test for the
+// directory under the remote $HOME. Canonicalization uses `cd -P`/`pwd -P`
+// (POSIX shell builtins) rather than `readlink -f`, which is GNU-only — BSD
+// (macOS) readlink has no `-f` and would silently leave the symlink path
+// unresolved, missing the conversation. Runs as a single positional-arg `sh -c`
+// so paths with shell metacharacters stay inert. Any SSH/probe failure returns
+// false, so revival falls back to a fresh spawn rather than risk
+// `claude --continue` exiting immediately.
 async function hasRemoteClaudeConversationHistory(
   host: Host,
   worktreePath: string
 ): Promise<boolean> {
   const script =
-    'p=$(readlink -f -- "$1" 2>/dev/null); [ -n "$p" ] || p="$1"; ' +
+    'p=$(CDPATH= cd -P -- "$1" 2>/dev/null && pwd -P); [ -n "$p" ] || p="$1"; ' +
     "enc=$(printf '%s' \"$p\" | sed 's/[^a-zA-Z0-9-]/-/g'); " +
     '[ -d "$HOME/.claude/projects/$enc" ]'
   try {


### PR DESCRIPTION
## Problem

On a remote project, reviving a session (e.g. "Restart terminal" after mirroring a worktree) showed:

> No conversation found to continue

…and the pane collapsed. This happens whenever `claude --continue` runs but no prior conversation exists for the worktree.

## Root cause

`reviveSession` in `src/main/session-manager.ts` was inconsistent between local and remote:

- **Local** revive already guarded against this — `canResumeAgent()` → `hasClaudeConversationHistory()` checks for `~/.claude/projects/<encoded-path>` and spawns fresh when it's missing.
- **Remote** revive hardcoded `continueSession: true` with no equivalent check, so it always ran `claude --continue` even when there was nothing to continue.

## Fix

Give the remote path the same guard the local path already has:

1. **`hasRemoteClaudeConversationHistory(host, worktreePath)`** — SSH-probes the remote for `$HOME/.claude/projects/<encoded>`, applying the same canonical-path (`readlink -f`) + `[^a-zA-Z0-9-]`→`-` encoding Claude uses, via a single positional-arg `sh -c` so paths with shell metacharacters stay inert. Any SSH/probe failure returns `false`, biasing toward a safe fresh spawn.
2. **`canResumeRemoteAgent(session, host)`** — remote analogue of `canResumeAgent` (codex keeps keying off `agentSessionId`; claude uses the probe).
3. **`reviveSession`'s remote branch** now computes `continueSession` from that instead of hardcoding `true`, with a `console.warn` when falling back — matching the local branch.

Net effect: when there's no conversation to continue, pewpew starts a brand-new session instead of surfacing the error.

## Tests

Added 3 regression tests in `session-manager.test.ts`:
- remote revive with no history → spawns fresh (`continueSession: false`)
- remote revive with history → resumes (`continueSession: true`)
- codex without a captured `agentSessionId` → spawns fresh

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` — clean
- `npx prettier --check` — clean
- `npx vitest run src/main/session-manager.test.ts` — 116 passed