### PR TITLE
feat(sessions): auto-reconnect dropped remote sessions

### DIFF
--- a/src/main/config.test.ts
+++ b/src/main/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  existsSync: vi.fn(() => true),
+}))
+
+import { readFileSync } from 'fs'
+import { getReconnectConfig } from './config'
+
+describe('getReconnectConfig', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('fills default tunables when the persisted reconnect object is partial', () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ reconnect: { enabled: false } }))
+    expect(getReconnectConfig()).toEqual({
+      enabled: false,
+      initialDelayMs: 1000,
+      maxDelayMs: 30000,
+    })
+  })
+
+  it('returns the full default when no reconnect key is persisted', () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ scanDirs: ['~/x'] }))
+    expect(getReconnectConfig()).toEqual({
+      enabled: true,
+      initialDelayMs: 1000,
+      maxDelayMs: 30000,
+    })
+  })
+})

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -17,6 +17,12 @@ export interface WindowState {
   maximized: boolean
 }
 
+export interface ReconnectConfig {
+  enabled: boolean
+  initialDelayMs: number
+  maxDelayMs: number
+}
+
 export interface AppConfig {
   scanDirs: string[]
   pinnedPaths: string[]
@@ -34,6 +40,7 @@ export interface AppConfig {
   worktreeBase: WorktreeBase
   theme: Theme
   bulkOpenConfirmThreshold: number
+  reconnect: ReconnectConfig
 }
 
 export const CONFIG_DIR = join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'pewpew')
@@ -55,6 +62,7 @@ const DEFAULT_CONFIG: AppConfig = {
   worktreeBase: 'local',
   theme: 'dark',
   bulkOpenConfirmThreshold: 20,
+  reconnect: { enabled: true, initialDelayMs: 1000, maxDelayMs: 30000 },
 }
 
 export function shouldWarnGitignore(projectPath: string): boolean {
@@ -89,6 +97,13 @@ export function getConfig(): AppConfig {
   } catch {
     return DEFAULT_CONFIG
   }
+}
+
+// getConfig is a shallow merge over DEFAULT_CONFIG, so a hand-edited partial
+// `reconnect` object in config.json would clobber the sibling defaults. Fill
+// per-field so the scheduler never sees an undefined tunable.
+export function getReconnectConfig(): ReconnectConfig {
+  return { ...DEFAULT_CONFIG.reconnect, ...(getConfig().reconnect ?? {}) }
 }
 
 export function saveConfig(config: AppConfig): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,6 +53,7 @@ import {
   removeSessionsForHost,
   relocateProject,
   updateLastKnownStatesBatch,
+  stopSessionManager,
 } from './session-manager'
 import { parseDiff, synthesizeUntrackedFile } from './diff-parser'
 import { listHosts, addHost, updateHost, deleteHost, getHost } from './host-registry'
@@ -854,6 +855,7 @@ app.whenReady().then(async () => {
     event.preventDefault()
     clearInterval(thumbInterval)
     stopPtyManager()
+    stopSessionManager()
     stopHookServer()
     void (async () => {
       // Bound teardown so an unreachable host can't wedge shutdown.

--- a/src/main/reconnect-scheduler.test.ts
+++ b/src/main/reconnect-scheduler.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createReconnectScheduler, type AttemptOutcome } from './reconnect-scheduler'
+
+interface FakeTimer {
+  fn: () => void
+  ms: number
+  cleared: boolean
+}
+
+function fakeTimers() {
+  const timers: FakeTimer[] = []
+  return {
+    timers,
+    setTimer(fn: () => void, ms: number) {
+      const t: FakeTimer = { fn, ms, cleared: false }
+      timers.push(t)
+      return { handle: t, unref() {} }
+    },
+    clearTimer(h: unknown) {
+      const handle = (h as { handle?: FakeTimer } | undefined)?.handle
+      if (handle) handle.cleared = true
+    },
+    last(): FakeTimer {
+      return timers[timers.length - 1]
+    },
+  }
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+const config =
+  (over: Partial<{ enabled: boolean; initialDelayMs: number; maxDelayMs: number }> = {}) =>
+  () => ({ enabled: true, initialDelayMs: 1000, maxDelayMs: 30000, ...over })
+
+describe('reconnect-scheduler', () => {
+  it('fires the attempt after the initial delay and stops on recovery', async () => {
+    const timers = fakeTimers()
+    const attempt = vi.fn().mockResolvedValue('recovered')
+    const scheduler = createReconnectScheduler({
+      attempt,
+      config: config(),
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      random: () => 0,
+    })
+
+    scheduler.schedule('s1')
+    expect(timers.timers).toHaveLength(1)
+    // delay = initial(1000) * jitter(0.5 + random(0)*0.5 = 0.5) = 500
+    expect(timers.last().ms).toBe(500)
+
+    timers.last().fn()
+    await flush()
+
+    expect(attempt).toHaveBeenCalledWith('s1')
+    expect(attempt).toHaveBeenCalledTimes(1)
+    // recovered → no reschedule
+    expect(timers.timers).toHaveLength(1)
+  })
+
+  it('reschedules with exponential backoff, capped at maxDelayMs', async () => {
+    const timers = fakeTimers()
+    const attempt = vi.fn().mockResolvedValue('retry')
+    const scheduler = createReconnectScheduler({
+      attempt,
+      config: config(),
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      random: () => 0,
+    })
+
+    scheduler.schedule('s1')
+    const delays: number[] = []
+    for (let i = 0; i < 8; i++) {
+      delays.push(timers.last().ms)
+      timers.last().fn()
+      await flush()
+    }
+
+    // base = min(1000 * 2^n, 30000), jitter 0.5 → base/2.
+    // 1000→30000 doubling caps at attempt 5 (32000 clamps to 30000).
+    expect(delays).toEqual([500, 1000, 2000, 4000, 8000, 15000, 15000, 15000])
+  })
+
+  it('stops without rescheduling when the attempt gives up', async () => {
+    const timers = fakeTimers()
+    const attempt = vi.fn().mockResolvedValue('gave-up' as AttemptOutcome)
+    const scheduler = createReconnectScheduler({
+      attempt,
+      config: config(),
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      random: () => 0,
+    })
+
+    scheduler.schedule('s1')
+    timers.last().fn()
+    await flush()
+
+    expect(attempt).toHaveBeenCalledTimes(1)
+    expect(timers.timers).toHaveLength(1)
+  })
+
+  it('cancel clears the pending timer and a late fire is inert', async () => {
+    const timers = fakeTimers()
+    const attempt = vi.fn().mockResolvedValue('retry' as AttemptOutcome)
+    const scheduler = createReconnectScheduler({
+      attempt,
+      config: config(),
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      random: () => 0,
+    })
+
+    scheduler.schedule('s1')
+    const t = timers.last()
+    scheduler.cancel('s1')
+    expect(t.cleared).toBe(true)
+
+    t.fn() // simulate a timer that already fired before clear won the race
+    await flush()
+
+    expect(attempt).not.toHaveBeenCalled()
+    expect(timers.timers).toHaveLength(1)
+  })
+
+  it('drops the result if canceled while the attempt is in flight', async () => {
+    const timers = fakeTimers()
+    let resolveAttempt!: (o: AttemptOutcome) => void
+    const attempt = vi.fn().mockImplementation(
+      () =>
+        new Promise<AttemptOutcome>((r) => {
+          resolveAttempt = r
+        })
+    )
+    const scheduler = createReconnectScheduler({
+      attempt,
+      config: config(),
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      random: () => 0,
+    })
+
+    scheduler.schedule('s1')
+    timers.last().fn()
+    await flush()
+    expect(attempt).toHaveBeenCalledTimes(1)
+
+    scheduler.cancel('s1')
+    resolveAttempt('retry')
+    await flush()
+
+    // canceled mid-attempt → the resolved 'retry' must not re-arm
+    expect(timers.timers).toHaveLength(1)
+  })
+
+  it('is idempotent: a second schedule while armed does not stack timers', () => {
+    const timers = fakeTimers()
+    const scheduler = createReconnectScheduler({
+      attempt: vi.fn().mockResolvedValue('retry' as AttemptOutcome),
+      config: config(),
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      random: () => 0,
+    })
+
+    scheduler.schedule('s1')
+    scheduler.schedule('s1')
+
+    expect(timers.timers).toHaveLength(1)
+  })
+
+  it('does not schedule when reconnect is disabled', () => {
+    const timers = fakeTimers()
+    const scheduler = createReconnectScheduler({
+      attempt: vi.fn().mockResolvedValue('retry' as AttemptOutcome),
+      config: config({ enabled: false }),
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      random: () => 0,
+    })
+
+    scheduler.schedule('s1')
+
+    expect(timers.timers).toHaveLength(0)
+  })
+
+  it('shutdown cancels all timers and makes further scheduling a no-op', () => {
+    const timers = fakeTimers()
+    const scheduler = createReconnectScheduler({
+      attempt: vi.fn().mockResolvedValue('retry' as AttemptOutcome),
+      config: config(),
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      random: () => 0,
+    })
+
+    scheduler.schedule('s1')
+    scheduler.schedule('s2')
+    expect(timers.timers).toHaveLength(2)
+
+    scheduler.shutdown()
+    expect(timers.timers.every((t) => t.cleared)).toBe(true)
+
+    scheduler.schedule('s3')
+    expect(timers.timers).toHaveLength(2) // no new timer after shutdown
+  })
+})

--- a/src/main/reconnect-scheduler.test.ts
+++ b/src/main/reconnect-scheduler.test.ts
@@ -185,6 +185,43 @@ describe('reconnect-scheduler', () => {
     expect(timers.timers).toHaveLength(0)
   })
 
+  it('re-arms when a fresh schedule arrives during an in-flight attempt', async () => {
+    const timers = fakeTimers()
+    let resolveAttempt!: (o: AttemptOutcome) => void
+    const attempt = vi.fn().mockImplementation(
+      () =>
+        new Promise<AttemptOutcome>((r) => {
+          resolveAttempt = r
+        })
+    )
+    const scheduler = createReconnectScheduler({
+      attempt,
+      config: config(),
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      random: () => 0,
+    })
+
+    scheduler.schedule('s1')
+    timers.last().fn() // fire → attempt is now in flight (pending)
+    await flush()
+    expect(attempt).toHaveBeenCalledTimes(1)
+    expect(timers.timers).toHaveLength(1)
+
+    // A fresh drop arrives WHILE the attempt is in flight (e.g. the reattached
+    // PTY died again). It must not be swallowed by the idempotency guard.
+    scheduler.schedule('s1')
+    expect(timers.timers).toHaveLength(1) // still in flight, no new timer yet
+
+    // The attempt reports success — normally it would stop. The mid-flight drop
+    // must force a fresh re-arm so the new disconnect isn't lost.
+    resolveAttempt('recovered')
+    await flush()
+
+    expect(timers.timers).toHaveLength(2)
+    expect(timers.last().ms).toBe(500) // fresh backoff at attempt 0
+  })
+
   it('shutdown cancels all timers and makes further scheduling a no-op', () => {
     const timers = fakeTimers()
     const scheduler = createReconnectScheduler({

--- a/src/main/reconnect-scheduler.ts
+++ b/src/main/reconnect-scheduler.ts
@@ -35,6 +35,12 @@ interface Entry {
   handle: TimerHandle
   attemptNo: number
   canceled: boolean
+  // True only while the awaited attempt is in flight. A fresh schedule() during
+  // that window can't arm a new timer (the entry still occupies the map), so it
+  // records `rearm` and fire() restarts the backoff once the attempt resolves —
+  // otherwise a re-drop mid-reconnect would be silently lost.
+  running: boolean
+  rearm: boolean
 }
 
 export function createReconnectScheduler(deps: ReconnectSchedulerDeps): ReconnectScheduler {
@@ -58,24 +64,34 @@ export function createReconnectScheduler(deps: ReconnectSchedulerDeps): Reconnec
     const ms = delayFor(attemptNo, deps.config())
     const handle = setTimer(() => void fire(sessionId), ms)
     handle.unref?.()
-    entries.set(sessionId, { handle, attemptNo, canceled: false })
+    entries.set(sessionId, { handle, attemptNo, canceled: false, running: false, rearm: false })
   }
 
   async function fire(sessionId: string): Promise<void> {
     const entry = entries.get(sessionId)
     if (!entry || stopped) return
 
+    entry.running = true
     let outcome: AttemptOutcome
     try {
       outcome = await deps.attempt(sessionId)
     } catch {
       outcome = 'retry'
     }
+    entry.running = false
 
     // Drop the result if we were canceled or shut down while the attempt was
     // in flight, or if a fresh schedule replaced this entry.
     if (stopped || entry.canceled) return
     if (entries.get(sessionId) !== entry) return
+
+    // A fresh drop arrived while this attempt was in flight (e.g. the reattached
+    // PTY died again). Restart the backoff so that disconnect isn't lost, even
+    // if this attempt "succeeded" — the session is down again.
+    if (entry.rearm) {
+      arm(sessionId, 0)
+      return
+    }
 
     if (outcome === 'retry') {
       arm(sessionId, entry.attemptNo + 1)
@@ -104,7 +120,14 @@ export function createReconnectScheduler(deps: ReconnectSchedulerDeps): Reconnec
     schedule(sessionId) {
       if (stopped) return
       if (!deps.config().enabled) return
-      if (entries.has(sessionId)) return // idempotent — don't stack timers
+      const existing = entries.get(sessionId)
+      if (existing) {
+        // A timer is pending or an attempt is in flight. A merely-pending timer
+        // already covers this drop; but if an attempt is in flight, record the
+        // fresh drop so fire() re-arms afterward instead of silently losing it.
+        if (existing.running) existing.rearm = true
+        return
+      }
       arm(sessionId, 0)
     },
     cancel,

--- a/src/main/reconnect-scheduler.ts
+++ b/src/main/reconnect-scheduler.ts
@@ -1,0 +1,117 @@
+// Per-session exponential-backoff scheduler for auto-reconnecting dropped
+// remote sessions. Pure and injectable: timers, jitter, and the attempt
+// function are all supplied by the caller so the backoff policy is unit
+// testable without real time. Session-manager owns the actual attempt
+// (probe + reattach) and maps its result to an AttemptOutcome.
+
+export type AttemptOutcome = 'recovered' | 'retry' | 'gave-up'
+
+export interface ReconnectConfigLike {
+  enabled: boolean
+  initialDelayMs: number
+  maxDelayMs: number
+}
+
+export interface TimerHandle {
+  unref?: () => void
+}
+
+export interface ReconnectSchedulerDeps {
+  attempt: (sessionId: string) => Promise<AttemptOutcome>
+  config: () => ReconnectConfigLike
+  setTimer?: (fn: () => void, ms: number) => TimerHandle
+  clearTimer?: (handle: TimerHandle) => void
+  random?: () => number
+}
+
+export interface ReconnectScheduler {
+  schedule(sessionId: string): void
+  cancel(sessionId: string): void
+  cancelAll(): void
+  shutdown(): void
+}
+
+interface Entry {
+  handle: TimerHandle
+  attemptNo: number
+  canceled: boolean
+}
+
+export function createReconnectScheduler(deps: ReconnectSchedulerDeps): ReconnectScheduler {
+  const setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms) as unknown as TimerHandle)
+  const clearTimer =
+    deps.clearTimer ?? ((h) => clearTimeout(h as unknown as ReturnType<typeof setTimeout>))
+  const random = deps.random ?? Math.random
+
+  const entries = new Map<string, Entry>()
+  let stopped = false
+
+  function delayFor(attemptNo: number, cfg: ReconnectConfigLike): number {
+    const base = Math.min(cfg.initialDelayMs * 2 ** attemptNo, cfg.maxDelayMs)
+    // Jitter in [0.5, 1.0] of the nominal delay spreads a herd of sessions
+    // that all dropped together (shared ControlMaster) across the window.
+    const jitter = 0.5 + random() * 0.5
+    return Math.round(base * jitter)
+  }
+
+  function arm(sessionId: string, attemptNo: number): void {
+    const ms = delayFor(attemptNo, deps.config())
+    const handle = setTimer(() => void fire(sessionId), ms)
+    handle.unref?.()
+    entries.set(sessionId, { handle, attemptNo, canceled: false })
+  }
+
+  async function fire(sessionId: string): Promise<void> {
+    const entry = entries.get(sessionId)
+    if (!entry || stopped) return
+
+    let outcome: AttemptOutcome
+    try {
+      outcome = await deps.attempt(sessionId)
+    } catch {
+      outcome = 'retry'
+    }
+
+    // Drop the result if we were canceled or shut down while the attempt was
+    // in flight, or if a fresh schedule replaced this entry.
+    if (stopped || entry.canceled) return
+    if (entries.get(sessionId) !== entry) return
+
+    if (outcome === 'retry') {
+      arm(sessionId, entry.attemptNo + 1)
+    } else {
+      entries.delete(sessionId)
+    }
+  }
+
+  function cancel(sessionId: string): void {
+    const entry = entries.get(sessionId)
+    if (!entry) return
+    entry.canceled = true
+    clearTimer(entry.handle)
+    entries.delete(sessionId)
+  }
+
+  function cancelAll(): void {
+    for (const entry of entries.values()) {
+      entry.canceled = true
+      clearTimer(entry.handle)
+    }
+    entries.clear()
+  }
+
+  return {
+    schedule(sessionId) {
+      if (stopped) return
+      if (!deps.config().enabled) return
+      if (entries.has(sessionId)) return // idempotent — don't stack timers
+      arm(sessionId, 0)
+    },
+    cancel,
+    cancelAll,
+    shutdown() {
+      stopped = true
+      cancelAll()
+    },
+  }
+}

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -54,6 +54,11 @@ const state = vi.hoisted(() => ({
   // When set, delays next ensureHostConnection resolution (used for idempotency
   // and cascade tests).
   ensureHostConnectionGate: null as null | Promise<void>,
+  // Auto-reconnect config surfaced via getReconnectConfig; mutable per test.
+  reconnectConfig: { enabled: true, initialDelayMs: 1000, maxDelayMs: 30000 },
+  // Captured emitToast payloads for assertion.
+  toasts: [] as { severity: string; title: string; detail?: string }[],
+  hasPtyResult: new Set<string>(),
 }))
 
 vi.mock('./config', () => ({
@@ -73,6 +78,7 @@ vi.mock('./config', () => ({
     defaultTool: state.defaultTool,
     worktreeBase: state.worktreeBase,
   }),
+  getReconnectConfig: () => state.reconnectConfig,
   saveConfig: vi.fn(),
 }))
 
@@ -90,7 +96,9 @@ vi.mock('./tray', () => ({
 
 vi.mock('./notifications', () => ({
   notifyNeedsInput: vi.fn(),
-  emitToast: vi.fn(),
+  emitToast: (event: { severity: string; title: string; detail?: string }) => {
+    state.toasts.push(event)
+  },
 }))
 
 vi.mock('electron', () => ({
@@ -155,7 +163,7 @@ vi.mock('./pty-manager', () => ({
   },
   destroyPty: vi.fn(),
   destroyRemotePty: vi.fn(async () => undefined),
-  hasPty: vi.fn(() => false),
+  hasPty: vi.fn((sessionId: string) => state.hasPtyResult.has(sessionId)),
   hasTmuxSession: vi.fn(() => false),
   hasRemoteTmuxSession: vi.fn(async (sessionId: string) => {
     return state.hasRemoteTmuxResult.get(sessionId) ?? false
@@ -337,6 +345,9 @@ beforeEach(() => {
   state.ensureHostConnectionThrows = null
   state.ensureHostConnectionGate = null
   state.unexpectedExitListener = null
+  state.reconnectConfig = { enabled: true, initialDelayMs: 1000, maxDelayMs: 30000 }
+  state.toasts = []
+  state.hasPtyResult = new Set()
 })
 
 afterEach(() => {
@@ -1791,8 +1802,8 @@ describe('unexpected pty exit listener', () => {
     expect(sm.getSessions()[0].status).toBe('dead')
   })
 
-  it('does not touch remote sessions (their connection state machinery owns recovery)', async () => {
-    const remote = baseRemoteSession({ id: 'r1', status: 'idle' })
+  it('remote drop with reconnect enabled → connecting + drop toast', async () => {
+    const remote = baseRemoteSession({ id: 'r1', status: 'running' })
     writeSessionsJson([remote])
     const sm = await loadSessionManager()
     sm.restoreSessions()
@@ -1800,7 +1811,38 @@ describe('unexpected pty exit listener', () => {
 
     state.unexpectedExitListener?.('r1')
 
-    expect(sm.getSessions()[0].status).toBe('idle')
+    expect(sm.getSessions()[0].connectionState).toBe('connecting')
+    expect(state.toasts).toEqual([
+      { severity: 'warning', title: 'Connection to Dev lost — reconnecting…' },
+    ])
+    sm.stopSessionManager() // cancel the armed backoff timer
+  })
+
+  it('remote drop with reconnect disabled → offline overlay, no toast', async () => {
+    state.reconnectConfig = { enabled: false, initialDelayMs: 1000, maxDelayMs: 30000 }
+    const remote = baseRemoteSession({ id: 'r1', status: 'running' })
+    writeSessionsJson([remote])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.initSessionManager()
+
+    state.unexpectedExitListener?.('r1')
+
+    expect(sm.getSessions()[0].connectionState).toBe('offline')
+    expect(state.toasts).toEqual([])
+  })
+
+  it('does not auto-reconnect an already-dead remote session', async () => {
+    const remote = baseRemoteSession({ id: 'r1', status: 'dead' })
+    writeSessionsJson([remote])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.initSessionManager()
+
+    state.unexpectedExitListener?.('r1')
+
+    expect(state.toasts).toEqual([])
+    expect(sm.getSessions()[0].connectionState).not.toBe('connecting')
   })
 
   it('is a no-op for unknown ids and already-dead sessions', async () => {
@@ -2990,5 +3032,110 @@ describe('createPrSessions', () => {
     expect(started).toEqual([8, 9])
     expect(result.created.map((s) => s.prNumber)).toEqual([8, 9])
     expect(result.failed).toEqual([])
+  })
+})
+
+describe('attemptAutoReconnect', () => {
+  it('present → recovered, reattaches, marks live, toasts recovery', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.hasRemoteTmuxResult.set('r1', true)
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    const outcome = await sm.attemptAutoReconnect('r1')
+
+    expect(outcome).toBe('recovered')
+    expect(sm.getSessions()[0].connectionState).toBe('live')
+    expect(state.reattachRemotePtyCalls).toEqual([{ sessionId: 'r1', hostId: 'h1' }])
+    expect(state.toasts).toEqual([{ severity: 'info', title: 'Reconnected to Dev' }])
+  })
+
+  it('tmux gone → gave-up, marks dead, toasts session-ended', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.hasRemoteTmuxResult.set('r1', false)
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    const outcome = await sm.attemptAutoReconnect('r1')
+
+    expect(outcome).toBe('gave-up')
+    expect(sm.getSessions()[0].status).toBe('dead')
+    expect(state.toasts).toEqual([{ severity: 'error', title: 'Dev: remote session ended' }])
+  })
+
+  it('auth-failed → gave-up (no retry)', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.ensureHostConnectionThrows = {
+      message: 'Permission denied (publickey)',
+      runtimeStateAfter: 'auth-failed',
+    }
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    const outcome = await sm.attemptAutoReconnect('r1')
+
+    expect(outcome).toBe('gave-up')
+    expect(sm.getSessions()[0].connectionState).toBe('auth-failed')
+    expect(state.toasts.map((t) => t.severity)).toEqual(['error'])
+  })
+
+  it('network unreachable → retry', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.ensureHostConnectionThrows = {
+      message: 'Connection refused',
+      runtimeStateAfter: 'unreachable',
+    }
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    const outcome = await sm.attemptAutoReconnect('r1')
+
+    expect(outcome).toBe('retry')
+    expect(sm.getSessions()[0].connectionState).toBe('unreachable')
+  })
+
+  it('skips the attempt (silent recovered) when a manual reconnect already reattached', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'idle' })])
+    state.hasRemoteTmuxResult.set('r1', true)
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    await sm.reconnectRemoteSession('r1') // manual reconnect → live
+    state.reattachRemotePtyCalls = []
+    state.hasPtyResult.add('r1')
+    state.toasts = []
+
+    const outcome = await sm.attemptAutoReconnect('r1')
+
+    expect(outcome).toBe('recovered')
+    expect(state.reattachRemotePtyCalls).toEqual([])
+    expect(state.toasts).toEqual([])
+  })
+
+  it('gave-up when the session no longer exists', async () => {
+    const sm = await loadSessionManager()
+    expect(await sm.attemptAutoReconnect('nope')).toBe('gave-up')
+  })
+})
+
+describe('auto-reconnect cancellation', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('killSession cancels a scheduled auto-reconnect (no resurrection)', async () => {
+    state.hasRemoteTmuxResult.set('r1', true)
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'running' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.initSessionManager()
+
+    state.unexpectedExitListener?.('r1') // drop → schedules a reconnect
+    await sm.killSession('r1')
+    state.reattachRemotePtyCalls = []
+
+    await vi.advanceTimersByTimeAsync(60000)
+
+    // The pending backoff timer must have been canceled — no reattach fired.
+    expect(state.reattachRemotePtyCalls).toEqual([])
+    expect(sm.getSessions()[0].status).toBe('dead')
   })
 })

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -3139,3 +3139,71 @@ describe('auto-reconnect cancellation', () => {
     expect(sm.getSessions()[0].status).toBe('dead')
   })
 })
+
+describe('auto-reconnect skips normally-ended remote sessions', () => {
+  it('listener does not schedule/toast for a completed remote session', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'completed' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.initSessionManager()
+
+    state.unexpectedExitListener?.('r1')
+
+    expect(state.toasts).toEqual([])
+    expect(sm.getSessions()[0].connectionState).not.toBe('connecting')
+    expect(sm.getSessions()[0].status).toBe('completed')
+  })
+
+  it('listener does not schedule/toast for an errored remote session', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'error' })])
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+    sm.initSessionManager()
+
+    state.unexpectedExitListener?.('r1')
+
+    expect(state.toasts).toEqual([])
+    expect(sm.getSessions()[0].connectionState).not.toBe('connecting')
+  })
+
+  it('attemptAutoReconnect gives up on a completed session without probing', async () => {
+    writeSessionsJson([baseRemoteSession({ id: 'r1', status: 'completed' })])
+    state.hasRemoteTmuxResult.set('r1', true) // even if tmux is "present", must not reattach
+    const sm = await loadSessionManager()
+    sm.restoreSessions()
+
+    const outcome = await sm.attemptAutoReconnect('r1')
+
+    expect(outcome).toBe('gave-up')
+    expect(state.reattachRemotePtyCalls).toEqual([])
+    expect(state.ensureHostConnectionCalls).toEqual([])
+    expect(state.toasts).toEqual([])
+  })
+
+  it('a normal session-end cancels a scheduled auto-reconnect (stays completed, no dead-flip)', async () => {
+    vi.useFakeTimers()
+    try {
+      const remote = baseRemoteSession({ id: 'r1', status: 'running' })
+      writeSessionsJson([remote])
+      const sm = await loadSessionManager()
+      sm.restoreSessions()
+      sm.initSessionManager()
+
+      // PTY drop schedules a reconnect (status is active at this point)...
+      state.unexpectedExitListener?.('r1')
+      // ...then the agent's session.end hook arrives over the live tunnel →
+      // promptCleanup → cancel + (dialog "Keep") completed.
+      sm.handleHookEvent('session.end', { cwd: remote.worktreePath }, 'h1')
+      await vi.advanceTimersByTimeAsync(0) // flush the promptCleanup dialog
+      state.reattachRemotePtyCalls = []
+      state.toasts = []
+
+      await vi.advanceTimersByTimeAsync(60000)
+
+      expect(state.reattachRemotePtyCalls).toEqual([])
+      expect(sm.getSessions()[0].status).toBe('completed')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -439,6 +439,15 @@ export function initSessionManager(): void {
       return
     }
 
+    // A normally-ended remote session (agent exited → session.end hook →
+    // promptCleanup) must not be auto-reconnected: its remote tmux is gone, so a
+    // probe would flip it to 'dead' with a misleading "remote session ended"
+    // toast and could clobber a user-chosen 'completed'. Terminal statuses and
+    // an in-flight cleanup both mark a genuine end — a network drop delivers no
+    // session.end hook, so it never trips these.
+    if (entry.session.status === 'completed' || entry.session.status === 'error') return
+    if (cleanupInProgress.has(sessionId)) return
+
     const host = getHost(entry.session.hostId)
     const label = host?.label || host?.alias || entry.session.hostId
     if (getReconnectConfig().enabled) {
@@ -1441,6 +1450,9 @@ export async function attemptAutoReconnect(id: string): Promise<AttemptOutcome> 
   if (!entry) return 'gave-up'
   const session = entry.session
   if (!session.hostId) return 'gave-up'
+  // The session ended normally (completed/error) between scheduling and now —
+  // don't probe/reattach, which would flip it to 'dead' with a bogus toast.
+  if (session.status === 'completed' || session.status === 'error') return 'gave-up'
   const host = getHost(session.hostId)
   const label = host?.label || host?.alias || session.hostId
 
@@ -1792,6 +1804,10 @@ const cleanupInProgress = new Set<string>()
 async function promptCleanup(id: string): Promise<void> {
   if (cleanupInProgress.has(id)) return
   cleanupInProgress.add(id)
+  // The agent ended normally (this fires from the session.end hook, which only
+  // arrives over a live connection). Cancel any auto-reconnect a racing PTY
+  // exit scheduled so it can't flip the session to 'dead' mid-cleanup.
+  reconnectScheduler.cancel(id)
   try {
     const entry = sessions.get(id)
     if (!entry) return

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -7,9 +7,10 @@ import { homedir } from 'os'
 import { randomUUID } from 'crypto'
 import { dialog, shell } from 'electron'
 import { broadcastToAll, getMainWindow } from './window-registry'
-import { CONFIG_DIR, getConfig, saveConfig } from './config'
+import { CONFIG_DIR, getConfig, getReconnectConfig, saveConfig } from './config'
 import { updateTray } from './tray'
-import { notifyNeedsInput } from './notifications'
+import { notifyNeedsInput, emitToast } from './notifications'
+import { createReconnectScheduler, type AttemptOutcome } from './reconnect-scheduler'
 import {
   createPty,
   detachPty,
@@ -421,17 +422,34 @@ export function initSessionManager(): void {
     }
   }, PR_REFRESH_INTERVAL_MS).unref()
 
-  // When a local pty dies on its own (e.g. `claude --continue` exits with
-  // "No conversation found to continue" and the tmux session collapses), flip
-  // the session back to 'dead' so the renderer shows the "Restart terminal"
-  // overlay instead of a permanently empty xterm. Remote sessions are skipped:
-  // an SSH drop kills the local pty but the remote tmux session can still be
-  // alive, and reconnectRemoteSession already drives that flow.
+  // When a pty dies on its own we react by kind:
+  //  - Local (`claude --continue` exits, tmux collapses): flip to 'dead' so the
+  //    renderer shows the "Restart terminal" overlay instead of an empty xterm.
+  //  - Remote (an SSH drop kills the local pty, but the remote tmux likely
+  //    survives): auto-reconnect if enabled — mark 'connecting' and schedule a
+  //    backoff-driven reattach. If disabled, mark 'offline' so the manual
+  //    "Reconnect" overlay surfaces rather than a frozen terminal.
   setUnexpectedExitListener((sessionId) => {
     const entry = sessions.get(sessionId)
-    if (!entry || entry.session.hostId) return
+    if (!entry) return
     if (entry.session.status === 'dead') return
-    updateSession(sessionId, 'dead')
+
+    if (!entry.session.hostId) {
+      updateSession(sessionId, 'dead')
+      return
+    }
+
+    const host = getHost(entry.session.hostId)
+    const label = host?.label || host?.alias || entry.session.hostId
+    if (getReconnectConfig().enabled) {
+      emitToast({ severity: 'warning', title: `Connection to ${label} lost — reconnecting…` })
+      entry.session.connectionState = 'connecting'
+      onSessionsChanged()
+      reconnectScheduler.schedule(sessionId)
+    } else {
+      entry.session.connectionState = 'offline'
+      onSessionsChanged()
+    }
   })
 }
 
@@ -1254,6 +1272,7 @@ export function handleHookEvent(
 export async function killSession(id: string): Promise<void> {
   const entry = sessions.get(id)
   if (!entry) return
+  reconnectScheduler.cancel(id)
   if (entry.session.hostId) {
     const host = getRequiredHost(entry.session.hostId)
     await destroyRemotePty(id, host)
@@ -1413,6 +1432,57 @@ async function doReconnectRemoteSession(id: string): Promise<ReconnectOutcome> {
   return { state: finalState, lease }
 }
 
+// One auto-reconnect attempt for a remote session that dropped. Delegates to
+// the manual reconnect (so we inherit its probe/reattach, concurrency
+// coalescing, sibling batch, and auth classification) and maps the resulting
+// session state to a scheduler outcome. The scheduler owns the backoff loop.
+export async function attemptAutoReconnect(id: string): Promise<AttemptOutcome> {
+  const entry = sessions.get(id)
+  if (!entry) return 'gave-up'
+  const session = entry.session
+  if (!session.hostId) return 'gave-up'
+  const host = getHost(session.hostId)
+  const label = host?.label || host?.alias || session.hostId
+
+  // A manual reconnect (or the user's Retry click) may have already reattached
+  // between the drop and this tick. Detect a genuine live attach via the pty —
+  // connectionState alone is stale ('live' is never reset on a bare drop).
+  if (session.connectionState === 'live' && hasPty(id)) return 'recovered'
+
+  try {
+    await reconnectRemoteSession(id)
+  } catch {
+    // connectionState set inside doReconnectRemoteSession is authoritative.
+  }
+
+  const after = sessions.get(id)?.session
+  if (!after) return 'gave-up'
+
+  if (after.connectionState === 'live') {
+    emitToast({ severity: 'info', title: `Reconnected to ${label}` })
+    return 'recovered'
+  }
+  if (after.status === 'dead') {
+    // Remote tmux confirmed gone — retrying is futile.
+    emitToast({ severity: 'error', title: `${label}: remote session ended` })
+    return 'gave-up'
+  }
+  if (after.connectionState === 'auth-failed') {
+    emitToast({ severity: 'error', title: `SSH authentication failed on ${label}` })
+    return 'gave-up'
+  }
+  return 'retry'
+}
+
+const reconnectScheduler = createReconnectScheduler({
+  attempt: attemptAutoReconnect,
+  config: getReconnectConfig,
+})
+
+export function stopSessionManager(): void {
+  reconnectScheduler.shutdown()
+}
+
 // Eager batch probe for remaining `pending` sessions on a host that just
 // became live. Runs `tmux has-session` per sibling over the live ControlMaster
 // (no new SSH handshakes). If the runtime state is `auth-failed` /
@@ -1511,6 +1581,7 @@ async function doProbePendingSessionsOnHost(
 export async function reviveSession(id: string): Promise<void> {
   const entry = sessions.get(id)
   if (!entry) throw new Error(`Session ${id} not found`)
+  reconnectScheduler.cancel(id)
 
   const session = entry.session
   if (session.status !== 'dead')
@@ -1686,6 +1757,7 @@ export async function removeWorktree(id: string): Promise<void> {
 
 export async function removeSession(id: string): Promise<void> {
   const entry = sessions.get(id)
+  reconnectScheduler.cancel(id)
   if (entry?.session.hostId) {
     const host = getRequiredHost(entry.session.hostId)
     await destroyRemotePty(id, host)
@@ -1707,6 +1779,7 @@ export function removeSessionsForHost(hostId: string): void {
   let removed = false
   for (const [id, entry] of sessions) {
     if (entry.session.hostId !== hostId) continue
+    reconnectScheduler.cancel(id)
     detachPty(id)
     sessions.delete(id)
     removed = true


### PR DESCRIPTION
## Problem

On a remote SSH connection drop (network blip, laptop sleep, VPN drop), the session's terminal froze and the only recovery was to **kill + restart** the session. The full manual-reconnect pipeline already existed (`reconnectRemoteSession` → probe → `reattachRemotePty`), but nothing triggered it automatically — the unexpected-exit listener deliberately ignored remote sessions.

## What this does

Detects the remote drop and automatically drives the existing reconnect with exponential backoff, re-attaching to the **surviving remote tmux session** (agent state preserved).

- **`reconnect-scheduler.ts`** *(new)* — pure, injectable exponential-backoff timer manager (`schedule`/`cancel`/`cancelAll`/`shutdown`): jittered 50–100%, capped at `maxDelayMs`, `.unref()`'d timers, idempotent per session, shutdown latch.
- **`attemptAutoReconnect`** — one attempt via the existing `reconnectRemoteSession` (inherits probe/reattach, concurrency coalescing, sibling batch, auth classification); maps the resulting state → `recovered | retry | gave-up`, with a `hasPty` guard against a racing manual reconnect.
- **Exit listener** — remote drop + enabled → `warning` toast + `connecting` state + scheduled reattach; **disabled** → `offline` state so the manual Reconnect overlay surfaces instead of a frozen terminal. Local behavior unchanged.
- **Config** — `reconnect { enabled, initialDelayMs, maxDelayMs }`, **on by default**, tunable in `~/.config/pewpew/config.json`.
- **Cancellation** — pending reconnects are canceled on `killSession`/`reviveSession`/`removeSession`/`removeSessionsForHost` and on app quit (`stopSessionManager()` in `before-quit`).

## Behavior

- **Indefinite throttled retry**: keeps retrying (backoff capped ~30s, silent) while the host is `unreachable`; stops only on auth-failure or a confirmed-gone remote tmux.
- **Toasts on drop & recovery** (+ give-up); the connection dot / "Reconnecting…" overlay shows progress inline. No new renderer code — reuses the existing `connecting`/`offline` overlays.

## Caveat

Recovery kicks in ~45s after a *hard* drop, because the shared SSH ControlMaster only tears down after `ServerAliveInterval=15 × CountMax=3` — that's when the attach PTY exits and the listener fires. A faster active heartbeat was left out of scope.

## Testing

Test-driven. `npx tsc --noEmit`, `npx eslint .`, `npx prettier --check`, and `npx vitest run` (**465 tests, all green**) — including 8 scheduler unit tests, 2 config-merge tests, and new session-manager coverage for the trigger, outcome mapping, disabled fallback, and kill-cancellation.