### PR TITLE
fix(main): recover from renderer crashes instead of spamming disposed-frame errors

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,7 @@ import { scanProjects } from './project-scanner'
 import { installHooks, isSettingsGitignored } from './hook-installer'
 import { startHookServer, stopHookServer } from './hook-server'
 import { createTray } from './tray'
-import { registerWindow, broadcastToAll } from './window-registry'
+import { registerWindow, broadcastToAll, safeSend } from './window-registry'
 import {
   initPtyManager,
   stopPtyManager,
@@ -191,6 +191,35 @@ function installNotifyScript(): void {
   chmodSync(dest, 0o755)
 }
 
+// Tracks the last auto-reload per window so a renderer that crashes again right
+// after we reload it doesn't get hammered into a tight reload loop.
+const lastRendererReload = new WeakMap<BrowserWindow, number>()
+
+// Recovers a window whose renderer process died (the "white window"). The main
+// process owns the node-pty/tmux state, so a reload re-feeds the terminals from
+// their buffers + tmux capture rather than losing the session.
+function attachRendererCrashHandlers(win: BrowserWindow, label: string): void {
+  win.webContents.on('render-process-gone', (_event, details) => {
+    console.error(
+      `[renderer] ${label} render process gone: reason=${details.reason} exitCode=${details.exitCode}`
+    )
+    if (details.reason === 'clean-exit' || win.isDestroyed()) return
+    const now = Date.now()
+    const prev = lastRendererReload.get(win) ?? 0
+    if (now - prev < 5000) {
+      console.error(
+        `[renderer] ${label} crashed again within 5s of a reload; not auto-reloading to avoid a crash loop`
+      )
+      return
+    }
+    lastRendererReload.set(win, now)
+    win.reload()
+  })
+  win.webContents.on('unresponsive', () => {
+    console.error(`[renderer] ${label} renderer became unresponsive`)
+  })
+}
+
 function createWindow(): BrowserWindow {
   const config = getConfig()
   const ws = config.windowState
@@ -219,6 +248,8 @@ function createWindow(): BrowserWindow {
     cfg.windowState = { ...bounds, maximized }
     saveConfig(cfg)
   })
+
+  attachRendererCrashHandlers(mainWindow, 'main')
 
   if (process.env.ELECTRON_RENDERER_URL) {
     mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL)
@@ -722,9 +753,7 @@ app.whenReady().then(async () => {
     // pick up the new theme without needing to reload. The sender no-ops
     // on its own broadcast because state.theme already matches.
     for (const win of BrowserWindow.getAllWindows()) {
-      if (!win.isDestroyed()) {
-        win.webContents.send('theme:changed', theme)
-      }
+      safeSend(win, 'theme:changed', theme)
     }
   })
 
@@ -741,6 +770,7 @@ app.whenReady().then(async () => {
     })
 
     registerWindow(swimWindow)
+    attachRendererCrashHandlers(swimWindow, 'swim-lanes')
 
     const query = `?sessions=${sessionIds.join(',')}`
     if (process.env.ELECTRON_RENDERER_URL) {

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow, Notification } from 'electron'
 import { randomUUID } from 'crypto'
-import { getMainWindow } from './window-registry'
+import { getMainWindow, safeSend } from './window-registry'
 import type { Session, ToastEvent } from '../shared/types'
 
 export function notifyNeedsInput(session: Session): void {
@@ -33,7 +33,6 @@ export function emitToast(event: Omit<ToastEvent, 'id'> & { id?: string }): void
     hostLabel: event.hostLabel,
   }
   for (const win of BrowserWindow.getAllWindows()) {
-    if (win.isDestroyed()) continue
-    win.webContents.send('toast:show', payload)
+    safeSend(win, 'toast:show', payload)
   }
 }

--- a/src/main/window-registry.ts
+++ b/src/main/window-registry.ts
@@ -17,11 +17,28 @@ export function unregisterWindow(win: BrowserWindow): void {
   if (win === mainWindow) mainWindow = null
 }
 
+// Sends to a single window, tolerating a disposed render frame. win.isDestroyed()
+// only reports whether the *window* object was destroyed; after a renderer
+// process crash (or mid-reload/navigation) the window survives but its render
+// frame is gone, and webContents.send() then throws "Render frame was disposed
+// before WebFrameMain could be accessed". Guard on the webContents state and
+// swallow the residual race so a crashed renderer can't spam the main log (the
+// 16ms pty flush loop was the visible offender).
+export function safeSend(win: BrowserWindow, channel: string, ...args: unknown[]): void {
+  if (win.isDestroyed()) return
+  const wc = win.webContents
+  if (wc.isDestroyed() || wc.isCrashed()) return
+  try {
+    wc.send(channel, ...args)
+  } catch {
+    // Frame can be disposed between the checks above and the send; ignore — the
+    // renderer resyncs once it finishes (re)loading.
+  }
+}
+
 export function broadcastToAll(channel: string, ...args: unknown[]): void {
   for (const win of windows) {
-    if (!win.isDestroyed()) {
-      win.webContents.send(channel, ...args)
-    }
+    safeSend(win, channel, ...args)
   }
 }
 


### PR DESCRIPTION
## Problem

A user reported the main window suddenly turning white while this error scrolled endlessly in the terminal:

```
Error sending from webFrameMain:  Error: Render frame was disposed before WebFrameMain could be accessed
    at broadcastToAll (.../main/index.js:502:69)
    at Timeout.flushBuffers [as _onTimeout] (.../main/index.js:1589:3)
```

Two distinct things were happening:

1. **The white window** — the main window's **renderer process crashed**. The `BrowserWindow` object survives a renderer crash, but its render frame is disposed, leaving the window blank. Swim-lane windows are separate `BrowserWindow`s with their own renderer processes, so they were unaffected (matching the report).
2. **The scrolling error** — a symptom. `flushBuffers` broadcasts pty output every 16ms via `broadcastToAll`, which guarded only with `win.isDestroyed()`. That checks the *window object*, which stays alive after a renderer crash, so `webContents.send()` kept throwing on the disposed frame forever, and nothing ever reloaded the dead window.

## Changes

- **`window-registry.ts`** — new `safeSend()` helper that also checks `webContents.isDestroyed()`/`isCrashed()` and try/catches the residual disposed-frame race. `broadcastToAll` routes through it. Reused at the other unguarded broadcast sites (`emitToast`, the `theme:changed` loop).
- **`index.ts`** — `attachRendererCrashHandlers()` on both the main and swim windows: logs `render-process-gone` with `reason`/`exitCode` (and `unresponsive`), then **auto-reloads** to recover the white window, with a 5s loop guard so a repeatedly-crashing renderer isn't hammered. pty/tmux state lives in main, so a reload re-feeds the terminals.

## Not addressed here

**Why the renderer crashed in the first place** — there was no `render-process-gone` handler, so nothing logged the reason. The new logging will print the exact `reason`/`exitCode` if it recurs (`[renderer] main render process gone: reason=… exitCode=…`), which will pin the real cause (likely renderer OOM or GPU/canvas context loss with many streaming terminals).

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx electron-vite build` — clean
- `npx vitest run` — 446 passed