### PR TITLE
fix(sessions): restore worktree cleanup prompt on real SessionEnd

### DIFF
--- a/src/main/session-state-machine.test.ts
+++ b/src/main/session-state-machine.test.ts
@@ -144,7 +144,7 @@ describe('applyHookEvent — session.end', () => {
     expect(result.state.get('s1')).toEqual(session)
   })
 
-  it.each(['clear', 'resume', 'bypass_permissions_disabled', 'other', 'unrecognised'])(
+  it.each(['clear', 'resume'])(
     'does not emit promptCleanup when reason is %p (session still alive)',
     (reason) => {
       const session = makeSession({ id: 's1', status: 'running' })
@@ -162,22 +162,25 @@ describe('applyHookEvent — session.end', () => {
     }
   )
 
-  it('emits promptCleanup when reason is "logout"', () => {
-    const session = makeSession({ id: 's1', status: 'running' })
-    const result = applyHookEvent(
-      stateOf(session),
-      {
-        method: 'session.end',
-        params: { cwd: '/p/w', reason: 'logout' },
-        originHostId: null,
-      },
-      1
-    )
-    expect(result.matched).toBe(true)
-    expect(result.intents).toContainEqual({ kind: 'promptCleanup', sessionId: 's1' })
-  })
+  it.each(['logout', 'bypass_permissions_disabled', 'other', 'unrecognised'])(
+    'emits promptCleanup when reason is %p (agent process gone)',
+    (reason) => {
+      const session = makeSession({ id: 's1', status: 'running' })
+      const result = applyHookEvent(
+        stateOf(session),
+        {
+          method: 'session.end',
+          params: { cwd: '/p/w', reason },
+          originHostId: null,
+        },
+        1
+      )
+      expect(result.matched).toBe(true)
+      expect(result.intents).toContainEqual({ kind: 'promptCleanup', sessionId: 's1' })
+    }
+  )
 
-  it('does not emit promptCleanup when reason is absent (treat as ambiguous)', () => {
+  it('emits promptCleanup when reason is absent (treat as a real end)', () => {
     const session = makeSession({ id: 's1', status: 'running' })
     const result = applyHookEvent(
       stateOf(session),
@@ -185,7 +188,7 @@ describe('applyHookEvent — session.end', () => {
       1
     )
     expect(result.matched).toBe(true)
-    expect(result.intents).toEqual([])
+    expect(result.intents).toContainEqual({ kind: 'promptCleanup', sessionId: 's1' })
   })
 })
 

--- a/src/main/session-state-machine.ts
+++ b/src/main/session-state-machine.ts
@@ -63,12 +63,17 @@ export function applyHookEvent(
       if (event.originHostId) next.connectionState = 'live'
       break
     case 'session.end': {
-      // Claude Code fires SessionEnd for several reasons, not all of which mean
-      // the user is done with the worktree. /clear, --continue/--resume, and
-      // bypass_permissions_disabled all fire SessionEnd while the session
-      // remains alive — treating them as "user wants cleanup" produces a
-      // disruptive false-positive dialog. Only fire on reasons that genuinely
-      // mean the agent process is gone.
+      // Claude Code fires SessionEnd for several reasons, only some of which
+      // mean the user is done with the worktree. `clear` (/clear resets context)
+      // and `resume` (--continue/--resume hands off to a fresh process) both
+      // fire while the session remains alive — prompting cleanup for those
+      // produces a disruptive false-positive dialog. Every other reason
+      // (prompt_input_exit, logout, bypass_permissions_disabled, other, or an
+      // absent/unrecognised reason) means the agent process is gone, so we
+      // prompt. Using a denylist of the two "still alive" reasons keeps the
+      // catch-all `other` — the common real-termination value — triggering
+      // cleanup, which an allowlist of {prompt_input_exit, logout} silently
+      // dropped (the 0.2.1 regression).
       // https://code.claude.com/docs/en/hooks (SessionEnd matcher values).
       const reason = typeof event.params.reason === 'string' ? event.params.reason : undefined
       // JSON.stringify escapes control characters and the slice caps length so a
@@ -78,8 +83,8 @@ export function applyHookEvent(
       // that keeps the diagnostic value of seeing the actual reason string.
       const safeReason = reason === undefined ? '<absent>' : JSON.stringify(reason).slice(0, 64)
       console.info(`[session.end] sessionId=${target.id} reason=${safeReason}`)
-      const triggersCleanup = reason === 'prompt_input_exit' || reason === 'logout'
-      if (!triggersCleanup) {
+      const sessionStillAlive = reason === 'clear' || reason === 'resume'
+      if (sessionStillAlive) {
         return { state, intents: [], matched: true }
       }
       return {


### PR DESCRIPTION
## Problem

Since **0.2.1**, closing/ending a session stopped offering to remove its git worktree. The removal *mechanism* (`removeSession`/`removeWorktree`) is fine — what broke is the **trigger** for the automatic "Session ended — Clean up worktree?" prompt.

Commit `5b36748` ("fix: only prompt worktree cleanup on real SessionEnd reasons") changed `applyHookEvent` to gate the `promptCleanup` intent behind an **allowlist**:

```ts
const triggersCleanup = reason === 'prompt_input_exit' || reason === 'logout'
```

Claude Code's `SessionEnd` `reason` is one of `clear`, `resume`, `logout`, `prompt_input_exit`, `bypass_permissions_disabled`, `other`. A normal termination — and especially the case where pewpew tears down the PTY/tmux — arrives as the catch-all **`other`**, which the allowlist dropped, so the prompt never appeared.

The commit's own message even said the `other` case "genuinely means the agent process is gone", but the implementation excluded it — the filter was inverted onto the wrong values.

## Fix

Switch to a **denylist** of the two reasons where the session genuinely stays alive:

```ts
const sessionStillAlive = reason === 'clear' || reason === 'resume'
if (sessionStillAlive) return { state, intents: [], matched: true }
```

- `clear` (/clear resets context) and `resume` (--continue/--resume hands off to a fresh process) → no prompt (keeps the #84 fix).
- `prompt_input_exit`, `logout`, `bypass_permissions_disabled`, `other`, and absent/unrecognised reasons → prompt cleanup (restores 0.2.0 behaviour).

## Tests

Updated `session-state-machine.test.ts` to match:
- `clear`/`resume` stay no-prompt.
- `other`/`bypass_permissions_disabled`/`unrecognised`/absent now emit `promptCleanup`.
- `prompt_input_exit`/`logout` continue to emit `promptCleanup`.

`npx tsc --noEmit`, `npx eslint`, and `npx vitest run src/main/session-state-machine.test.ts` (29 passed) all green.