### PR TITLE
feat: filter bulk issue sessions by label with open confirmation

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -33,6 +33,7 @@ export interface AppConfig {
   defaultTool: AgentTool
   worktreeBase: WorktreeBase
   theme: Theme
+  bulkOpenConfirmThreshold: number
 }
 
 export const CONFIG_DIR = join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'pewpew')
@@ -53,6 +54,7 @@ const DEFAULT_CONFIG: AppConfig = {
   defaultTool: 'claude',
   worktreeBase: 'local',
   theme: 'dark',
+  bulkOpenConfirmThreshold: 20,
 }
 
 export function shouldWarnGitignore(projectPath: string): boolean {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,8 @@ import {
   createPrSessions,
   openSessionsForOpenPrs,
   openSessionsForOpenIssues,
+  countOpenIssues,
+  listRepoLabels,
   getSession,
   getSessions,
   restoreSessions,
@@ -361,8 +363,22 @@ app.whenReady().then(async () => {
 
   ipcMain.handle(
     'sessions:open-all-issues',
+    async (_event, projectPath: string, hostId?: string | null, label?: string | null) => {
+      return openSessionsForOpenIssues(projectPath, hostId ?? null, label ?? undefined)
+    }
+  )
+
+  ipcMain.handle(
+    'sessions:count-open-issues',
+    async (_event, projectPath: string, hostId?: string | null, label?: string | null) => {
+      return countOpenIssues(projectPath, hostId ?? null, label ?? undefined)
+    }
+  )
+
+  ipcMain.handle(
+    'repo:list-labels',
     async (_event, projectPath: string, hostId?: string | null) => {
-      return openSessionsForOpenIssues(projectPath, hostId ?? null)
+      return listRepoLabels(projectPath, hostId ?? null)
     }
   )
 
@@ -684,6 +700,10 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('config:get-default-tool', () => {
     return getConfig().defaultTool
+  })
+
+  ipcMain.handle('config:get-bulk-open-confirm-threshold', () => {
+    return getConfig().bulkOpenConfirmThreshold
   })
 
   ipcMain.handle('config:get-worktree-base', () => {

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -2015,6 +2015,31 @@ describe('ghApiOpenItemsArgs', () => {
       '.[] | select(.pull_request | not) | .number',
     ])
   })
+
+  it('appends an encoded labels filter for issues when a label is given', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.ghApiOpenItemsArgs('issue', 'owner/repo', 'bug')).toEqual([
+      'api',
+      '--paginate',
+      'repos/owner/repo/issues?state=open&per_page=100&labels=bug',
+      '--jq',
+      '.[] | select(.pull_request | not) | .number',
+    ])
+  })
+
+  it('url-encodes labels containing spaces', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.ghApiOpenItemsArgs('issue', 'owner/repo', 'good first issue')[2]).toBe(
+      'repos/owner/repo/issues?state=open&per_page=100&labels=good%20first%20issue'
+    )
+  })
+
+  it('ignores the label for PRs', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.ghApiOpenItemsArgs('pr', 'owner/repo', 'bug')[2]).toBe(
+      'repos/owner/repo/pulls?state=open&per_page=100'
+    )
+  })
 })
 
 describe('openSessionsForOpenPrs', () => {
@@ -2097,7 +2122,7 @@ describe('openSessionsForOpenIssues', () => {
         baseLocalSession({ id: `s-${issueNumber}`, issueNumber }) as Session | string
     )
 
-    const result = await sm.openSessionsForOpenIssues('/proj', null, {
+    const result = await sm.openSessionsForOpenIssues('/proj', null, undefined, {
       listIssues,
       createIssueSession,
     })
@@ -2114,7 +2139,7 @@ describe('openSessionsForOpenIssues', () => {
 
   it('records per-issue create failures in the summary', async () => {
     const sm = await loadSessionManager()
-    const result = await sm.openSessionsForOpenIssues('/proj', null, {
+    const result = await sm.openSessionsForOpenIssues('/proj', null, undefined, {
       listIssues: async () => [{ number: 5 }],
       createIssueSession: async () => 'boom',
     })
@@ -2123,6 +2148,67 @@ describe('openSessionsForOpenIssues', () => {
     expect(result.created).toEqual([])
     expect(result.skipped).toEqual([])
     expect(result.failed).toEqual([{ number: 5, error: 'boom' }])
+  })
+
+  it('accepts a label and still produces a summary via injected deps', async () => {
+    const sm = await loadSessionManager()
+    const listIssues = vi.fn(async () => [{ number: 7 }])
+    const createIssueSession = vi.fn(
+      async (_projectPath: string, issueNumber: number, _hostId: string | null) =>
+        baseLocalSession({ id: `s-${issueNumber}`, issueNumber }) as Session | string
+    )
+
+    const result = await sm.openSessionsForOpenIssues('/proj', null, 'bug', {
+      listIssues,
+      createIssueSession,
+    })
+    expect(typeof result).not.toBe('string')
+    if (typeof result === 'string') throw new Error(result)
+    expect(result.created.map((s) => s.issueNumber)).toEqual([7])
+  })
+})
+
+describe('countOpenIssues', () => {
+  it('returns the number of matched open issues', async () => {
+    const sm = await loadSessionManager()
+    const listIssues = vi.fn(async () => [{ number: 1 }, { number: 2 }, { number: 3 }])
+    const result = await sm.countOpenIssues('/proj', null, 'bug', { listIssues })
+    expect(result).toBe(3)
+    expect(listIssues).toHaveBeenCalledWith('/proj', null)
+  })
+
+  it('passes through gh list errors as a string', async () => {
+    const sm = await loadSessionManager()
+    const result = await sm.countOpenIssues('/proj', null, undefined, {
+      listIssues: async () => 'Failed to list open issues: gh auth failed',
+    })
+    expect(result).toBe('Failed to list open issues: gh auth failed')
+  })
+})
+
+describe('parseLabelLines', () => {
+  it('splits, trims, and drops blank lines', async () => {
+    const sm = await loadSessionManager()
+    expect(sm.parseLabelLines('bug\nenhancement\n\n  good first issue ')).toEqual([
+      'bug',
+      'enhancement',
+      'good first issue',
+    ])
+  })
+})
+
+describe('listRepoLabels', () => {
+  it('surfaces a remote gh probe failure instead of attempting to list', async () => {
+    const sm = await loadSessionManager()
+    state.execRemoteResults.set('sh -c command -v gh >/dev/null 2>&1', {
+      stdout: '',
+      stderr: 'Permission denied (publickey).\n',
+      code: 255,
+      timedOut: false,
+    })
+
+    const result = await sm.listRepoLabels('/remote/proj', 'h1')
+    expect(result).toBe('SSH authentication failed on Dev: Permission denied (publickey).')
   })
 })
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -1805,11 +1805,12 @@ function describeGhError(err: unknown): string {
   return String(err)
 }
 
-export function ghApiOpenItemsArgs(kind: 'pr' | 'issue', repo: string): string[] {
+export function ghApiOpenItemsArgs(kind: 'pr' | 'issue', repo: string, label?: string): string[] {
+  const labelQuery = kind === 'issue' && label ? `&labels=${encodeURIComponent(label)}` : ''
   const endpoint =
     kind === 'pr'
       ? `repos/${repo}/pulls?state=open&per_page=100`
-      : `repos/${repo}/issues?state=open&per_page=100`
+      : `repos/${repo}/issues?state=open&per_page=100${labelQuery}`
   const jq = kind === 'pr' ? '.[].number' : '.[] | select(.pull_request | not) | .number'
   return ['api', '--paginate', endpoint, '--jq', jq]
 }
@@ -1828,9 +1829,17 @@ function parseNumberedGhLines(stdout: string, label: string): NumberedGhItem[] {
   return items
 }
 
+export function parseLabelLines(stdout: string): string[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
 async function listLocalOpenGhItems(
   projectPath: string,
-  kind: 'pr' | 'issue'
+  kind: 'pr' | 'issue',
+  label?: string
 ): Promise<NumberedGhItem[] | string> {
   try {
     const { stdout: repoStdout } = await execFileAsync(
@@ -1839,7 +1848,7 @@ async function listLocalOpenGhItems(
       { cwd: projectPath, timeout: 30000 }
     )
     const repo = String(repoStdout).trim()
-    const { stdout } = await execFileAsync('gh', ghApiOpenItemsArgs(kind, repo), {
+    const { stdout } = await execFileAsync('gh', ghApiOpenItemsArgs(kind, repo, label), {
       cwd: projectPath,
       timeout: 30000,
     })
@@ -1852,12 +1861,14 @@ async function listLocalOpenGhItems(
 async function listRemoteOpenGhItems(
   projectPath: string,
   hostId: string,
-  kind: 'pr' | 'issue'
+  kind: 'pr' | 'issue',
+  label?: string
 ): Promise<NumberedGhItem[] | string> {
   const host = getRequiredHost(hostId)
   const ghProbe = await probeRemoteGh(host)
   if (!ghProbe.ok) return ghProbe.error
 
+  const labelQuery = kind === 'issue' && label ? `&labels=${encodeURIComponent(label)}` : ''
   try {
     const stdout = await expectRemoteOk(
       host,
@@ -1871,12 +1882,13 @@ async function listRemoteOpenGhItems(
           'if [ "$2" = pr ]; then',
           '  gh api --paginate "repos/$repo/pulls?state=open&per_page=100" --jq ".[].number"',
           'else',
-          '  gh api --paginate "repos/$repo/issues?state=open&per_page=100" --jq ".[] | select(.pull_request | not) | .number"',
+          '  gh api --paginate "repos/$repo/issues?state=open&per_page=100$3" --jq ".[] | select(.pull_request | not) | .number"',
           'fi',
         ].join('\n'),
         '_',
         projectPath,
         kind,
+        labelQuery,
       ],
       'gh failed'
     )
@@ -1897,11 +1909,78 @@ async function listOpenPrs(
 
 async function listOpenIssues(
   projectPath: string,
-  hostId: string | null
+  hostId: string | null,
+  label?: string
 ): Promise<NumberedGhItem[] | string> {
   return hostId === null
-    ? listLocalOpenGhItems(projectPath, 'issue')
-    : listRemoteOpenGhItems(projectPath, hostId, 'issue')
+    ? listLocalOpenGhItems(projectPath, 'issue', label)
+    : listRemoteOpenGhItems(projectPath, hostId, 'issue', label)
+}
+
+export async function countOpenIssues(
+  projectPath: string,
+  hostId: string | null = null,
+  label?: string,
+  deps: { listIssues?: ListNumberedItems } = {}
+): Promise<number | string> {
+  const list = deps.listIssues ?? ((p: string, h: string | null) => listOpenIssues(p, h, label))
+  try {
+    const items = await list(projectPath, hostId)
+    if (typeof items === 'string') return items
+    return items.length
+  } catch (err) {
+    return describeGhError(err)
+  }
+}
+
+export async function listRepoLabels(
+  projectPath: string,
+  hostId: string | null = null
+): Promise<string[] | string> {
+  if (hostId === null) {
+    try {
+      const { stdout: repoStdout } = await execFileAsync(
+        'gh',
+        ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
+        { cwd: projectPath, timeout: 30000 }
+      )
+      const repo = String(repoStdout).trim()
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['api', '--paginate', `repos/${repo}/labels?per_page=100`, '--jq', '.[].name'],
+        { cwd: projectPath, timeout: 30000 }
+      )
+      return parseLabelLines(String(stdout))
+    } catch (err) {
+      return `Failed to list labels: ${describeGhError(err)}`
+    }
+  }
+
+  const host = getRequiredHost(hostId)
+  const ghProbe = await probeRemoteGh(host)
+  if (!ghProbe.ok) return ghProbe.error
+
+  try {
+    const stdout = await expectRemoteOk(
+      host,
+      [
+        'sh',
+        '-c',
+        [
+          'set -e',
+          'cd "$1"',
+          'repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)',
+          'gh api --paginate "repos/$repo/labels?per_page=100" --jq ".[].name"',
+        ].join('\n'),
+        '_',
+        projectPath,
+      ],
+      'gh failed'
+    )
+    return parseLabelLines(stdout)
+  } catch (err) {
+    return `Failed to list labels: ${describeGhError(err)}`
+  }
 }
 
 function findSessionByBranch(
@@ -2408,13 +2487,14 @@ export async function openSessionsForOpenPrs(
 export async function openSessionsForOpenIssues(
   projectPath: string,
   hostId: string | null = null,
+  label?: string,
   deps: OpenSessionsDeps = {}
 ): Promise<OpenSessionsSummary | string> {
   return openSessionsForNumberedItems(
     projectPath,
     hostId,
     'issueNumber',
-    deps.listIssues ?? listOpenIssues,
+    deps.listIssues ?? ((p, h) => listOpenIssues(p, h, label)),
     deps.createIssueSession ?? createIssueSession
   )
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -34,8 +34,12 @@ contextBridge.exposeInMainWorld('api', {
   ) => ipcRenderer.invoke('sessions:create-prs', projectPath, prNumbers, hostId ?? null, options),
   openSessionsForOpenPrs: (projectPath: string, hostId?: string | null) =>
     ipcRenderer.invoke('sessions:open-all-prs', projectPath, hostId ?? null),
-  openSessionsForOpenIssues: (projectPath: string, hostId?: string | null) =>
-    ipcRenderer.invoke('sessions:open-all-issues', projectPath, hostId ?? null),
+  openSessionsForOpenIssues: (projectPath: string, hostId?: string | null, label?: string | null) =>
+    ipcRenderer.invoke('sessions:open-all-issues', projectPath, hostId ?? null, label ?? null),
+  countOpenIssues: (projectPath: string, hostId?: string | null, label?: string | null) =>
+    ipcRenderer.invoke('sessions:count-open-issues', projectPath, hostId ?? null, label ?? null),
+  listRepoLabels: (projectPath: string, hostId?: string | null) =>
+    ipcRenderer.invoke('repo:list-labels', projectPath, hostId ?? null),
   mirrorWorktree: (projectPath: string, worktreePath: string, hostId?: string | null) =>
     ipcRenderer.invoke('sessions:mirror', projectPath, worktreePath, hostId ?? null),
   mirrorAllWorktrees: (projectPath: string, hostId?: string | null) =>
@@ -71,6 +75,8 @@ contextBridge.exposeInMainWorld('api', {
   saveSidebarWidth: (width: number) => ipcRenderer.invoke('config:save-sidebar-width', width),
   getUiScale: () => ipcRenderer.invoke('config:get-ui-scale'),
   getDefaultTool: () => ipcRenderer.invoke('config:get-default-tool') as Promise<AgentTool>,
+  getBulkOpenConfirmThreshold: () =>
+    ipcRenderer.invoke('config:get-bulk-open-confirm-threshold') as Promise<number>,
   getWorktreeBase: () => ipcRenderer.invoke('config:get-worktree-base'),
   getTheme: () => ipcRenderer.invoke('config:get-theme') as Promise<Theme>,
   saveTheme: (theme: Theme) => ipcRenderer.invoke('config:save-theme', theme),

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -123,6 +123,9 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
   } = ui
   const sessionNameInputRef = useRef<HTMLInputElement>(null)
   const prNumberInputRef = useRef<HTMLInputElement>(null)
+  // Monotonic token: bumped whenever the issue dialog opens or closes so an
+  // in-flight countOpenIssues can detect it was canceled/reopened mid-await.
+  const issueRequestRef = useRef(0)
 
   const showToast = (msg: string) => {
     setUi({ toast: msg })
@@ -275,6 +278,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
   }
 
   const openIssuesDialog = (projectPath: string, hostId: string | null) => {
+    issueRequestRef.current += 1
     setUi({
       pendingIssuePath: projectPath,
       pendingIssueHostId: hostId,
@@ -299,6 +303,9 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
   }
 
   const closeIssuesDialog = () => {
+    // Bump the token first so any in-flight count bails instead of opening
+    // sessions, and clear `creating` so the menu isn't stuck disabled.
+    issueRequestRef.current += 1
     setUi({
       pendingIssuePath: null,
       pendingIssueHostId: null,
@@ -307,6 +314,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
       selectedIssueLabel: '',
       issueConfirmCount: null,
       issueError: null,
+      creating: false,
     })
   }
 
@@ -329,12 +337,23 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
     const projectPath = pendingIssuePath
     const hostId = pendingIssueHostId
     const label = selectedIssueLabel
+    const token = issueRequestRef.current
     setUi({ creating: true, issueError: null })
     let count: number | string
     try {
       count = await window.api.countOpenIssues(projectPath, hostId, label || null)
     } catch (err) {
+      if (issueRequestRef.current !== token) {
+        setUi({ creating: false })
+        return
+      }
       setUi({ creating: false, issueError: `Failed to count open issues: ${String(err)}` })
+      return
+    }
+    // The dialog was canceled or reopened while the count was in flight —
+    // discard the result so we never open sessions for a dismissed dialog.
+    if (issueRequestRef.current !== token) {
+      setUi({ creating: false })
       return
     }
     setUi({ creating: false })

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -39,6 +39,14 @@ interface ProjectTreeUiState {
   pendingPrTool: AgentTool
   prNumberInput: string
   prError: string | null
+  pendingIssuePath: string | null
+  pendingIssueHostId: string | null
+  issueLabels: string[] | null
+  issueLabelsError: string | null
+  selectedIssueLabel: string
+  issueConfirmCount: number | null
+  issueError: string | null
+  bulkOpenConfirmThreshold: number
   toast: string | null
 }
 
@@ -77,6 +85,14 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
     pendingPrTool: 'claude',
     prNumberInput: '',
     prError: null,
+    pendingIssuePath: null,
+    pendingIssueHostId: null,
+    issueLabels: null,
+    issueLabelsError: null,
+    selectedIssueLabel: '',
+    issueConfirmCount: null,
+    issueError: null,
+    bulkOpenConfirmThreshold: 20,
     toast: null,
   })
   const {
@@ -95,6 +111,14 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
     pendingPrTool,
     prNumberInput,
     prError,
+    pendingIssuePath,
+    pendingIssueHostId,
+    issueLabels,
+    issueLabelsError,
+    selectedIssueLabel,
+    issueConfirmCount,
+    issueError,
+    bulkOpenConfirmThreshold,
     toast,
   } = ui
   const sessionNameInputRef = useRef<HTMLInputElement>(null)
@@ -119,6 +143,10 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
       // defaultTool at click time. Mutating pendingTool from this async
       // callback would race against any user toggle made between the click
       // and getDefaultTool resolving.
+    })
+    window.api.getBulkOpenConfirmThreshold().then((n) => {
+      if (cancelled) return
+      setUi({ bulkOpenConfirmThreshold: n })
     })
     return () => {
       cancelled = true
@@ -246,17 +274,84 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
     }
   }
 
-  const handleOpenAllIssues = async (projectPath: string, hostId: string | null) => {
+  const openIssuesDialog = (projectPath: string, hostId: string | null) => {
+    setUi({
+      pendingIssuePath: projectPath,
+      pendingIssueHostId: hostId,
+      issueLabels: null,
+      issueLabelsError: null,
+      selectedIssueLabel: '',
+      issueConfirmCount: null,
+      issueError: null,
+    })
+    window.api
+      .listRepoLabels(projectPath, hostId)
+      .then((result) => {
+        if (typeof result === 'string') {
+          setUi({ issueLabels: [], issueLabelsError: result })
+        } else {
+          setUi({ issueLabels: result })
+        }
+      })
+      .catch((err) => {
+        setUi({ issueLabels: [], issueLabelsError: String(err) })
+      })
+  }
+
+  const closeIssuesDialog = () => {
+    setUi({
+      pendingIssuePath: null,
+      pendingIssueHostId: null,
+      issueLabels: null,
+      issueLabelsError: null,
+      selectedIssueLabel: '',
+      issueConfirmCount: null,
+      issueError: null,
+    })
+  }
+
+  const proceedOpenIssues = async (projectPath: string, hostId: string | null, label: string) => {
     if (creating) return
-    setUi({ creating: true })
+    setUi({ creating: true, issueError: null })
     try {
-      const result = await window.api.openSessionsForOpenIssues(projectPath, hostId)
+      const result = await window.api.openSessionsForOpenIssues(projectPath, hostId, label || null)
       showToast(typeof result === 'string' ? result : formatOpenAllSummary(result, 'issue'))
+      closeIssuesDialog()
     } catch (err) {
-      showToast(`Failed to open issue sessions: ${String(err)}`)
+      setUi({ issueError: `Failed to open issue sessions: ${String(err)}` })
     } finally {
       setUi({ creating: false })
     }
+  }
+
+  const handleSubmitIssues = async () => {
+    if (!pendingIssuePath || creating) return
+    const projectPath = pendingIssuePath
+    const hostId = pendingIssueHostId
+    const label = selectedIssueLabel
+    setUi({ creating: true, issueError: null })
+    let count: number | string
+    try {
+      count = await window.api.countOpenIssues(projectPath, hostId, label || null)
+    } catch (err) {
+      setUi({ creating: false, issueError: `Failed to count open issues: ${String(err)}` })
+      return
+    }
+    setUi({ creating: false })
+    if (typeof count === 'string') {
+      setUi({ issueError: count })
+      return
+    }
+    if (count === 0) {
+      showToast(label ? `No open issues match "${label}"` : 'No open issues to open')
+      closeIssuesDialog()
+      return
+    }
+    if (count > bulkOpenConfirmThreshold) {
+      setUi({ issueConfirmCount: count })
+      return
+    }
+    await proceedOpenIssues(projectPath, hostId, label)
   }
 
   const getMenuItems = (
@@ -285,9 +380,9 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         onClick: () => void handleOpenAllPrs(projectPath, hostId),
       })
       items.push({
-        label: 'Open sessions for all open issues',
+        label: 'Open sessions for all open issues…',
         disabled: creating,
-        onClick: () => void handleOpenAllIssues(projectPath, hostId),
+        onClick: () => openIssuesDialog(projectPath, hostId),
       })
       const remoteWts = remoteWorktreesCache[remoteWorktreeKey(hostId, projectPath)] ?? []
       const remoteUnmirrored = remoteWts.filter(
@@ -365,9 +460,9 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         onClick: () => void handleOpenAllPrs(projectPath, null),
       })
       items.push({
-        label: 'Open sessions for all open issues',
+        label: 'Open sessions for all open issues…',
         disabled: creating,
-        onClick: () => void handleOpenAllIssues(projectPath, null),
+        onClick: () => openIssuesDialog(projectPath, null),
       })
 
       const project = projects.find((p) => p.path === projectPath)
@@ -620,6 +715,70 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
               Cancel
             </button>
           </div>
+        </div>
+      )}
+      {pendingIssuePath && (
+        <div className="session-name-dialog">
+          {issueConfirmCount === null ? (
+            <>
+              <div className="session-name-label">Label filter:</div>
+              {issueLabels === null ? (
+                <div className="session-name-label">Loading labels…</div>
+              ) : (
+                <select
+                  className="create-input"
+                  value={selectedIssueLabel}
+                  onChange={(e) => setUi({ selectedIssueLabel: e.target.value })}
+                >
+                  <option value="">All open issues</option>
+                  {issueLabels.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {issueLabelsError && (
+                <div className="pr-error">Could not load labels: {issueLabelsError}</div>
+              )}
+              {issueError && <div className="pr-error">{issueError}</div>}
+              <div className="create-actions">
+                <button
+                  className="create-btn"
+                  onClick={handleSubmitIssues}
+                  disabled={creating || issueLabels === null}
+                >
+                  {creating ? 'Working…' : 'Open sessions'}
+                </button>
+                <button className="create-btn cancel" onClick={closeIssuesDialog}>
+                  Cancel
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="session-name-label">
+                This will open up to {issueConfirmCount} issue session
+                {issueConfirmCount === 1 ? '' : 's'}
+                {selectedIssueLabel ? ` labelled "${selectedIssueLabel}"` : ''}. Continue?
+              </div>
+              {issueError && <div className="pr-error">{issueError}</div>}
+              <div className="create-actions">
+                <button
+                  className="create-btn"
+                  onClick={() =>
+                    void proceedOpenIssues(pendingIssuePath, pendingIssueHostId, selectedIssueLabel)
+                  }
+                  disabled={creating}
+                >
+                  {creating ? 'Opening…' : `Open ${issueConfirmCount}`}
+                </button>
+                <button className="create-btn cancel" onClick={closeIssuesDialog}>
+                  Cancel
+                </button>
+              </div>
+            </>
+          )}
         </div>
       )}
       {displayProjects.map((project) => {

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -747,6 +747,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
                 <select
                   className="create-input"
                   value={selectedIssueLabel}
+                  disabled={creating}
                   onChange={(e) => setUi({ selectedIssueLabel: e.target.value })}
                 >
                   <option value="">All open issues</option>

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -744,13 +744,14 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
               {issueError && <div className="pr-error">{issueError}</div>}
               <div className="create-actions">
                 <button
+                  type="button"
                   className="create-btn"
                   onClick={handleSubmitIssues}
                   disabled={creating || issueLabels === null}
                 >
                   {creating ? 'Working…' : 'Open sessions'}
                 </button>
-                <button className="create-btn cancel" onClick={closeIssuesDialog}>
+                <button type="button" className="create-btn cancel" onClick={closeIssuesDialog}>
                   Cancel
                 </button>
               </div>
@@ -765,6 +766,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
               {issueError && <div className="pr-error">{issueError}</div>}
               <div className="create-actions">
                 <button
+                  type="button"
                   className="create-btn"
                   onClick={() =>
                     void proceedOpenIssues(pendingIssuePath, pendingIssueHostId, selectedIssueLabel)
@@ -773,7 +775,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
                 >
                   {creating ? 'Opening…' : `Open ${issueConfirmCount}`}
                 </button>
-                <button className="create-btn cancel" onClick={closeIssuesDialog}>
+                <button type="button" className="create-btn cancel" onClick={closeIssuesDialog}>
                   Cancel
                 </button>
               </div>

--- a/src/renderer/components/ProjectTree.tsx
+++ b/src/renderer/components/ProjectTree.tsx
@@ -278,7 +278,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
   }
 
   const openIssuesDialog = (projectPath: string, hostId: string | null) => {
-    issueRequestRef.current += 1
+    const token = (issueRequestRef.current += 1)
     setUi({
       pendingIssuePath: projectPath,
       pendingIssueHostId: hostId,
@@ -291,6 +291,9 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
     window.api
       .listRepoLabels(projectPath, hostId)
       .then((result) => {
+        // Discard a response that resolved after the dialog was canceled or
+        // reopened (possibly for a different project).
+        if (issueRequestRef.current !== token) return
         if (typeof result === 'string') {
           setUi({ issueLabels: [], issueLabelsError: result })
         } else {
@@ -298,6 +301,7 @@ function useProjectTreeElement({ onOpenSession }: TreeProps) {
         }
       })
       .catch((err) => {
+        if (issueRequestRef.current !== token) return
         setUi({ issueLabels: [], issueLabelsError: String(err) })
       })
   }

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -51,8 +51,15 @@ declare global {
       ) => Promise<OpenSessionsSummary | string>
       openSessionsForOpenIssues: (
         projectPath: string,
-        hostId?: string | null
+        hostId?: string | null,
+        label?: string | null
       ) => Promise<OpenSessionsSummary | string>
+      countOpenIssues: (
+        projectPath: string,
+        hostId?: string | null,
+        label?: string | null
+      ) => Promise<number | string>
+      listRepoLabels: (projectPath: string, hostId?: string | null) => Promise<string[] | string>
       mirrorWorktree: (
         projectPath: string,
         worktreePath: string,
@@ -86,6 +93,7 @@ declare global {
       saveSidebarWidth: (width: number) => Promise<void>
       getUiScale: () => Promise<number>
       getDefaultTool: () => Promise<AgentTool>
+      getBulkOpenConfirmThreshold: () => Promise<number>
       getWorktreeBase: () => Promise<WorktreeBase>
       getTheme: () => Promise<Theme>
       saveTheme: (theme: Theme) => Promise<void>


### PR DESCRIPTION
## Summary

Extends the existing **"Open sessions for all open issues"** action:

- **Optional label filter** — pick a GitHub label from a `gh`-fetched dropdown to open sessions only for issues with that label. Selecting *"All open issues"* (no label) keeps today's behavior.
- **Bulk-open confirmation** — before opening more than a configurable number of sessions in one go, the user is prompted to confirm. The threshold is `bulkOpenConfirmThreshold` in `~/.config/pewpew/config.json` (default **20**); the count is the number of issues **matched by the label**.

## Changes

- **`session-manager.ts`** — thread an optional `label` through the issue-listing chain (`ghApiOpenItemsArgs` → `&labels=<encoded>`, retaining the PR-exclusion `jq`); new `countOpenIssues`, `listRepoLabels` + pure `parseLabelLines`; `label` arg on `openSessionsForOpenIssues`.
- **`config.ts`** — `bulkOpenConfirmThreshold` (auto-backfilled via the existing default spread-merge).
- **IPC / preload / env** — `sessions:count-open-issues`, `repo:list-labels`, `config:get-bulk-open-confirm-threshold`, plus the label arg on `sessions:open-all-issues`.
- **`ProjectTree.tsx`** — the menu action now opens a dialog: label dropdown → count → confirm-if-over-threshold → open. Reuses `formatOpenAllSummary`. No tool picker (the bulk path uses `defaultTool`, as before).

## Testing

- `npx vitest run` — **434 passed** (+6 new tests in `session-manager.test.ts`, developed TDD).
- `npx tsc --noEmit` — clean.
- `npx eslint .` — clean; `prettier` — unchanged.
- `electron-vite build` — succeeds.
- Core logic (gh-arg label encoding, `countOpenIssues`, `parseLabelLines`, `listRepoLabels` remote probe-failure, label-arg threading) is unit-tested; the renderer dialog flow is covered by type-check + build (no UI test harness).

## Notes / scope

- Single-label filtering only (the `gh` `labels` query is comma-AND; matches "a given label").
- The count→open path issues two `gh` list calls (count, then open); the count is advisory, so a mid-flight change only mis-states the prompt.
- PR bulk-open is unchanged (issues only).